### PR TITLE
fix(server): avoid misparsing ziti ids

### DIFF
--- a/internal/server/server.go
+++ b/internal/server/server.go
@@ -266,9 +266,6 @@ func (s *Server) resolveManagedIdentity(ctx context.Context, zitiID string) (sto
 }
 
 func parseManagedIdentityID(value string) (uuid.UUID, bool) {
-	if identityID, err := uuid.Parse(value); err == nil {
-		return identityID, true
-	}
 	const agentPrefix = "agent-"
 	const uuidLength = 36
 	if strings.HasPrefix(value, agentPrefix) && len(value) >= len(agentPrefix)+uuidLength {

--- a/internal/server/server_test.go
+++ b/internal/server/server_test.go
@@ -82,8 +82,7 @@ func TestParseManagedIdentityID(t *testing.T) {
 		{
 			name:  "uuid",
 			value: identityID.String(),
-			want:  identityID,
-			ok:    true,
+			ok:    false,
 		},
 		{
 			name:  "agent prefix",


### PR DESCRIPTION
## Summary
- stop parsing raw UUIDs as managed identity ids (only `agent-<uuid>` supported)
- update `TestParseManagedIdentityID` to cover raw UUID being ignored

## Testing
- go vet ./...
- go test ./...
- NODE_TLS_REJECT_UNAUTHORIZED=0 E2E_BASE_URL=https://chat.agyn.dev:2496 pnpm exec playwright test

#1