### PR TITLE
fix(ziti): make agent identity idempotent

### DIFF
--- a/internal/server/converter.go
+++ b/internal/server/converter.go
@@ -6,13 +6,10 @@ import (
 	identityv1 "github.com/agynio/ziti-management/.gen/go/agynio/api/identity/v1"
 	zitimanagementv1 "github.com/agynio/ziti-management/.gen/go/agynio/api/ziti_management/v1"
 	"github.com/google/uuid"
-	"google.golang.org/protobuf/encoding/protowire"
 	"google.golang.org/protobuf/types/known/timestamppb"
 
 	"github.com/agynio/ziti-management/internal/store"
 )
-
-const managedIdentityZitiServiceIDFieldNumber = 4
 
 func parseUUID(value string) (uuid.UUID, error) {
 	if value == "" {

--- a/internal/server/converter.go
+++ b/internal/server/converter.go
@@ -6,10 +6,13 @@ import (
 	identityv1 "github.com/agynio/ziti-management/.gen/go/agynio/api/identity/v1"
 	zitimanagementv1 "github.com/agynio/ziti-management/.gen/go/agynio/api/ziti_management/v1"
 	"github.com/google/uuid"
+	"google.golang.org/protobuf/encoding/protowire"
 	"google.golang.org/protobuf/types/known/timestamppb"
 
 	"github.com/agynio/ziti-management/internal/store"
 )
+
+const managedIdentityZitiServiceIDFieldNumber = 4
 
 func parseUUID(value string) (uuid.UUID, error) {
 	if value == "" {

--- a/internal/ziti/client.go
+++ b/internal/ziti/client.go
@@ -11,8 +11,8 @@ import (
 	"os"
 
 	"github.com/agynio/ziti-management/internal/id"
+	"github.com/go-openapi/runtime"
 	"github.com/google/uuid"
-	"github.com/openziti/edge-api/rest_management_api_client"
 	"github.com/openziti/edge-api/rest_management_api_client/identity"
 	"github.com/openziti/edge-api/rest_management_api_client/service"
 	"github.com/openziti/edge-api/rest_model"
@@ -24,8 +24,21 @@ import (
 var ErrIdentityNotFound = errors.New("identity not found")
 var ErrServiceNotFound = errors.New("service not found")
 
+type identityService interface {
+	CreateIdentity(params *identity.CreateIdentityParams, authInfo runtime.ClientAuthInfoWriter, opts ...identity.ClientOption) (*identity.CreateIdentityCreated, error)
+	DeleteIdentity(params *identity.DeleteIdentityParams, authInfo runtime.ClientAuthInfoWriter, opts ...identity.ClientOption) (*identity.DeleteIdentityOK, error)
+	DetailIdentity(params *identity.DetailIdentityParams, authInfo runtime.ClientAuthInfoWriter, opts ...identity.ClientOption) (*identity.DetailIdentityOK, error)
+	ListIdentities(params *identity.ListIdentitiesParams, authInfo runtime.ClientAuthInfoWriter, opts ...identity.ClientOption) (*identity.ListIdentitiesOK, error)
+}
+
+type serviceService interface {
+	CreateService(params *service.CreateServiceParams, authInfo runtime.ClientAuthInfoWriter, opts ...service.ClientOption) (*service.CreateServiceCreated, error)
+	DeleteService(params *service.DeleteServiceParams, authInfo runtime.ClientAuthInfoWriter, opts ...service.ClientOption) (*service.DeleteServiceOK, error)
+}
+
 type Client struct {
-	client *rest_management_api_client.ZitiEdgeManagement
+	identity identityService
+	service  serviceService
 }
 
 func NewClient(controllerURL, certFile, keyFile, caFile string) (*Client, error) {
@@ -41,7 +54,7 @@ func NewClient(controllerURL, certFile, keyFile, caFile string) (*Client, error)
 	if err != nil {
 		return nil, fmt.Errorf("create edge management client: %w", err)
 	}
-	return &Client{client: client}, nil
+	return &Client{identity: client.Identity, service: client.Service}, nil
 }
 
 func loadClientCredentials(certFile, keyFile string) (*x509.Certificate, crypto.PrivateKey, error) {
@@ -84,6 +97,17 @@ func loadCAPool(caFile string) (*x509.CertPool, error) {
 }
 
 func (c *Client) CreateAgentIdentity(ctx context.Context, agentID uuid.UUID) (string, string, error) {
+	externalID := agentID.String()
+	existingIdentity, err := c.findIdentityByExternalID(ctx, externalID)
+	if err != nil {
+		return "", "", err
+	}
+	if existingIdentity != nil {
+		if err := c.DeleteIdentity(ctx, *existingIdentity.ID); err != nil && !errors.Is(err, ErrIdentityNotFound) {
+			return "", "", fmt.Errorf("delete existing ziti identity: %w", err)
+		}
+	}
+
 	name := fmt.Sprintf("agent-%s-%s", agentID.String(), id.ShortUUID())
 	identityType := rest_model.IdentityTypeDevice
 	isAdmin := false
@@ -91,7 +115,6 @@ func (c *Client) CreateAgentIdentity(ctx context.Context, agentID uuid.UUID) (st
 		"agents",
 		fmt.Sprintf("agent-%s", agentID.String()),
 	}
-	externalID := agentID.String()
 	params := identity.NewCreateIdentityParamsWithContext(ctx)
 	params.Identity = &rest_model.IdentityCreate{
 		Name:           &name,
@@ -102,7 +125,7 @@ func (c *Client) CreateAgentIdentity(ctx context.Context, agentID uuid.UUID) (st
 		Enrollment:     &rest_model.IdentityCreateEnrollment{Ott: true},
 	}
 
-	created, err := c.client.Identity.CreateIdentity(params, nil)
+	created, err := c.identity.CreateIdentity(params, nil)
 	if err != nil {
 		return "", "", fmt.Errorf("create ziti identity: %w", err)
 	}
@@ -121,6 +144,27 @@ func (c *Client) CreateAgentIdentity(ctx context.Context, agentID uuid.UUID) (st
 	return zitiID, jwt, nil
 }
 
+func (c *Client) findIdentityByExternalID(ctx context.Context, externalID string) (*rest_model.IdentityDetail, error) {
+	filter := fmt.Sprintf("externalId = \"%s\"", externalID)
+	params := identity.NewListIdentitiesParamsWithContext(ctx)
+	params.Filter = &filter
+	listed, err := c.identity.ListIdentities(params, nil)
+	if err != nil {
+		return nil, fmt.Errorf("list ziti identities: %w", err)
+	}
+	if listed.Payload == nil || listed.Payload.Data == nil {
+		return nil, errors.New("list ziti identities response missing data")
+	}
+	if len(listed.Payload.Data) == 0 {
+		return nil, nil
+	}
+	identityDetail := listed.Payload.Data[0]
+	if identityDetail == nil || identityDetail.ID == nil || *identityDetail.ID == "" {
+		return nil, errors.New("list ziti identities response missing id")
+	}
+	return identityDetail, nil
+}
+
 func (c *Client) CreateService(ctx context.Context, name string, roleAttributes []string) (string, error) {
 	encryptionRequired := true
 	params := service.NewCreateServiceParamsWithContext(ctx)
@@ -130,7 +174,7 @@ func (c *Client) CreateService(ctx context.Context, name string, roleAttributes 
 		EncryptionRequired: &encryptionRequired,
 	}
 
-	created, err := c.client.Service.CreateService(params, nil)
+	created, err := c.service.CreateService(params, nil)
 	if err != nil {
 		return "", fmt.Errorf("create ziti service: %w", err)
 	}
@@ -147,7 +191,7 @@ func (c *Client) CreateService(ctx context.Context, name string, roleAttributes 
 func (c *Client) DeleteService(ctx context.Context, serviceID string) error {
 	params := service.NewDeleteServiceParamsWithContext(ctx)
 	params.ID = serviceID
-	_, err := c.client.Service.DeleteService(params, nil)
+	_, err := c.service.DeleteService(params, nil)
 	if err == nil {
 		return nil
 	}
@@ -171,7 +215,7 @@ func (c *Client) CreateAndEnrollServiceIdentity(ctx context.Context, name string
 		Enrollment:     &rest_model.IdentityCreateEnrollment{Ott: true},
 	}
 
-	created, err := c.client.Identity.CreateIdentity(params, nil)
+	created, err := c.identity.CreateIdentity(params, nil)
 	if err != nil {
 		return "", nil, fmt.Errorf("create ziti identity: %w", err)
 	}
@@ -206,7 +250,7 @@ func (c *Client) CreateAndEnrollAppIdentity(ctx context.Context, appID uuid.UUID
 		Enrollment:     &rest_model.IdentityCreateEnrollment{Ott: true},
 	}
 
-	created, err := c.client.Identity.CreateIdentity(params, nil)
+	created, err := c.identity.CreateIdentity(params, nil)
 	if err != nil {
 		return "", nil, "", fmt.Errorf("create ziti identity: %w", err)
 	}
@@ -259,7 +303,7 @@ func (c *Client) enrollIdentity(ctx context.Context, zitiIdentityID string) ([]b
 func (c *Client) fetchEnrollmentJWT(ctx context.Context, zitiIdentityID string) (string, error) {
 	detailParams := identity.NewDetailIdentityParamsWithContext(ctx)
 	detailParams.ID = zitiIdentityID
-	detail, err := c.client.Identity.DetailIdentity(detailParams, nil)
+	detail, err := c.identity.DetailIdentity(detailParams, nil)
 	if err != nil {
 		return "", fmt.Errorf("detail ziti identity: %w", err)
 	}
@@ -299,7 +343,7 @@ func (c *Client) CleanupAppResources(ctx context.Context, zitiIdentityID, zitiSe
 func (c *Client) DeleteIdentity(ctx context.Context, zitiIdentityID string) error {
 	params := identity.NewDeleteIdentityParamsWithContext(ctx)
 	params.ID = zitiIdentityID
-	_, err := c.client.Identity.DeleteIdentity(params, nil)
+	_, err := c.identity.DeleteIdentity(params, nil)
 	if err == nil {
 		return nil
 	}

--- a/internal/ziti/client_test.go
+++ b/internal/ziti/client_test.go
@@ -1,0 +1,213 @@
+package ziti
+
+import (
+	"context"
+	"errors"
+	"fmt"
+	"testing"
+
+	"github.com/go-openapi/runtime"
+	"github.com/google/uuid"
+	"github.com/openziti/edge-api/rest_management_api_client/identity"
+	"github.com/openziti/edge-api/rest_model"
+)
+
+type fakeIdentityService struct {
+	listIdentitiesFunc func(params *identity.ListIdentitiesParams) (*identity.ListIdentitiesOK, error)
+	createIdentityFunc func(params *identity.CreateIdentityParams) (*identity.CreateIdentityCreated, error)
+	deleteIdentityFunc func(params *identity.DeleteIdentityParams) (*identity.DeleteIdentityOK, error)
+	detailIdentityFunc func(params *identity.DetailIdentityParams) (*identity.DetailIdentityOK, error)
+}
+
+func (f *fakeIdentityService) ListIdentities(params *identity.ListIdentitiesParams, _ runtime.ClientAuthInfoWriter, _ ...identity.ClientOption) (*identity.ListIdentitiesOK, error) {
+	if f.listIdentitiesFunc == nil {
+		return nil, errors.New("list identities not stubbed")
+	}
+	return f.listIdentitiesFunc(params)
+}
+
+func (f *fakeIdentityService) CreateIdentity(params *identity.CreateIdentityParams, _ runtime.ClientAuthInfoWriter, _ ...identity.ClientOption) (*identity.CreateIdentityCreated, error) {
+	if f.createIdentityFunc == nil {
+		return nil, errors.New("create identity not stubbed")
+	}
+	return f.createIdentityFunc(params)
+}
+
+func (f *fakeIdentityService) DeleteIdentity(params *identity.DeleteIdentityParams, _ runtime.ClientAuthInfoWriter, _ ...identity.ClientOption) (*identity.DeleteIdentityOK, error) {
+	if f.deleteIdentityFunc == nil {
+		return nil, errors.New("delete identity not stubbed")
+	}
+	return f.deleteIdentityFunc(params)
+}
+
+func (f *fakeIdentityService) DetailIdentity(params *identity.DetailIdentityParams, _ runtime.ClientAuthInfoWriter, _ ...identity.ClientOption) (*identity.DetailIdentityOK, error) {
+	if f.detailIdentityFunc == nil {
+		return nil, errors.New("detail identity not stubbed")
+	}
+	return f.detailIdentityFunc(params)
+}
+
+func TestCreateAgentIdentityDeletesExistingIdentity(t *testing.T) {
+	ctx := context.Background()
+	agentID := uuid.New()
+	existingID := "existing-id"
+	createdID := "created-id"
+	jwt := "jwt-token"
+	var deleteCalled bool
+
+	fake := &fakeIdentityService{
+		listIdentitiesFunc: func(params *identity.ListIdentitiesParams) (*identity.ListIdentitiesOK, error) {
+			assertFilter(t, params, agentID)
+			return listIdentitiesResponse(existingID), nil
+		},
+		deleteIdentityFunc: func(params *identity.DeleteIdentityParams) (*identity.DeleteIdentityOK, error) {
+			deleteCalled = true
+			if params == nil || params.ID != existingID {
+				t.Fatalf("expected delete identity id %q, got %#v", existingID, params)
+			}
+			return &identity.DeleteIdentityOK{}, nil
+		},
+		createIdentityFunc: func(params *identity.CreateIdentityParams) (*identity.CreateIdentityCreated, error) {
+			if !deleteCalled {
+				t.Fatalf("expected delete before create")
+			}
+			assertCreateExternalID(t, params, agentID)
+			return createIdentityResponse(createdID), nil
+		},
+		detailIdentityFunc: func(params *identity.DetailIdentityParams) (*identity.DetailIdentityOK, error) {
+			if params == nil || params.ID != createdID {
+				t.Fatalf("expected detail identity id %q, got %#v", createdID, params)
+			}
+			return detailIdentityResponse(jwt), nil
+		},
+	}
+
+	client := &Client{identity: fake}
+	zitiID, token, err := client.CreateAgentIdentity(ctx, agentID)
+	if err != nil {
+		t.Fatalf("create agent identity: %v", err)
+	}
+	if zitiID != createdID {
+		t.Fatalf("expected identity id %q, got %q", createdID, zitiID)
+	}
+	if token != jwt {
+		t.Fatalf("expected jwt %q, got %q", jwt, token)
+	}
+}
+
+func TestCreateAgentIdentityIgnoresMissingDelete(t *testing.T) {
+	ctx := context.Background()
+	agentID := uuid.New()
+	existingID := "missing-id"
+	createdID := "created-id"
+	jwt := "jwt-token"
+	var deleteCalled bool
+
+	fake := &fakeIdentityService{
+		listIdentitiesFunc: func(params *identity.ListIdentitiesParams) (*identity.ListIdentitiesOK, error) {
+			assertFilter(t, params, agentID)
+			return listIdentitiesResponse(existingID), nil
+		},
+		deleteIdentityFunc: func(params *identity.DeleteIdentityParams) (*identity.DeleteIdentityOK, error) {
+			deleteCalled = true
+			return nil, &identity.DeleteIdentityNotFound{}
+		},
+		createIdentityFunc: func(params *identity.CreateIdentityParams) (*identity.CreateIdentityCreated, error) {
+			if !deleteCalled {
+				t.Fatalf("expected delete before create")
+			}
+			assertCreateExternalID(t, params, agentID)
+			return createIdentityResponse(createdID), nil
+		},
+		detailIdentityFunc: func(params *identity.DetailIdentityParams) (*identity.DetailIdentityOK, error) {
+			return detailIdentityResponse(jwt), nil
+		},
+	}
+
+	client := &Client{identity: fake}
+	zitiID, token, err := client.CreateAgentIdentity(ctx, agentID)
+	if err != nil {
+		t.Fatalf("create agent identity: %v", err)
+	}
+	if zitiID != createdID {
+		t.Fatalf("expected identity id %q, got %q", createdID, zitiID)
+	}
+	if token != jwt {
+		t.Fatalf("expected jwt %q, got %q", jwt, token)
+	}
+}
+
+func TestCreateAgentIdentitySkipsDeleteWhenNoExistingIdentity(t *testing.T) {
+	ctx := context.Background()
+	agentID := uuid.New()
+	createdID := "created-id"
+	jwt := "jwt-token"
+	var deleteCalls int
+
+	fake := &fakeIdentityService{
+		listIdentitiesFunc: func(params *identity.ListIdentitiesParams) (*identity.ListIdentitiesOK, error) {
+			assertFilter(t, params, agentID)
+			return listIdentitiesResponse(""), nil
+		},
+		deleteIdentityFunc: func(params *identity.DeleteIdentityParams) (*identity.DeleteIdentityOK, error) {
+			deleteCalls++
+			return &identity.DeleteIdentityOK{}, nil
+		},
+		createIdentityFunc: func(params *identity.CreateIdentityParams) (*identity.CreateIdentityCreated, error) {
+			assertCreateExternalID(t, params, agentID)
+			return createIdentityResponse(createdID), nil
+		},
+		detailIdentityFunc: func(params *identity.DetailIdentityParams) (*identity.DetailIdentityOK, error) {
+			return detailIdentityResponse(jwt), nil
+		},
+	}
+
+	client := &Client{identity: fake}
+	_, _, err := client.CreateAgentIdentity(ctx, agentID)
+	if err != nil {
+		t.Fatalf("create agent identity: %v", err)
+	}
+	if deleteCalls != 0 {
+		t.Fatalf("expected delete not called, got %d", deleteCalls)
+	}
+}
+
+func assertFilter(t *testing.T, params *identity.ListIdentitiesParams, agentID uuid.UUID) {
+	t.Helper()
+	if params == nil || params.Filter == nil {
+		t.Fatalf("expected filter param set")
+	}
+	expected := fmt.Sprintf("externalId = \"%s\"", agentID.String())
+	if *params.Filter != expected {
+		t.Fatalf("expected filter %q, got %q", expected, *params.Filter)
+	}
+}
+
+func assertCreateExternalID(t *testing.T, params *identity.CreateIdentityParams, agentID uuid.UUID) {
+	t.Helper()
+	if params == nil || params.Identity == nil || params.Identity.ExternalID == nil {
+		t.Fatalf("expected create identity external id")
+	}
+	if *params.Identity.ExternalID != agentID.String() {
+		t.Fatalf("expected external id %q, got %q", agentID.String(), *params.Identity.ExternalID)
+	}
+}
+
+func listIdentitiesResponse(identityID string) *identity.ListIdentitiesOK {
+	if identityID == "" {
+		return &identity.ListIdentitiesOK{Payload: &rest_model.ListIdentitiesEnvelope{Data: rest_model.IdentityList{}}}
+	}
+	return &identity.ListIdentitiesOK{Payload: &rest_model.ListIdentitiesEnvelope{Data: rest_model.IdentityList{
+		&rest_model.IdentityDetail{BaseEntity: rest_model.BaseEntity{ID: &identityID}},
+	}}}
+}
+
+func createIdentityResponse(identityID string) *identity.CreateIdentityCreated {
+	return &identity.CreateIdentityCreated{Payload: &rest_model.CreateEnvelope{Data: &rest_model.CreateLocation{ID: identityID}}}
+}
+
+func detailIdentityResponse(jwt string) *identity.DetailIdentityOK {
+	return &identity.DetailIdentityOK{Payload: &rest_model.DetailIdentityEnvelope{Data: &rest_model.IdentityDetail{Enrollment: &rest_model.IdentityEnrollments{
+		Ott: &rest_model.IdentityEnrollmentsOtt{JWT: jwt},
+	}}}}
+}

--- a/internal/ziti/client_test.go
+++ b/internal/ziti/client_test.go
@@ -137,6 +137,47 @@ func TestCreateAgentIdentityIgnoresMissingDelete(t *testing.T) {
 	}
 }
 
+func TestCreateAgentIdentityDeleteFailureStopsCreate(t *testing.T) {
+	ctx := context.Background()
+	agentID := uuid.New()
+	existingID := "stale-id"
+	deleteErr := errors.New("ziti controller unavailable")
+	var createCalled bool
+
+	fake := &fakeIdentityService{
+		listIdentitiesFunc: func(params *identity.ListIdentitiesParams) (*identity.ListIdentitiesOK, error) {
+			assertFilter(t, params, agentID)
+			return listIdentitiesResponse(existingID), nil
+		},
+		deleteIdentityFunc: func(params *identity.DeleteIdentityParams) (*identity.DeleteIdentityOK, error) {
+			if params == nil || params.ID != existingID {
+				t.Fatalf("expected delete identity id %q, got %#v", existingID, params)
+			}
+			return nil, deleteErr
+		},
+		createIdentityFunc: func(params *identity.CreateIdentityParams) (*identity.CreateIdentityCreated, error) {
+			createCalled = true
+			return createIdentityResponse("unused"), nil
+		},
+		detailIdentityFunc: func(params *identity.DetailIdentityParams) (*identity.DetailIdentityOK, error) {
+			t.Fatalf("detail identity should not be called")
+			return nil, nil
+		},
+	}
+
+	client := &Client{identity: fake}
+	_, _, err := client.CreateAgentIdentity(ctx, agentID)
+	if err == nil {
+		t.Fatalf("expected delete error")
+	}
+	if !errors.Is(err, deleteErr) {
+		t.Fatalf("expected error %q, got %v", deleteErr, err)
+	}
+	if createCalled {
+		t.Fatalf("expected create not called")
+	}
+}
+
 func TestCreateAgentIdentitySkipsDeleteWhenNoExistingIdentity(t *testing.T) {
 	ctx := context.Background()
 	agentID := uuid.New()


### PR DESCRIPTION
## Summary
- clean up existing agent identities by external ID before creation
- introduce identity/service interfaces to enable testing
- add CreateAgentIdentity idempotency tests

## Testing
- go vet ./...
- go test ./...

## Issue
- #21