### PR TITLE
fix: split service-base template into individual files to fix helm lint

### DIFF
--- a/charts/ziti-management/templates/deployment.yaml
+++ b/charts/ziti-management/templates/deployment.yaml
@@ -1,0 +1,1 @@
+{{- include "service-base.deployment" . -}}

--- a/charts/ziti-management/templates/hpa.yaml
+++ b/charts/ziti-management/templates/hpa.yaml
@@ -1,0 +1,1 @@
+{{- include "service-base.hpa" . -}}

--- a/charts/ziti-management/templates/ingress.yaml
+++ b/charts/ziti-management/templates/ingress.yaml
@@ -1,0 +1,1 @@
+{{- include "service-base.ingress" . -}}

--- a/charts/ziti-management/templates/metrics.yaml
+++ b/charts/ziti-management/templates/metrics.yaml
@@ -1,0 +1,1 @@
+{{- include "service-base.metrics" . -}}

--- a/charts/ziti-management/templates/pdb.yaml
+++ b/charts/ziti-management/templates/pdb.yaml
@@ -1,0 +1,1 @@
+{{- include "service-base.pdb" . -}}

--- a/charts/ziti-management/templates/rbac.yaml
+++ b/charts/ziti-management/templates/rbac.yaml
@@ -1,0 +1,1 @@
+{{- include "service-base.rbac" . -}}

--- a/charts/ziti-management/templates/service-base.yaml
+++ b/charts/ziti-management/templates/service-base.yaml
@@ -1,8 +1,0 @@
-{{- include "service-base.rbac" . -}}
-{{- include "service-base.serviceAccount" . -}}
-{{- include "service-base.service" . -}}
-{{- include "service-base.deployment" . -}}
-{{- include "service-base.hpa" . -}}
-{{- include "service-base.ingress" . -}}
-{{- include "service-base.pdb" . -}}
-{{- include "service-base.metrics" . -}}

--- a/charts/ziti-management/templates/service.yaml
+++ b/charts/ziti-management/templates/service.yaml
@@ -1,0 +1,1 @@
+{{- include "service-base.service" . -}}

--- a/charts/ziti-management/templates/serviceaccount.yaml
+++ b/charts/ziti-management/templates/serviceaccount.yaml
@@ -1,0 +1,1 @@
+{{- include "service-base.serviceAccount" . -}}


### PR DESCRIPTION
## Problem

`helm lint charts/ziti-management` fails with:

```
[ERROR] templates/service-base.yaml: unable to parse YAML: error converting YAML to JSON: yaml: line 10: did not find expected key
```

## Root Cause

The file `charts/ziti-management/templates/service-base.yaml` contained all eight `service-base` library chart includes in a single file using aggressive whitespace trimming (`{{- include "..." . -}}`):

```yaml
{{- include "service-base.rbac" . -}}
{{- include "service-base.serviceAccount" . -}}
{{- include "service-base.service" . -}}
...
```

The `-` on both sides of every `include` action trims **all** surrounding whitespace, including newlines. This causes the rendered output of each template to be concatenated directly with the next, with no YAML document separator (`---`) between them. The rendered output looks like:

```yaml
    app.kubernetes.io/version: "0.1.0"apiVersion: v1
kind: Service
```

This is invalid YAML — `apiVersion: v1` runs into the previous line.

## Fix

Split the single `service-base.yaml` into individual template files, one per resource kind:

| File | Include |
|---|---|
| `rbac.yaml` | `service-base.rbac` |
| `serviceaccount.yaml` | `service-base.serviceAccount` |
| `service.yaml` | `service-base.service` |
| `deployment.yaml` | `service-base.deployment` |
| `hpa.yaml` | `service-base.hpa` |
| `ingress.yaml` | `service-base.ingress` |
| `pdb.yaml` | `service-base.pdb` |
| `metrics.yaml` | `service-base.metrics` |

Helm processes each `.yaml` file as a separate YAML document, so no explicit `---` separators are needed. This matches the convention used in `agynio/gateway`.

## Verification

```bash
helm dependency build charts/ziti-management
helm lint charts/ziti-management          # passes
helm template test charts/ziti-management # renders valid YAML
```

No `--set` flags are required — the chart's `values.yaml` defaults are sufficient for lint (empty string values for `DATABASE_URL` etc. are valid YAML).