### PR TITLE
feat: add llm proxy service type

### DIFF
--- a/internal/server/converter.go
+++ b/internal/server/converter.go
@@ -47,6 +47,8 @@ func fromProtoServiceType(value zitimanagementv1.ServiceType) (store.ServiceType
 		return store.ServiceTypeOrchestrator, nil
 	case zitimanagementv1.ServiceType_SERVICE_TYPE_RUNNER:
 		return store.ServiceTypeRunner, nil
+	case zitimanagementv1.ServiceType_SERVICE_TYPE_LLM_PROXY:
+		return store.ServiceTypeLLMProxy, nil
 	case zitimanagementv1.ServiceType_SERVICE_TYPE_UNSPECIFIED:
 		return store.ServiceTypeUnspecified, fmt.Errorf("service type unspecified")
 	default:

--- a/internal/server/converter_test.go
+++ b/internal/server/converter_test.go
@@ -1,0 +1,72 @@
+package server
+
+import (
+	"strings"
+	"testing"
+
+	zitimanagementv1 "github.com/agynio/ziti-management/.gen/go/agynio/api/ziti_management/v1"
+
+	"github.com/agynio/ziti-management/internal/store"
+)
+
+func TestFromProtoServiceType(t *testing.T) {
+	tests := []struct {
+		name    string
+		input   zitimanagementv1.ServiceType
+		want    store.ServiceType
+		wantErr string
+	}{
+		{
+			name:  "gateway",
+			input: zitimanagementv1.ServiceType_SERVICE_TYPE_GATEWAY,
+			want:  store.ServiceTypeGateway,
+		},
+		{
+			name:  "orchestrator",
+			input: zitimanagementv1.ServiceType_SERVICE_TYPE_ORCHESTRATOR,
+			want:  store.ServiceTypeOrchestrator,
+		},
+		{
+			name:  "runner",
+			input: zitimanagementv1.ServiceType_SERVICE_TYPE_RUNNER,
+			want:  store.ServiceTypeRunner,
+		},
+		{
+			name:  "llm proxy",
+			input: zitimanagementv1.ServiceType_SERVICE_TYPE_LLM_PROXY,
+			want:  store.ServiceTypeLLMProxy,
+		},
+		{
+			name:    "unspecified",
+			input:   zitimanagementv1.ServiceType_SERVICE_TYPE_UNSPECIFIED,
+			want:    store.ServiceTypeUnspecified,
+			wantErr: "service type unspecified",
+		},
+		{
+			name:    "unknown",
+			input:   zitimanagementv1.ServiceType(99),
+			want:    store.ServiceTypeUnspecified,
+			wantErr: "unknown service type",
+		},
+	}
+
+	for _, tc := range tests {
+		tc := tc
+		t.Run(tc.name, func(t *testing.T) {
+			got, err := fromProtoServiceType(tc.input)
+			if tc.wantErr != "" {
+				if err == nil {
+					t.Fatalf("expected error")
+				}
+				if !strings.Contains(err.Error(), tc.wantErr) {
+					t.Fatalf("unexpected error: %v", err)
+				}
+			} else if err != nil {
+				t.Fatalf("unexpected error: %v", err)
+			}
+			if got != tc.want {
+				t.Fatalf("expected %v, got %v", tc.want, got)
+			}
+		})
+	}
+}

--- a/internal/server/server.go
+++ b/internal/server/server.go
@@ -278,6 +278,8 @@ func serviceIdentityConfig(serviceType store.ServiceType) (string, []string, err
 		return fmt.Sprintf("svc-orchestrator-%s", suffix), []string{"orchestrators"}, nil
 	case store.ServiceTypeRunner:
 		return fmt.Sprintf("svc-runner-%s", suffix), []string{"runners"}, nil
+	case store.ServiceTypeLLMProxy:
+		return fmt.Sprintf("svc-llm-proxy-%s", suffix), []string{"llm-proxy-hosts"}, nil
 	case store.ServiceTypeUnspecified:
 		return "", nil, fmt.Errorf("service type unspecified")
 	default:

--- a/internal/server/server_test.go
+++ b/internal/server/server_test.go
@@ -1,0 +1,71 @@
+package server
+
+import (
+	"reflect"
+	"strings"
+	"testing"
+
+	"github.com/agynio/ziti-management/internal/store"
+)
+
+func TestServiceIdentityConfig(t *testing.T) {
+	tests := []struct {
+		name       string
+		service    store.ServiceType
+		wantPrefix string
+		wantRoles  []string
+		wantErr    string
+	}{
+		{
+			name:       "llm proxy",
+			service:    store.ServiceTypeLLMProxy,
+			wantPrefix: "svc-llm-proxy-",
+			wantRoles:  []string{"llm-proxy-hosts"},
+		},
+		{
+			name:    "unspecified",
+			service: store.ServiceTypeUnspecified,
+			wantErr: "service type unspecified",
+		},
+		{
+			name:    "unknown",
+			service: store.ServiceType(99),
+			wantErr: "unknown service type",
+		},
+	}
+
+	for _, tc := range tests {
+		tc := tc
+		t.Run(tc.name, func(t *testing.T) {
+			name, roles, err := serviceIdentityConfig(tc.service)
+			if tc.wantErr != "" {
+				if err == nil {
+					t.Fatalf("expected error")
+				}
+				if !strings.Contains(err.Error(), tc.wantErr) {
+					t.Fatalf("unexpected error: %v", err)
+				}
+				if name != "" {
+					t.Fatalf("expected empty name, got %q", name)
+				}
+				if roles != nil {
+					t.Fatalf("expected nil roles, got %v", roles)
+				}
+				return
+			}
+			if err != nil {
+				t.Fatalf("unexpected error: %v", err)
+			}
+			if !strings.HasPrefix(name, tc.wantPrefix) {
+				t.Fatalf("expected name prefix %q, got %q", tc.wantPrefix, name)
+			}
+			suffix := strings.TrimPrefix(name, tc.wantPrefix)
+			if len(suffix) != 8 {
+				t.Fatalf("expected 8-char suffix, got %q", suffix)
+			}
+			if !reflect.DeepEqual(roles, tc.wantRoles) {
+				t.Fatalf("expected roles %v, got %v", tc.wantRoles, roles)
+			}
+		})
+	}
+}

--- a/internal/store/types.go
+++ b/internal/store/types.go
@@ -27,6 +27,7 @@ const (
 	ServiceTypeGateway      ServiceType = 1
 	ServiceTypeOrchestrator ServiceType = 2
 	ServiceTypeRunner       ServiceType = 3
+	ServiceTypeLLMProxy     ServiceType = 4
 )
 
 type ManagedIdentity struct {


### PR DESCRIPTION
## Summary
- add LLM proxy service type constant and mappings
- add service identity configuration for LLM proxy services

## Testing
- go test ./...
- go vet ./...

#19