### PR TITLE
feat(ziti): add startup enrollment

### DIFF
--- a/charts/ziti-management/templates/_ziti-volumes.tpl
+++ b/charts/ziti-management/templates/_ziti-volumes.tpl
@@ -1,0 +1,28 @@
+{{- define "service-base.renderExtraVolumes" -}}
+{{- $volumes := list -}}
+{{- $persistence := .Values.persistence | default dict -}}
+{{- if $persistence.enabled }}
+{{- $claimName := printf "%s-ziti-data" (include "service-base.fullname" .) -}}
+{{- $volumes = append $volumes (dict "name" "ziti-data" "persistentVolumeClaim" (dict "claimName" $claimName)) -}}
+{{- end }}
+{{- with .Values.extraVolumes }}
+{{- $volumes = concat $volumes . }}
+{{- end }}
+{{- if $volumes }}
+{{ toYaml $volumes }}
+{{- end }}
+{{- end -}}
+
+{{- define "service-base.renderExtraVolumeMounts" -}}
+{{- $mounts := list -}}
+{{- $persistence := .Values.persistence | default dict -}}
+{{- if $persistence.enabled }}
+{{- $mounts = append $mounts (dict "name" "ziti-data" "mountPath" "/var/lib/ziti") -}}
+{{- end }}
+{{- with .Values.extraVolumeMounts }}
+{{- $mounts = concat $mounts . }}
+{{- end }}
+{{- if $mounts }}
+{{ toYaml $mounts }}
+{{- end }}
+{{- end -}}

--- a/charts/ziti-management/templates/pvc.yaml
+++ b/charts/ziti-management/templates/pvc.yaml
@@ -1,0 +1,21 @@
+{{- if .Values.persistence.enabled }}
+apiVersion: v1
+kind: PersistentVolumeClaim
+metadata:
+  name: {{ include "service-base.fullname" . }}-ziti-data
+  labels:
+    {{- include "service-base.labels" . | nindent 4 }}
+  {{- with .Values.persistence.annotations }}
+  annotations:
+    {{- toYaml . | nindent 4 }}
+  {{- end }}
+spec:
+  accessModes:
+    - {{ .Values.persistence.accessMode }}
+  resources:
+    requests:
+      storage: {{ .Values.persistence.size }}
+  {{- if .Values.persistence.storageClass }}
+  storageClassName: {{ .Values.persistence.storageClass }}
+  {{- end }}
+{{- end }}

--- a/charts/ziti-management/values.yaml
+++ b/charts/ziti-management/values.yaml
@@ -96,13 +96,8 @@ configMounts:
     type: secret
     mountPath: /etc/ziti-enrollment
     readOnly: true
-extraVolumeMounts:
-  - name: ziti-data
-    mountPath: /var/lib/ziti
-extraVolumes:
-  - name: ziti-data
-    persistentVolumeClaim:
-      claimName: ziti-management-ziti-data
+extraVolumeMounts: []
+extraVolumes: []
 
 persistence:
   enabled: true

--- a/charts/ziti-management/values.yaml
+++ b/charts/ziti-management/values.yaml
@@ -14,7 +14,8 @@ image:
 
 replicaCount: 1
 revisionHistoryLimit: 10
-updateStrategy: {}
+updateStrategy:
+  type: Recreate
 
 deploymentAnnotations: {}
 
@@ -77,24 +78,38 @@ env:
   - name: ZITI_CONTROLLER_URL
     value: ""
   - name: ZITI_CERT_FILE
-    value: "/etc/ziti/tls.crt"
+    value: "/var/lib/ziti/tls.crt"
   - name: ZITI_KEY_FILE
-    value: "/etc/ziti/tls.key"
+    value: "/var/lib/ziti/tls.key"
   - name: ZITI_CA_FILE
-    value: "/etc/ziti/ca.crt"
+    value: "/var/lib/ziti/ca.crt"
+  - name: ZITI_ENROLLMENT_JWT_FILE
+    value: "/etc/ziti-enrollment/enrollmentJwt"
 envFrom: []
 extraEnvVars: []
 extraEnvVarsCM: ""
 extraEnvVarsSecret: ""
 
 configMounts:
