### PR TITLE
Remove tenant_id from identities

### DIFF
--- a/.gen/go/agynio/api/ziti_management/v1/ziti_management.pb.go
+++ b/.gen/go/agynio/api/ziti_management/v1/ziti_management.pb.go
@@ -79,7 +79,6 @@ type ManagedIdentity struct {
 	ZitiIdentityId string                 `protobuf:"bytes,1,opt,name=ziti_identity_id,json=zitiIdentityId,proto3" json:"ziti_identity_id,omitempty"`
 	IdentityId     string                 `protobuf:"bytes,2,opt,name=identity_id,json=identityId,proto3" json:"identity_id,omitempty"`
 	IdentityType   IdentityType           `protobuf:"varint,3,opt,name=identity_type,json=identityType,proto3,enum=agynio.api.ziti_management.v1.IdentityType" json:"identity_type,omitempty"`
-	TenantId       string                 `protobuf:"bytes,4,opt,name=tenant_id,json=tenantId,proto3" json:"tenant_id,omitempty"`
 	CreatedAt      *timestamppb.Timestamp `protobuf:"bytes,5,opt,name=created_at,json=createdAt,proto3" json:"created_at,omitempty"`
 	unknownFields  protoimpl.UnknownFields
 	sizeCache      protoimpl.SizeCache
@@ -136,13 +135,6 @@ func (x *ManagedIdentity) GetIdentityType() IdentityType {
 	return IdentityType_IDENTITY_TYPE_UNSPECIFIED
 }
 
-func (x *ManagedIdentity) GetTenantId() string {
-	if x != nil {
-		return x.TenantId
-	}
-	return ""
-}
-
 func (x *ManagedIdentity) GetCreatedAt() *timestamppb.Timestamp {
 	if x != nil {
 		return x.CreatedAt
@@ -153,7 +145,6 @@ func (x *ManagedIdentity) GetCreatedAt() *timestamppb.Timestamp {
 type CreateAgentIdentityRequest struct {
 	state         protoimpl.MessageState `protogen:"open.v1"`
 	AgentId       string                 `protobuf:"bytes,1,opt,name=agent_id,json=agentId,proto3" json:"agent_id,omitempty"`
-	TenantId      string                 `protobuf:"bytes,2,opt,name=tenant_id,json=tenantId,proto3" json:"tenant_id,omitempty"`
 	unknownFields protoimpl.UnknownFields
 	sizeCache     protoimpl.SizeCache
 }
@@ -191,13 +182,6 @@ func (*CreateAgentIdentityRequest) Descriptor() ([]byte, []int) {
 func (x *CreateAgentIdentityRequest) GetAgentId() string {
 	if x != nil {
 		return x.AgentId
-	}
-	return ""
-}
-
-func (x *CreateAgentIdentityRequest) GetTenantId() string {
-	if x != nil {
-		return x.TenantId
 	}
 	return ""
 }
@@ -337,7 +321,6 @@ func (*DeleteIdentityResponse) Descriptor() ([]byte, []int) {
 type ListManagedIdentitiesRequest struct {
 	state         protoimpl.MessageState `protogen:"open.v1"`
 	IdentityType  IdentityType           `protobuf:"varint,1,opt,name=identity_type,json=identityType,proto3,enum=agynio.api.ziti_management.v1.IdentityType" json:"identity_type,omitempty"`
-	TenantId      string                 `protobuf:"bytes,2,opt,name=tenant_id,json=tenantId,proto3" json:"tenant_id,omitempty"`
 	PageSize      int32                  `protobuf:"varint,3,opt,name=page_size,json=pageSize,proto3" json:"page_size,omitempty"`
 	PageToken     string                 `protobuf:"bytes,4,opt,name=page_token,json=pageToken,proto3" json:"page_token,omitempty"`
 	unknownFields protoimpl.UnknownFields
@@ -379,13 +362,6 @@ func (x *ListManagedIdentitiesRequest) GetIdentityType() IdentityType {
 		return x.IdentityType
 	}
 	return IdentityType_IDENTITY_TYPE_UNSPECIFIED
-}
-
-func (x *ListManagedIdentitiesRequest) GetTenantId() string {
-	if x != nil {
-		return x.TenantId
-	}
-	return ""
 }
 
 func (x *ListManagedIdentitiesRequest) GetPageSize() int32 {
@@ -502,7 +478,6 @@ type ResolveIdentityResponse struct {
 	state         protoimpl.MessageState `protogen:"open.v1"`
 	IdentityId    string                 `protobuf:"bytes,1,opt,name=identity_id,json=identityId,proto3" json:"identity_id,omitempty"`
 	IdentityType  IdentityType           `protobuf:"varint,2,opt,name=identity_type,json=identityType,proto3,enum=agynio.api.ziti_management.v1.IdentityType" json:"identity_type,omitempty"`
-	TenantId      string                 `protobuf:"bytes,3,opt,name=tenant_id,json=tenantId,proto3" json:"tenant_id,omitempty"`
 	unknownFields protoimpl.UnknownFields
 	sizeCache     protoimpl.SizeCache
 }
@@ -551,38 +526,28 @@ func (x *ResolveIdentityResponse) GetIdentityType() IdentityType {
 	return IdentityType_IDENTITY_TYPE_UNSPECIFIED
 }
 
-func (x *ResolveIdentityResponse) GetTenantId() string {
-	if x != nil {
-		return x.TenantId
-	}
-	return ""
-}
-
 var File_agynio_api_ziti_management_v1_ziti_management_proto protoreflect.FileDescriptor
 
 const file_agynio_api_ziti_management_v1_ziti_management_proto_rawDesc = "" +
 	"\n" +
-	"3agynio/api/ziti_management/v1/ziti_management.proto\x12\x1dagynio.api.ziti_management.v1\x1a\x1fgoogle/protobuf/timestamp.proto\"\x86\x02\n" +
+	"3agynio/api/ziti_management/v1/ziti_management.proto\x12\x1dagynio.api.ziti_management.v1\x1a\x1fgoogle/protobuf/timestamp.proto\"\xe9\x01\n" +
 	"\x0fManagedIdentity\x12(\n" +
 	"\x10ziti_identity_id\x18\x01 \x01(\tR\x0ezitiIdentityId\x12\x1f\n" +
 	"\videntity_id\x18\x02 \x01(\tR\n" +
 	"identityId\x12P\n" +
-	"\ridentity_type\x18\x03 \x01(\x0e2+.agynio.api.ziti_management.v1.IdentityTypeR\fidentityType\x12\x1b\n" +
-	"\ttenant_id\x18\x04 \x01(\tR\btenantId\x129\n" +
+	"\ridentity_type\x18\x03 \x01(\x0e2+.agynio.api.ziti_management.v1.IdentityTypeR\fidentityType\x129\n" +
 	"\n" +
-	"created_at\x18\x05 \x01(\v2\x1a.google.protobuf.TimestampR\tcreatedAt\"T\n" +
+	"created_at\x18\x05 \x01(\v2\x1a.google.protobuf.TimestampR\tcreatedAt\"7\n" +
 	"\x1aCreateAgentIdentityRequest\x12\x19\n" +
-	"\bagent_id\x18\x01 \x01(\tR\aagentId\x12\x1b\n" +
-	"\ttenant_id\x18\x02 \x01(\tR\btenantId\"n\n" +
+	"\bagent_id\x18\x01 \x01(\tR\aagentId\"n\n" +
 	"\x1bCreateAgentIdentityResponse\x12(\n" +
 	"\x10ziti_identity_id\x18\x01 \x01(\tR\x0ezitiIdentityId\x12%\n" +
 	"\x0eenrollment_jwt\x18\x02 \x01(\tR\renrollmentJwt\"A\n" +
 	"\x15DeleteIdentityRequest\x12(\n" +
 	"\x10ziti_identity_id\x18\x01 \x01(\tR\x0ezitiIdentityId\"\x18\n" +
-	"\x16DeleteIdentityResponse\"\xc9\x01\n" +
+	"\x16DeleteIdentityResponse\"\xac\x01\n" +
 	"\x1cListManagedIdentitiesRequest\x12P\n" +
 	"\ridentity_type\x18\x01 \x01(\x0e2+.agynio.api.ziti_management.v1.IdentityTypeR\fidentityType\x12\x1b\n" +
-	"\ttenant_id\x18\x02 \x01(\tR\btenantId\x12\x1b\n" +
 	"\tpage_size\x18\x03 \x01(\x05R\bpageSize\x12\x1d\n" +
 	"\n" +
 	"page_token\x18\x04 \x01(\tR\tpageToken\"\x97\x01\n" +
@@ -592,12 +557,11 @@ const file_agynio_api_ziti_management_v1_ziti_management_proto_rawDesc = "" +
 	"identities\x12&\n" +
 	"\x0fnext_page_token\x18\x02 \x01(\tR\rnextPageToken\"B\n" +
 	"\x16ResolveIdentityRequest\x12(\n" +
-	"\x10ziti_identity_id\x18\x01 \x01(\tR\x0ezitiIdentityId\"\xa9\x01\n" +
+	"\x10ziti_identity_id\x18\x01 \x01(\tR\x0ezitiIdentityId\"\x8c\x01\n" +
 	"\x17ResolveIdentityResponse\x12\x1f\n" +
 	"\videntity_id\x18\x01 \x01(\tR\n" +
 	"identityId\x12P\n" +
-	"\ridentity_type\x18\x02 \x01(\x0e2+.agynio.api.ziti_management.v1.IdentityTypeR\fidentityType\x12\x1b\n" +
-	"\ttenant_id\x18\x03 \x01(\tR\btenantId*{\n" +
+	"\ridentity_type\x18\x02 \x01(\x0e2+.agynio.api.ziti_management.v1.IdentityTypeR\fidentityType*{\n" +
 	"\fIdentityType\x12\x1d\n" +
 	"\x19IDENTITY_TYPE_UNSPECIFIED\x10\x00\x12\x17\n" +
 	"\x13IDENTITY_TYPE_AGENT\x10\x01\x12\x18\n" +

--- a/.gen/go/agynio/api/ziti_management/v1/ziti_management_grpc.pb.go
+++ b/.gen/go/agynio/api/ziti_management/v1/ziti_management_grpc.pb.go
@@ -29,13 +29,13 @@ const (
 //
 // For semantics around ctx use and closing/ending streaming RPCs, please refer to https://pkg.go.dev/google.golang.org/grpc/?tab=doc#ClientConn.NewStream.
 type ZitiManagementServiceClient interface {
-	// Orchestrator → create OpenZiti identity for an agent, return enrollment JWT.
+	// Orchestrator -> create OpenZiti identity for an agent, return enrollment JWT.
 	CreateAgentIdentity(ctx context.Context, in *CreateAgentIdentityRequest, opts ...grpc.CallOption) (*CreateAgentIdentityResponse, error)
-	// Orchestrator → delete OpenZiti identity and its platform mapping.
+	// Orchestrator -> delete OpenZiti identity and its platform mapping.
 	DeleteIdentity(ctx context.Context, in *DeleteIdentityRequest, opts ...grpc.CallOption) (*DeleteIdentityResponse, error)
-	// Orchestrator → list all platform-managed identities (orphan reconciliation).
+	// Orchestrator -> list all platform-managed identities (orphan reconciliation).
 	ListManagedIdentities(ctx context.Context, in *ListManagedIdentitiesRequest, opts ...grpc.CallOption) (*ListManagedIdentitiesResponse, error)
-	// Gateway → map OpenZiti identity ID to platform identity (hot path).
+	// Gateway -> map OpenZiti identity ID to platform identity (hot path).
 	ResolveIdentity(ctx context.Context, in *ResolveIdentityRequest, opts ...grpc.CallOption) (*ResolveIdentityResponse, error)
 }
 
@@ -91,13 +91,13 @@ func (c *zitiManagementServiceClient) ResolveIdentity(ctx context.Context, in *R
 // All implementations should embed UnimplementedZitiManagementServiceServer
 // for forward compatibility.
 type ZitiManagementServiceServer interface {
-	// Orchestrator → create OpenZiti identity for an agent, return enrollment JWT.
+	// Orchestrator -> create OpenZiti identity for an agent, return enrollment JWT.
 	CreateAgentIdentity(context.Context, *CreateAgentIdentityRequest) (*CreateAgentIdentityResponse, error)
-	// Orchestrator → delete OpenZiti identity and its platform mapping.
+	// Orchestrator -> delete OpenZiti identity and its platform mapping.
 	DeleteIdentity(context.Context, *DeleteIdentityRequest) (*DeleteIdentityResponse, error)
-	// Orchestrator → list all platform-managed identities (orphan reconciliation).
+	// Orchestrator -> list all platform-managed identities (orphan reconciliation).
 	ListManagedIdentities(context.Context, *ListManagedIdentitiesRequest) (*ListManagedIdentitiesResponse, error)
-	// Gateway → map OpenZiti identity ID to platform identity (hot path).
+	// Gateway -> map OpenZiti identity ID to platform identity (hot path).
 	ResolveIdentity(context.Context, *ResolveIdentityRequest) (*ResolveIdentityResponse, error)
 }
 

--- a/internal/server/converter.go
+++ b/internal/server/converter.go
@@ -60,7 +60,6 @@ func toProtoManagedIdentity(identity store.ManagedIdentity) (*zitimanagementv1.M
 		ZitiIdentityId: identity.ZitiIdentityID,
 		IdentityId:     identity.IdentityID.String(),
 		IdentityType:   identityType,
-		TenantId:       identity.TenantID.String(),
 		CreatedAt:      timestamppb.New(identity.CreatedAt),
 	}, nil
 }

--- a/internal/server/server.go
+++ b/internal/server/server.go
@@ -28,12 +28,8 @@ func (s *Server) CreateAgentIdentity(ctx context.Context, req *zitimanagementv1.
 	if err != nil {
 		return nil, status.Errorf(codes.InvalidArgument, "agent_id: %v", err)
 	}
-	tenantID, err := parseUUID(req.GetTenantId())
-	if err != nil {
-		return nil, status.Errorf(codes.InvalidArgument, "tenant_id: %v", err)
-	}
 
-	zitiID, jwt, err := s.ziti.CreateAgentIdentity(ctx, agentID, tenantID)
+	zitiID, jwt, err := s.ziti.CreateAgentIdentity(ctx, agentID)
 	if err != nil {
 		return nil, status.Errorf(codes.Internal, "create ziti identity: %v", err)
 	}
@@ -42,7 +38,6 @@ func (s *Server) CreateAgentIdentity(ctx context.Context, req *zitimanagementv1.
 		ZitiIdentityID: zitiID,
 		IdentityID:     agentID,
 		IdentityType:   store.IdentityTypeAgent,
-		TenantID:       tenantID,
 	}
 	if err := s.store.InsertManagedIdentity(ctx, identity); err != nil {
 		cleanupErr := s.ziti.DeleteIdentity(ctx, zitiID)
@@ -84,13 +79,6 @@ func (s *Server) ListManagedIdentities(ctx context.Context, req *zitimanagementv
 			return nil, status.Errorf(codes.InvalidArgument, "identity_type: %v", err)
 		}
 		filter.IdentityType = &identityType
-	}
-	if req.GetTenantId() != "" {
-		tenantID, err := parseUUID(req.GetTenantId())
-		if err != nil {
-			return nil, status.Errorf(codes.InvalidArgument, "tenant_id: %v", err)
-		}
-		filter.TenantID = &tenantID
 	}
 
 	var cursor *store.PageCursor
@@ -144,7 +132,6 @@ func (s *Server) ResolveIdentity(ctx context.Context, req *zitimanagementv1.Reso
 	return &zitimanagementv1.ResolveIdentityResponse{
 		IdentityId:   identity.IdentityID.String(),
 		IdentityType: identityType,
-		TenantId:     identity.TenantID.String(),
 	}, nil
 }
 

--- a/internal/store/store.go
+++ b/internal/store/store.go
@@ -19,11 +19,10 @@ func NewStore(pool *pgxpool.Pool) *Store {
 }
 
 func (s *Store) InsertManagedIdentity(ctx context.Context, identity ManagedIdentity) error {
-	_, err := s.pool.Exec(ctx, `INSERT INTO managed_identities (ziti_identity_id, identity_id, identity_type, tenant_id) VALUES ($1, $2, $3, $4)`,
+	_, err := s.pool.Exec(ctx, `INSERT INTO managed_identities (ziti_identity_id, identity_id, identity_type) VALUES ($1, $2, $3)`,
 		identity.ZitiIdentityID,
 		identity.IdentityID,
 		identity.IdentityType,
-		identity.TenantID,
 	)
 	if err != nil {
 		return fmt.Errorf("insert managed identity: %w", err)
@@ -43,9 +42,9 @@ func (s *Store) DeleteManagedIdentity(ctx context.Context, zitiIdentityID string
 }
 
 func (s *Store) ResolveIdentity(ctx context.Context, zitiIdentityID string) (ManagedIdentity, error) {
-	row := s.pool.QueryRow(ctx, `SELECT identity_id, identity_type, tenant_id, created_at FROM managed_identities WHERE ziti_identity_id = $1`, zitiIdentityID)
+	row := s.pool.QueryRow(ctx, `SELECT identity_id, identity_type, created_at FROM managed_identities WHERE ziti_identity_id = $1`, zitiIdentityID)
 	identity := ManagedIdentity{ZitiIdentityID: zitiIdentityID}
-	if err := row.Scan(&identity.IdentityID, &identity.IdentityType, &identity.TenantID, &identity.CreatedAt); err != nil {
+	if err := row.Scan(&identity.IdentityID, &identity.IdentityType, &identity.CreatedAt); err != nil {
 		if errors.Is(err, pgx.ErrNoRows) {
 			return ManagedIdentity{}, ErrManagedIdentityNotFound
 		}
@@ -63,16 +62,12 @@ func (s *Store) ListManagedIdentities(ctx context.Context, filter ListFilter, pa
 		args = append(args, *filter.IdentityType)
 		clauses = append(clauses, fmt.Sprintf("identity_type = $%d", len(args)))
 	}
-	if filter.TenantID != nil {
-		args = append(args, *filter.TenantID)
-		clauses = append(clauses, fmt.Sprintf("tenant_id = $%d", len(args)))
-	}
 	if cursor != nil {
 		args = append(args, cursor.AfterID)
 		clauses = append(clauses, fmt.Sprintf("ziti_identity_id > $%d", len(args)))
 	}
 
-	query := "SELECT ziti_identity_id, identity_id, identity_type, tenant_id, created_at FROM managed_identities"
+	query := "SELECT ziti_identity_id, identity_id, identity_type, created_at FROM managed_identities"
 	if len(clauses) > 0 {
 		query += " WHERE " + strings.Join(clauses, " AND ")
 	}
@@ -88,7 +83,7 @@ func (s *Store) ListManagedIdentities(ctx context.Context, filter ListFilter, pa
 	identities := make([]ManagedIdentity, 0)
 	for rows.Next() {
 		var identity ManagedIdentity
-		if err := rows.Scan(&identity.ZitiIdentityID, &identity.IdentityID, &identity.IdentityType, &identity.TenantID, &identity.CreatedAt); err != nil {
+		if err := rows.Scan(&identity.ZitiIdentityID, &identity.IdentityID, &identity.IdentityType, &identity.CreatedAt); err != nil {
 			return ListResult{}, fmt.Errorf("scan managed identity: %w", err)
 		}
 		identities = append(identities, identity)

--- a/internal/store/types.go
+++ b/internal/store/types.go
@@ -22,13 +22,11 @@ type ManagedIdentity struct {
 	ZitiIdentityID string
 	IdentityID     uuid.UUID
 	IdentityType   IdentityType
-	TenantID       uuid.UUID
 	CreatedAt      time.Time
 }
 
 type ListFilter struct {
 	IdentityType *IdentityType
-	TenantID     *uuid.UUID
 }
 
 type PageCursor struct {

--- a/internal/ziti/client.go
+++ b/internal/ziti/client.go
@@ -77,13 +77,12 @@ func loadCAPool(caFile string) (*x509.CertPool, error) {
 	return pool, nil
 }
 
-func (c *Client) CreateAgentIdentity(ctx context.Context, agentID uuid.UUID, tenantID uuid.UUID) (string, string, error) {
+func (c *Client) CreateAgentIdentity(ctx context.Context, agentID uuid.UUID) (string, string, error) {
 	name := fmt.Sprintf("agent-%s-%s", agentID.String(), shortUUID())
 	identityType := rest_model.IdentityTypeDevice
 	isAdmin := false
 	roleAttrs := rest_model.Attributes{
 		"agents",
-		fmt.Sprintf("tenant-%s", tenantID.String()),
 		fmt.Sprintf("agent-%s", agentID.String()),
 	}
 	externalID := agentID.String()

--- a/migrations/0002_remove_tenant_id.sql
+++ b/migrations/0002_remove_tenant_id.sql
@@ -1,0 +1,6 @@
+DROP INDEX IF EXISTS idx_managed_identities_tenant;
+DROP INDEX IF EXISTS idx_managed_identities_type_tenant;
+
+ALTER TABLE managed_identities DROP COLUMN tenant_id;
+
+CREATE INDEX IF NOT EXISTS idx_managed_identities_type ON managed_identities (identity_type);

--- a/test/e2e/e2e_test.go
+++ b/test/e2e/e2e_test.go
@@ -27,11 +27,9 @@ func TestZitiManagementServiceE2E(t *testing.T) {
 	client := zitimanagementv1.NewZitiManagementServiceClient(conn)
 
 	agentID := uuid.NewString()
-	tenantID := uuid.NewString()
 
 	createResp, err := client.CreateAgentIdentity(ctx, &zitimanagementv1.CreateAgentIdentityRequest{
-		AgentId:  agentID,
-		TenantId: tenantID,
+		AgentId: agentID,
 	})
 	require.NoError(t, err)
 	require.NotNil(t, createResp)
@@ -58,7 +56,6 @@ func TestZitiManagementServiceE2E(t *testing.T) {
 	})
 	require.NoError(t, err)
 	require.Equal(t, agentID, resolveResp.GetIdentityId())
-	require.Equal(t, tenantID, resolveResp.GetTenantId())
 	require.Equal(t, zitimanagementv1.IdentityType_IDENTITY_TYPE_AGENT, resolveResp.GetIdentityType())
 
 	pageToken := ""
@@ -66,7 +63,6 @@ func TestZitiManagementServiceE2E(t *testing.T) {
 	for i := 0; i < 10; i++ {
 		listResp, err := client.ListManagedIdentities(ctx, &zitimanagementv1.ListManagedIdentitiesRequest{
 			IdentityType: zitimanagementv1.IdentityType_IDENTITY_TYPE_AGENT,
-			TenantId:     tenantID,
 			PageSize:     50,
 			PageToken:    pageToken,
 		})
@@ -76,7 +72,6 @@ func TestZitiManagementServiceE2E(t *testing.T) {
 			if identity.GetZitiIdentityId() == createResp.GetZitiIdentityId() {
 				found = true
 				require.Equal(t, agentID, identity.GetIdentityId())
-				require.Equal(t, tenantID, identity.GetTenantId())
 				require.Equal(t, zitimanagementv1.IdentityType_IDENTITY_TYPE_AGENT, identity.GetIdentityType())
 				require.NotNil(t, identity.GetCreatedAt())
 				break


### PR DESCRIPTION
## Summary
- drop tenant_id from managed identities schema and store queries
- update server/ziti client flows to stop handling tenant_id
- regenerate ziti-management proto stubs from BSR

## Testing
- go build ./...
- go test ./...
- go vet ./...

Fixes #4