### PR TITLE
fix(proto): update managed identity mapping

### DIFF
--- a/buf.lock
+++ b/buf.lock
@@ -4,8 +4,8 @@ deps:
   - remote: buf.build
     owner: agynio
     repository: api
-    commit: 5703b32f4b2644a6b56a6054e24ead9a
-    digest: shake256:87da4ca6ee4627fac5d01ceb0abc78c6f0b684c7e2f094a3ddb1c663b28035945b91bcf4a1a4b41732f111430a49dd5a90ca5e9cea0a5f7896925ea3c94a3edc
+    commit: 07b4eb9abdf04686ba06ceeb2bdc4315
+    digest: shake256:34b139ee81e9c93cae98bb25762e73b4e0a22af87fd8b4f39c64068b4b0f05bebb63a912765fcc4a041dcd46a382812d3f7cd9a04b62168a458f959ef4c68a27
   - remote: buf.build
     owner: opentelemetry
     repository: opentelemetry

--- a/internal/server/converter.go
+++ b/internal/server/converter.go
@@ -6,13 +6,10 @@ import (
 	identityv1 "github.com/agynio/ziti-management/.gen/go/agynio/api/identity/v1"
 	zitimanagementv1 "github.com/agynio/ziti-management/.gen/go/agynio/api/ziti_management/v1"
 	"github.com/google/uuid"
-	"google.golang.org/protobuf/encoding/protowire"
 	"google.golang.org/protobuf/types/known/timestamppb"
 
 	"github.com/agynio/ziti-management/internal/store"
 )
-
-const managedIdentityZitiServiceIDFieldNumber = 4
 
 func parseUUID(value string) (uuid.UUID, error) {
 	if value == "" {
@@ -79,21 +76,16 @@ func toProtoManagedIdentity(identity store.ManagedIdentity) (*zitimanagementv1.M
 	if err != nil {
 		return nil, err
 	}
+	zitiServiceID := ""
+	if identity.ZitiServiceID != nil {
+		zitiServiceID = *identity.ZitiServiceID
+	}
 	protoIdentity := &zitimanagementv1.ManagedIdentity{
 		ZitiIdentityId: identity.ZitiIdentityID,
 		IdentityId:     identity.IdentityID.String(),
 		IdentityType:   identityType,
+		ZitiServiceId:  zitiServiceID,
 		CreatedAt:      timestamppb.New(identity.CreatedAt),
 	}
-	if identity.ZitiServiceID != nil {
-		appendManagedIdentityServiceID(protoIdentity, *identity.ZitiServiceID)
-	}
 	return protoIdentity, nil
-}
-
-func appendManagedIdentityServiceID(identity *zitimanagementv1.ManagedIdentity, zitiServiceID string) {
-	msg := identity.ProtoReflect()
-	field := protowire.AppendTag(nil, managedIdentityZitiServiceIDFieldNumber, protowire.BytesType)
-	field = protowire.AppendString(field, zitiServiceID)
-	msg.SetUnknown(append(msg.GetUnknown(), field...))
 }

--- a/internal/server/server.go
+++ b/internal/server/server.go
@@ -79,8 +79,8 @@ func (s *Server) CreateAppIdentity(ctx context.Context, req *zitimanagementv1.Cr
 		ZitiIdentityID: zitiID,
 		IdentityID:     appID,
 		IdentityType:   store.IdentityTypeApp,
+		ZitiServiceID:  &serviceID,
 	}
-	identity.ZitiServiceID = &serviceID
 	if err := s.store.InsertManagedIdentity(ctx, identity); err != nil {
 		cleanupErr := s.ziti.CleanupAppResources(ctx, zitiID, serviceID, err)
 		if cleanupErr != err {


### PR DESCRIPTION
## Summary
- update buf.lock and regenerate stubs to pick up managed identity service IDs
- remove protowire workaround and map ZitiServiceId directly
- inline app identity service ID assignment in managed identity creation

## Testing
- buf generate buf.build/agynio/api --path agynio/api/ziti_management/v1 --path agynio/api/identity/v1 --include-imports
- go vet ./...
- go test ./...

#1