-  - name: ziti-certs
-    sourceName: ziti-certs
+  - name: ziti-enrollment
+    sourceName: ziti-enrollment
     type: secret
-    mountPath: /etc/ziti
+    mountPath: /etc/ziti-enrollment
     readOnly: true
-extraVolumeMounts: []
-extraVolumes: []
+extraVolumeMounts:
+  - name: ziti-data
+    mountPath: /var/lib/ziti
+extraVolumes:
+  - name: ziti-data
+    persistentVolumeClaim:
+      claimName: ziti-management-ziti-data
+
+persistence:
+  enabled: true
+  accessMode: ReadWriteOnce
+  size: 10Mi
+  storageClass: ""
+  annotations: {}
 
 initContainers: []
 extraContainers: []

--- a/cmd/ziti-management/main.go
+++ b/cmd/ziti-management/main.go
@@ -37,6 +37,10 @@ func run() error {
 		return err
 	}
 
+	if err := ziti.EnsureEnrollment(cfg.ZitiCertFile, cfg.ZitiKeyFile, cfg.ZitiCAFile, cfg.ZitiEnrollmentJWTFile); err != nil {
+		return fmt.Errorf("ensure ziti enrollment: %w", err)
+	}
+
 	poolCfg, err := pgxpool.ParseConfig(cfg.DatabaseURL)
 	if err != nil {
 		return fmt.Errorf("parse database url: %w", err)

--- a/internal/config/config.go
+++ b/internal/config/config.go
@@ -13,6 +13,7 @@ type Config struct {
 	ZitiCertFile              string
 	ZitiKeyFile               string
 	ZitiCAFile                string
+	ZitiEnrollmentJWTFile     string
 	ServiceIdentityLeaseTTL   time.Duration
 	ServiceIdentityGCInterval time.Duration
 }
@@ -43,6 +44,7 @@ func FromEnv() (Config, error) {
 	if cfg.ZitiCAFile == "" {
 		return Config{}, fmt.Errorf("ZITI_CA_FILE must be set")
 	}
+	cfg.ZitiEnrollmentJWTFile = os.Getenv("ZITI_ENROLLMENT_JWT_FILE")
 	leaseTTL, err := durationFromEnv("SERVICE_IDENTITY_LEASE_TTL", 5*time.Minute)
 	if err != nil {
 		return Config{}, err

--- a/internal/ziti/enroll.go
+++ b/internal/ziti/enroll.go
@@ -1,0 +1,138 @@
+package ziti
+
+import (
+	"errors"
+	"fmt"
+	"os"
+	"strings"
+
+	"github.com/openziti/sdk-golang/ziti"
+	"github.com/openziti/sdk-golang/ziti/enroll"
+)
+
+const pemPrefix = "pem:"
+
+var parseEnrollmentToken = enroll.ParseToken
+var enrollIdentity = enroll.Enroll
+
+func EnsureEnrollment(certFile, keyFile, caFile, jwtFile string) error {
+	if jwtFile == "" {
+		return nil
+	}
+
+	certsExist, err := certFilesExist(certFile, keyFile, caFile)
+	if err != nil {
+		return err
+	}
+	if certsExist {
+		return nil
+	}
+
+	jwtBytes, err := os.ReadFile(jwtFile)
+	if err != nil {
+		return fmt.Errorf("read enrollment jwt: %w", err)
+	}
+	jwt := strings.TrimSpace(string(jwtBytes))
+	if jwt == "" {
+		return errors.New("enrollment jwt is empty")
+	}
+
+	claims, _, err := parseEnrollmentToken(jwt)
+	if err != nil {
+		return fmt.Errorf("parse enrollment jwt: %w", err)
+	}
+
+	var keyAlg ziti.KeyAlgVar
+	if err := keyAlg.Set("EC"); err != nil {
+		return fmt.Errorf("set key algorithm: %w", err)
+	}
+
+	cfg, err := enrollIdentity(enroll.EnrollmentFlags{
+		Token:  claims,
+		KeyAlg: keyAlg,
+	})
+	if err != nil {
+		return fmt.Errorf("enroll identity: %w", err)
+	}
+
+	certPEM, keyPEM, caPEM, err := extractPEMCredentials(cfg)
+	if err != nil {
+		return err
+	}
+
+	if err := writePEMFile(certFile, certPEM); err != nil {
+		return fmt.Errorf("write ziti cert: %w", err)
+	}
+	if err := writePEMFile(keyFile, keyPEM); err != nil {
+		return fmt.Errorf("write ziti key: %w", err)
+	}
+	if err := writePEMFile(caFile, caPEM); err != nil {
+		return fmt.Errorf("write ziti ca: %w", err)
+	}
+
+	return nil
+}
+
+func certFilesExist(certFile, keyFile, caFile string) (bool, error) {
+	for _, entry := range []struct {
+		label string
+		path  string
+	}{
+		{label: "cert", path: certFile},
+		{label: "key", path: keyFile},
+		{label: "ca", path: caFile},
+	} {
+		if entry.path == "" {
+			return false, fmt.Errorf("ziti %s file path is empty", entry.label)
+		}
+		_, err := os.Stat(entry.path)
+		if err != nil {
+			if os.IsNotExist(err) {
+				return false, nil
+			}
+			return false, fmt.Errorf("stat ziti %s file: %w", entry.label, err)
+		}
+	}
+	return true, nil
+}
+
+func extractPEMCredentials(cfg *ziti.Config) (string, string, string, error) {
+	if cfg == nil {
+		return "", "", "", errors.New("enrollment returned nil config")
+	}
+
+	certPEM, err := stripPEMPrefix(cfg.ID.Cert, "cert")
+	if err != nil {
+		return "", "", "", err
+	}
+	keyPEM, err := stripPEMPrefix(cfg.ID.Key, "key")
+	if err != nil {
+		return "", "", "", err
+	}
+	caPEM, err := stripPEMPrefix(cfg.ID.CA, "ca")
+	if err != nil {
+		return "", "", "", err
+	}
+	return certPEM, keyPEM, caPEM, nil
+}
+
+func stripPEMPrefix(value, label string) (string, error) {
+	if value == "" {
+		return "", fmt.Errorf("enrollment config missing %s", label)
+	}
+	if !strings.HasPrefix(value, pemPrefix) {
+		return "", fmt.Errorf("enrollment config %s missing %s prefix", label, pemPrefix)
+	}
+	trimmed := strings.TrimPrefix(value, pemPrefix)
+	if trimmed == "" {
+		return "", fmt.Errorf("enrollment config %s is empty", label)
+	}
+	return trimmed, nil
+}
+
+func writePEMFile(path, contents string) error {
+	if err := os.WriteFile(path, []byte(contents), 0o600); err != nil {
+		return err
+	}
+	return os.Chmod(path, 0o600)
+}

--- a/internal/ziti/enroll_test.go
+++ b/internal/ziti/enroll_test.go
@@ -1,0 +1,150 @@
+package ziti
+
+import (
+	"os"
+	"path/filepath"
+	"testing"
+
+	"github.com/golang-jwt/jwt/v5"
+	"github.com/openziti/identity"
+	"github.com/openziti/sdk-golang/ziti"
+	"github.com/openziti/sdk-golang/ziti/enroll"
+)
+
+func TestEnsureEnrollmentSkipsWhenJWTEmpty(t *testing.T) {
+	stubEnrollmentFuncs(t, func(token string) (*ziti.EnrollmentClaims, *jwt.Token, error) {
+		t.Fatalf("parse enrollment called unexpectedly")
+		return nil, nil, nil
+	}, func(flags enroll.EnrollmentFlags) (*ziti.Config, error) {
+		t.Fatalf("enroll called unexpectedly")
+		return nil, nil
+	})
+
+	tempDir := t.TempDir()
+	certFile := filepath.Join(tempDir, "tls.crt")
+	keyFile := filepath.Join(tempDir, "tls.key")
+	caFile := filepath.Join(tempDir, "ca.crt")
+
+	if err := EnsureEnrollment(certFile, keyFile, caFile, ""); err != nil {
+		t.Fatalf("EnsureEnrollment returned error: %v", err)
+	}
+}
+
+func TestEnsureEnrollmentSkipsWhenCertsExist(t *testing.T) {
+	stubEnrollmentFuncs(t, func(token string) (*ziti.EnrollmentClaims, *jwt.Token, error) {
+		t.Fatalf("parse enrollment called unexpectedly")
+		return nil, nil, nil
+	}, func(flags enroll.EnrollmentFlags) (*ziti.Config, error) {
+		t.Fatalf("enroll called unexpectedly")
+		return nil, nil
+	})
+
+	tempDir := t.TempDir()
+	certFile := filepath.Join(tempDir, "tls.crt")
+	keyFile := filepath.Join(tempDir, "tls.key")
+	caFile := filepath.Join(tempDir, "ca.crt")
+	for _, path := range []string{certFile, keyFile, caFile} {
+		if err := os.WriteFile(path, []byte("existing"), 0o600); err != nil {
+			t.Fatalf("write test file: %v", err)
+		}
+	}
+
+	if err := EnsureEnrollment(certFile, keyFile, caFile, filepath.Join(tempDir, "missing.jwt")); err != nil {
+		t.Fatalf("EnsureEnrollment returned error: %v", err)
+	}
+
+	for _, path := range []string{certFile, keyFile, caFile} {
+		data, err := os.ReadFile(path)
+		if err != nil {
+			t.Fatalf("read file: %v", err)
+		}
+		if string(data) != "existing" {
+			t.Fatalf("unexpected file contents for %s: %s", path, string(data))
+		}
+	}
+}
+
+func TestEnsureEnrollmentWritesFiles(t *testing.T) {
+	stubEnrollmentFuncs(t, func(token string) (*ziti.EnrollmentClaims, *jwt.Token, error) {
+		if token != "test-jwt" {
+			t.Fatalf("unexpected jwt token: %s", token)
+		}
+		return &ziti.EnrollmentClaims{}, nil, nil
+	}, func(flags enroll.EnrollmentFlags) (*ziti.Config, error) {
+		if flags.Token == nil {
+			t.Fatalf("expected enrollment claims")
+		}
+		if !flags.KeyAlg.EC() {
+			t.Fatalf("expected EC key algorithm")
+		}
+		return &ziti.Config{
+			ID: identity.Config{
+				Cert: "pem:cert-data",
+				Key:  "pem:key-data",
+				CA:   "pem:ca-data",
+			},
+		}, nil
+	})
+
+	tempDir := t.TempDir()
+	certFile := filepath.Join(tempDir, "tls.crt")
+	keyFile := filepath.Join(tempDir, "tls.key")
+	caFile := filepath.Join(tempDir, "ca.crt")
+	jwtFile := filepath.Join(tempDir, "enrollment.jwt")
+	if err := os.WriteFile(jwtFile, []byte("test-jwt\n"), 0o600); err != nil {
+		t.Fatalf("write jwt file: %v", err)
+	}
+
+	if err := EnsureEnrollment(certFile, keyFile, caFile, jwtFile); err != nil {
+		t.Fatalf("EnsureEnrollment returned error: %v", err)
+	}
+
+	assertFileContents(t, certFile, "cert-data")
+	assertFileContents(t, keyFile, "key-data")
+	assertFileContents(t, caFile, "ca-data")
+
+	assertFileMode(t, certFile, 0o600)
+	assertFileMode(t, keyFile, 0o600)
+	assertFileMode(t, caFile, 0o600)
+}
+
+func stubEnrollmentFuncs(
+	t *testing.T,
+	parse func(string) (*ziti.EnrollmentClaims, *jwt.Token, error),
+	enrollFn func(enroll.EnrollmentFlags) (*ziti.Config, error),
+) {
+	t.Helper()
+
+	originalParse := parseEnrollmentToken
+	originalEnroll := enrollIdentity
+	parseEnrollmentToken = parse
+	enrollIdentity = enrollFn
+	t.Cleanup(func() {
+		parseEnrollmentToken = originalParse
+		enrollIdentity = originalEnroll
+	})
+}
+
+func assertFileContents(t *testing.T, path, expected string) {
+	t.Helper()
+
+	data, err := os.ReadFile(path)
+	if err != nil {
+		t.Fatalf("read file: %v", err)
+	}
+	if string(data) != expected {
+		t.Fatalf("unexpected file contents for %s: %s", path, string(data))
+	}
+}
+
+func assertFileMode(t *testing.T, path string, expected os.FileMode) {
+	t.Helper()
+
+	info, err := os.Stat(path)
+	if err != nil {
+		t.Fatalf("stat file: %v", err)
+	}
+	if info.Mode().Perm() != expected {
+		t.Fatalf("unexpected file mode for %s: %v", path, info.Mode().Perm())
+	}
+}

--- a/internal/ziti/enroll_test.go
+++ b/internal/ziti/enroll_test.go
@@ -1,8 +1,10 @@
 package ziti
 
 import (
+	"errors"
 	"os"
 	"path/filepath"
+	"strings"
 	"testing"
 
 	"github.com/golang-jwt/jwt/v5"
@@ -106,6 +108,134 @@ func TestEnsureEnrollmentWritesFiles(t *testing.T) {
 	assertFileMode(t, certFile, 0o600)
 	assertFileMode(t, keyFile, 0o600)
 	assertFileMode(t, caFile, 0o600)
+}
+
+func TestEnsureEnrollmentErrorsWhenJWTEmptyContent(t *testing.T) {
+	stubEnrollmentFuncs(t, func(token string) (*ziti.EnrollmentClaims, *jwt.Token, error) {
+		t.Fatalf("parse enrollment called unexpectedly")
+		return nil, nil, nil
+	}, func(flags enroll.EnrollmentFlags) (*ziti.Config, error) {
+		t.Fatalf("enroll called unexpectedly")
+		return nil, nil
+	})
+
+	tempDir := t.TempDir()
+	certFile := filepath.Join(tempDir, "tls.crt")
+	keyFile := filepath.Join(tempDir, "tls.key")
+	caFile := filepath.Join(tempDir, "ca.crt")
+	jwtFile := filepath.Join(tempDir, "enrollment.jwt")
+	if err := os.WriteFile(jwtFile, []byte(" \n"), 0o600); err != nil {
+		t.Fatalf("write jwt file: %v", err)
+	}
+
+	err := EnsureEnrollment(certFile, keyFile, caFile, jwtFile)
+	if err == nil {
+		t.Fatalf("expected error")
+	}
+	if !strings.Contains(err.Error(), "enrollment jwt is empty") {
+		t.Fatalf("unexpected error: %v", err)
+	}
+}
+
+func TestEnsureEnrollmentErrorsWhenPEMPrefixMissing(t *testing.T) {
+	stubEnrollmentFuncs(t, func(token string) (*ziti.EnrollmentClaims, *jwt.Token, error) {
+		return &ziti.EnrollmentClaims{}, nil, nil
+	}, func(flags enroll.EnrollmentFlags) (*ziti.Config, error) {
+		return &ziti.Config{
+			ID: identity.Config{
+				Cert: "cert-data",
+				Key:  "pem:key-data",
+				CA:   "pem:ca-data",
+			},
+		}, nil
+	})
+
+	tempDir := t.TempDir()
+	certFile := filepath.Join(tempDir, "tls.crt")
+	keyFile := filepath.Join(tempDir, "tls.key")
+	caFile := filepath.Join(tempDir, "ca.crt")
+	jwtFile := filepath.Join(tempDir, "enrollment.jwt")
+	if err := os.WriteFile(jwtFile, []byte("test-jwt"), 0o600); err != nil {
+		t.Fatalf("write jwt file: %v", err)
+	}
+
+	err := EnsureEnrollment(certFile, keyFile, caFile, jwtFile)
+	if err == nil {
+		t.Fatalf("expected error")
+	}
+	if !strings.Contains(err.Error(), "missing pem: prefix") {
+		t.Fatalf("unexpected error: %v", err)
+	}
+}
+
+func TestEnsureEnrollmentReenrollsWhenCertsMissing(t *testing.T) {
+	parseCalled := false
+	enrollCalled := false
+	stubEnrollmentFuncs(t, func(token string) (*ziti.EnrollmentClaims, *jwt.Token, error) {
+		parseCalled = true
+		return &ziti.EnrollmentClaims{}, nil, nil
+	}, func(flags enroll.EnrollmentFlags) (*ziti.Config, error) {
+		enrollCalled = true
+		return &ziti.Config{
+			ID: identity.Config{
+				Cert: "pem:new-cert",
+				Key:  "pem:new-key",
+				CA:   "pem:new-ca",
+			},
+		}, nil
+	})
+
+	tempDir := t.TempDir()
+	certFile := filepath.Join(tempDir, "tls.crt")
+	keyFile := filepath.Join(tempDir, "tls.key")
+	caFile := filepath.Join(tempDir, "ca.crt")
+	jwtFile := filepath.Join(tempDir, "enrollment.jwt")
+	if err := os.WriteFile(jwtFile, []byte("test-jwt"), 0o600); err != nil {
+		t.Fatalf("write jwt file: %v", err)
+	}
+	if err := os.WriteFile(certFile, []byte("old-cert"), 0o600); err != nil {
+		t.Fatalf("write existing cert: %v", err)
+	}
+
+	if err := EnsureEnrollment(certFile, keyFile, caFile, jwtFile); err != nil {
+		t.Fatalf("EnsureEnrollment returned error: %v", err)
+	}
+	if !parseCalled {
+		t.Fatalf("expected enrollment token parse")
+	}
+	if !enrollCalled {
+		t.Fatalf("expected enrollment")
+	}
+
+	assertFileContents(t, certFile, "new-cert")
+	assertFileContents(t, keyFile, "new-key")
+	assertFileContents(t, caFile, "new-ca")
+}
+
+func TestEnsureEnrollmentErrorsWhenEnrollFails(t *testing.T) {
+	enrollErr := errors.New("enroll failed")
+	stubEnrollmentFuncs(t, func(token string) (*ziti.EnrollmentClaims, *jwt.Token, error) {
+		return &ziti.EnrollmentClaims{}, nil, nil
+	}, func(flags enroll.EnrollmentFlags) (*ziti.Config, error) {
+		return nil, enrollErr
+	})
+
+	tempDir := t.TempDir()
+	certFile := filepath.Join(tempDir, "tls.crt")
+	keyFile := filepath.Join(tempDir, "tls.key")
+	caFile := filepath.Join(tempDir, "ca.crt")
+	jwtFile := filepath.Join(tempDir, "enrollment.jwt")
+	if err := os.WriteFile(jwtFile, []byte("test-jwt"), 0o600); err != nil {
+		t.Fatalf("write jwt file: %v", err)
+	}
+
+	err := EnsureEnrollment(certFile, keyFile, caFile, jwtFile)
+	if err == nil {
+		t.Fatalf("expected error")
+	}
+	if !strings.Contains(err.Error(), "enroll identity") {
+		t.Fatalf("unexpected error: %v", err)
+	}
 }
 
 func stubEnrollmentFuncs(


### PR DESCRIPTION
## Summary
- add startup enrollment helper with PEM extraction and file writes
- wire self-enrollment config into startup flow
- update Helm chart for PVC-backed cert storage and enrollment secret mount
- add unit tests for EnsureEnrollment

## Testing
- go test ./...
- golangci-lint run ./...

Refs #13