### PR TITLE
fix(app-identity): address review feedback

### DIFF
--- a/internal/server/converter.go
+++ b/internal/server/converter.go
@@ -6,10 +6,13 @@ import (
 	identityv1 "github.com/agynio/ziti-management/.gen/go/agynio/api/identity/v1"
 	zitimanagementv1 "github.com/agynio/ziti-management/.gen/go/agynio/api/ziti_management/v1"
 	"github.com/google/uuid"
+	"google.golang.org/protobuf/encoding/protowire"
 	"google.golang.org/protobuf/types/known/timestamppb"
 
 	"github.com/agynio/ziti-management/internal/store"
 )
+
+const managedIdentityZitiServiceIDFieldNumber = 4
 
 func parseUUID(value string) (uuid.UUID, error) {
 	if value == "" {
@@ -76,10 +79,21 @@ func toProtoManagedIdentity(identity store.ManagedIdentity) (*zitimanagementv1.M
 	if err != nil {
 		return nil, err
 	}
-	return &zitimanagementv1.ManagedIdentity{
+	protoIdentity := &zitimanagementv1.ManagedIdentity{
 		ZitiIdentityId: identity.ZitiIdentityID,
 		IdentityId:     identity.IdentityID.String(),
 		IdentityType:   identityType,
 		CreatedAt:      timestamppb.New(identity.CreatedAt),
-	}, nil
+	}
+	if identity.ZitiServiceID != nil {
+		appendManagedIdentityServiceID(protoIdentity, *identity.ZitiServiceID)
+	}
+	return protoIdentity, nil
+}
+
+func appendManagedIdentityServiceID(identity *zitimanagementv1.ManagedIdentity, zitiServiceID string) {
+	msg := identity.ProtoReflect()
+	field := protowire.AppendTag(nil, managedIdentityZitiServiceIDFieldNumber, protowire.BytesType)
+	field = protowire.AppendString(field, zitiServiceID)
+	msg.SetUnknown(append(msg.GetUnknown(), field...))
 }

--- a/internal/server/server.go
+++ b/internal/server/server.go
@@ -79,16 +79,12 @@ func (s *Server) CreateAppIdentity(ctx context.Context, req *zitimanagementv1.Cr
 		ZitiIdentityID: zitiID,
 		IdentityID:     appID,
 		IdentityType:   store.IdentityTypeApp,
-		ZitiServiceID:  serviceID,
 	}
+	identity.ZitiServiceID = &serviceID
 	if err := s.store.InsertManagedIdentity(ctx, identity); err != nil {
-		cleanupErr := s.ziti.DeleteIdentity(ctx, zitiID)
-		if cleanupErr != nil && !errors.Is(cleanupErr, ziti.ErrIdentityNotFound) {
-			log.Printf("failed to cleanup ziti identity %s: %v", zitiID, cleanupErr)
-		}
-		cleanupErr = s.ziti.DeleteService(ctx, serviceID)
-		if cleanupErr != nil && !errors.Is(cleanupErr, ziti.ErrServiceNotFound) {
-			log.Printf("failed to cleanup ziti service %s: %v", serviceID, cleanupErr)
+		cleanupErr := s.ziti.CleanupAppResources(ctx, zitiID, serviceID, err)
+		if cleanupErr != err {
+			log.Printf("failed to cleanup app resources for %s: %v", zitiID, cleanupErr)
 		}
 		return nil, status.Errorf(codes.Internal, "insert managed identity: %v", err)
 	}
@@ -123,9 +119,13 @@ func (s *Server) DeleteAppIdentity(ctx context.Context, req *zitimanagementv1.De
 	if zitiID == "" {
 		return nil, status.Error(codes.InvalidArgument, "ziti_identity_id is required")
 	}
-	zitiServiceID := req.GetZitiServiceId()
-	if zitiServiceID == "" {
-		return nil, status.Error(codes.InvalidArgument, "ziti_service_id is required")
+
+	identity, err := s.store.ResolveIdentity(ctx, zitiID)
+	if err != nil {
+		return nil, toStatusError(err)
+	}
+	if identity.ZitiServiceID == nil {
+		return nil, status.Errorf(codes.Internal, "managed identity %s missing ziti service id", zitiID)
 	}
 
 	if err := s.store.DeleteManagedIdentity(ctx, zitiID); err != nil {
@@ -139,6 +139,7 @@ func (s *Server) DeleteAppIdentity(ctx context.Context, req *zitimanagementv1.De
 			return nil, status.Errorf(codes.Internal, "delete ziti identity: %v", err)
 		}
 	}
+	zitiServiceID := *identity.ZitiServiceID
 	if err := s.ziti.DeleteService(ctx, zitiServiceID); err != nil {
 		if errors.Is(err, ziti.ErrServiceNotFound) {
 			log.Printf("ziti service %s already deleted", zitiServiceID)

--- a/internal/store/store.go
+++ b/internal/store/store.go
@@ -20,18 +20,6 @@ func NewStore(pool *pgxpool.Pool) *Store {
 }
 
 func (s *Store) InsertManagedIdentity(ctx context.Context, identity ManagedIdentity) error {
-	if identity.ZitiServiceID == "" {
-		_, err := s.pool.Exec(ctx, `INSERT INTO managed_identities (ziti_identity_id, identity_id, identity_type) VALUES ($1, $2, $3)`,
-			identity.ZitiIdentityID,
-			identity.IdentityID,
-			identity.IdentityType,
-		)
-		if err != nil {
-			return fmt.Errorf("insert managed identity: %w", err)
-		}
-		return nil
-	}
-
 	_, err := s.pool.Exec(ctx, `INSERT INTO managed_identities (ziti_identity_id, identity_id, identity_type, ziti_service_id) VALUES ($1, $2, $3, $4)`,
 		identity.ZitiIdentityID,
 		identity.IdentityID,
@@ -58,15 +46,11 @@ func (s *Store) DeleteManagedIdentity(ctx context.Context, zitiIdentityID string
 func (s *Store) ResolveIdentity(ctx context.Context, zitiIdentityID string) (ManagedIdentity, error) {
 	row := s.pool.QueryRow(ctx, `SELECT identity_id, identity_type, ziti_service_id, created_at FROM managed_identities WHERE ziti_identity_id = $1`, zitiIdentityID)
 	identity := ManagedIdentity{ZitiIdentityID: zitiIdentityID}
-	var zitiServiceID *string
-	if err := row.Scan(&identity.IdentityID, &identity.IdentityType, &zitiServiceID, &identity.CreatedAt); err != nil {
+	if err := row.Scan(&identity.IdentityID, &identity.IdentityType, &identity.ZitiServiceID, &identity.CreatedAt); err != nil {
 		if errors.Is(err, pgx.ErrNoRows) {
 			return ManagedIdentity{}, ErrManagedIdentityNotFound
 		}
 		return ManagedIdentity{}, fmt.Errorf("resolve identity: %w", err)
-	}
-	if zitiServiceID != nil {
-		identity.ZitiServiceID = *zitiServiceID
 	}
 	return identity, nil
 }
@@ -101,12 +85,8 @@ func (s *Store) ListManagedIdentities(ctx context.Context, filter ListFilter, pa
 	identities := make([]ManagedIdentity, 0)
 	for rows.Next() {
 		var identity ManagedIdentity
-		var zitiServiceID *string
-		if err := rows.Scan(&identity.ZitiIdentityID, &identity.IdentityID, &identity.IdentityType, &zitiServiceID, &identity.CreatedAt); err != nil {
+		if err := rows.Scan(&identity.ZitiIdentityID, &identity.IdentityID, &identity.IdentityType, &identity.ZitiServiceID, &identity.CreatedAt); err != nil {
 			return ListResult{}, fmt.Errorf("scan managed identity: %w", err)
-		}
-		if zitiServiceID != nil {
-			identity.ZitiServiceID = *zitiServiceID
 		}
 		identities = append(identities, identity)
 	}

--- a/internal/store/types.go
+++ b/internal/store/types.go
@@ -33,7 +33,7 @@ type ManagedIdentity struct {
 	ZitiIdentityID string
 	IdentityID     uuid.UUID
 	IdentityType   IdentityType
-	ZitiServiceID  string
+	ZitiServiceID  *string
 	CreatedAt      time.Time
 }
 

--- a/internal/ziti/client.go
+++ b/internal/ziti/client.go
@@ -191,7 +191,7 @@ func (c *Client) CreateAndEnrollServiceIdentity(ctx context.Context, name string
 }
 
 func (c *Client) CreateAndEnrollAppIdentity(ctx context.Context, appID uuid.UUID, slug string) (string, []byte, string, error) {
-	name := fmt.Sprintf("app-%s", slug)
+	name := fmt.Sprintf("app-%s-%s", slug, id.ShortUUID())
 	identityType := rest_model.IdentityTypeDevice
 	isAdmin := false
 	roleAttrs := rest_model.Attributes{"apps"}
@@ -220,12 +220,12 @@ func (c *Client) CreateAndEnrollAppIdentity(ctx context.Context, appID uuid.UUID
 
 	serviceID, err := c.CreateService(ctx, name, []string{"app-services"})
 	if err != nil {
-		return "", nil, "", c.cleanupAppResources(ctx, zitiID, "", err)
+		return "", nil, "", c.CleanupAppResources(ctx, zitiID, "", err)
 	}
 
 	identityJSON, err := c.enrollIdentity(ctx, zitiID)
 	if err != nil {
-		return "", nil, "", c.cleanupAppResources(ctx, zitiID, serviceID, err)
+		return "", nil, "", c.CleanupAppResources(ctx, zitiID, serviceID, err)
 	}
 	return zitiID, identityJSON, serviceID, nil
 }
@@ -281,7 +281,7 @@ func (c *Client) cleanupServiceIdentity(ctx context.Context, zitiIdentityID stri
 	return fmt.Errorf("%w; cleanup failed: %w", err, cleanupErr)
 }
 
-func (c *Client) cleanupAppResources(ctx context.Context, zitiIdentityID, zitiServiceID string, err error) error {
+func (c *Client) CleanupAppResources(ctx context.Context, zitiIdentityID, zitiServiceID string, err error) error {
 	identityErr := c.DeleteIdentity(ctx, zitiIdentityID)
 	if identityErr != nil && !errors.Is(identityErr, ErrIdentityNotFound) {
 		err = fmt.Errorf("%w; cleanup identity failed: %w", err, identityErr)


### PR DESCRIPTION
## Summary
- use nullable service IDs for managed identity inserts and scans
- resolve app service IDs from the DB and reuse cleanup helper
- add uniqueness suffix for app identity/service names and surface service IDs in list responses

## Testing
- buf generate buf.build/agynio/api --template buf.gen.yaml --path agynio/api/ziti_management/v1
- go vet ./...
- go test ./...

#1