### PR TITLE
feat: add runner identity management

### DIFF
--- a/buf.lock
+++ b/buf.lock
@@ -4,8 +4,8 @@ deps:
   - remote: buf.build
     owner: agynio
     repository: api
-    commit: 07b4eb9abdf04686ba06ceeb2bdc4315
-    digest: shake256:34b139ee81e9c93cae98bb25762e73b4e0a22af87fd8b4f39c64068b4b0f05bebb63a912765fcc4a041dcd46a382812d3f7cd9a04b62168a458f959ef4c68a27
+    commit: 8352aa52d6d24a16a83fcaac76a44348
+    digest: shake256:f6f74b097b9349ff456e23e8763f9fc0f99bc8e45402eaeb573351544e717ac1f0ceeb8851c6a0f224af6ea33e665ecc9ecb85e2246219b45c3a4bde6d820857
   - remote: buf.build
     owner: opentelemetry
     repository: opentelemetry

--- a/internal/server/converter.go
+++ b/internal/server/converter.go
@@ -28,8 +28,6 @@ func fromProtoIdentityType(value identityv1.IdentityType) (store.IdentityType, e
 		return store.IdentityTypeAgent, nil
 	case identityv1.IdentityType_IDENTITY_TYPE_RUNNER:
 		return store.IdentityTypeRunner, nil
-	case identityv1.IdentityType_IDENTITY_TYPE_CHANNEL:
-		return store.IdentityTypeChannel, nil
 	case identityv1.IdentityType_IDENTITY_TYPE_APP:
 		return store.IdentityTypeApp, nil
 	case identityv1.IdentityType_IDENTITY_TYPE_UNSPECIFIED:
@@ -45,8 +43,6 @@ func fromProtoServiceType(value zitimanagementv1.ServiceType) (store.ServiceType
 		return store.ServiceTypeGateway, nil
 	case zitimanagementv1.ServiceType_SERVICE_TYPE_ORCHESTRATOR:
 		return store.ServiceTypeOrchestrator, nil
-	case zitimanagementv1.ServiceType_SERVICE_TYPE_RUNNER:
-		return store.ServiceTypeRunner, nil
 	case zitimanagementv1.ServiceType_SERVICE_TYPE_LLM_PROXY:
 		return store.ServiceTypeLLMProxy, nil
 	case zitimanagementv1.ServiceType_SERVICE_TYPE_UNSPECIFIED:
@@ -62,8 +58,6 @@ func toProtoIdentityType(value store.IdentityType) (identityv1.IdentityType, err
 		return identityv1.IdentityType_IDENTITY_TYPE_AGENT, nil
 	case store.IdentityTypeRunner:
 		return identityv1.IdentityType_IDENTITY_TYPE_RUNNER, nil
-	case store.IdentityTypeChannel:
-		return identityv1.IdentityType_IDENTITY_TYPE_CHANNEL, nil
 	case store.IdentityTypeApp:
 		return identityv1.IdentityType_IDENTITY_TYPE_APP, nil
 	case store.IdentityTypeUnspecified:

--- a/internal/server/converter_test.go
+++ b/internal/server/converter_test.go
@@ -27,11 +27,6 @@ func TestFromProtoServiceType(t *testing.T) {
 			want:  store.ServiceTypeOrchestrator,
 		},
 		{
-			name:  "runner",
-			input: zitimanagementv1.ServiceType_SERVICE_TYPE_RUNNER,
-			want:  store.ServiceTypeRunner,
-		},
-		{
 			name:  "llm proxy",
 			input: zitimanagementv1.ServiceType_SERVICE_TYPE_LLM_PROXY,
 			want:  store.ServiceTypeLLMProxy,

--- a/internal/server/server.go
+++ b/internal/server/server.go
@@ -161,7 +161,7 @@ func (s *Server) DeleteRunnerIdentity(ctx context.Context, req *zitimanagementv1
 		}
 	}
 
-	zitiServiceID := req.GetZitiServiceId()
+	zitiServiceID := *identity.ZitiServiceID
 	if err := s.ziti.DeleteService(ctx, zitiServiceID); err != nil {
 		if errors.Is(err, ziti.ErrServiceNotFound) {
 			log.Printf("ziti service %s already deleted", zitiServiceID)

--- a/internal/server/server.go
+++ b/internal/server/server.go
@@ -97,6 +97,82 @@ func (s *Server) CreateAppIdentity(ctx context.Context, req *zitimanagementv1.Cr
 	}, nil
 }
 
+func (s *Server) CreateRunnerIdentity(ctx context.Context, req *zitimanagementv1.CreateRunnerIdentityRequest) (*zitimanagementv1.CreateRunnerIdentityResponse, error) {
+	runnerID, err := parseUUID(req.GetRunnerId())
+	if err != nil {
+		return nil, status.Errorf(codes.InvalidArgument, "runner_id: %v", err)
+	}
+
+	roleAttributes := req.GetRoleAttributes()
+	if len(roleAttributes) == 0 {
+		return nil, status.Error(codes.InvalidArgument, "role_attributes is required")
+	}
+
+	zitiID, identityJSON, serviceName, serviceID, err := s.ziti.CreateAndEnrollRunnerIdentity(ctx, runnerID, roleAttributes)
+	if err != nil {
+		return nil, status.Errorf(codes.Internal, "create runner identity: %v", err)
+	}
+
+	identity := store.ManagedIdentity{
+		ZitiIdentityID: zitiID,
+		IdentityID:     runnerID,
+		IdentityType:   store.IdentityTypeRunner,
+		ZitiServiceID:  &serviceID,
+	}
+	if err := s.store.InsertManagedIdentity(ctx, identity); err != nil {
+		cleanupErr := s.ziti.CleanupAppResources(ctx, zitiID, serviceID, err)
+		if cleanupErr != err {
+			log.Printf("failed to cleanup runner resources for %s: %v", zitiID, cleanupErr)
+		}
+		return nil, status.Errorf(codes.Internal, "insert managed identity: %v", err)
+	}
+
+	return &zitimanagementv1.CreateRunnerIdentityResponse{
+		ZitiIdentityId:  zitiID,
+		IdentityJson:    identityJSON,
+		ZitiServiceId:   serviceID,
+		ZitiServiceName: serviceName,
+	}, nil
+}
+
+func (s *Server) DeleteRunnerIdentity(ctx context.Context, req *zitimanagementv1.DeleteRunnerIdentityRequest) (*zitimanagementv1.DeleteRunnerIdentityResponse, error) {
+	zitiID := req.GetZitiIdentityId()
+	if zitiID == "" {
+		return nil, status.Error(codes.InvalidArgument, "ziti_identity_id is required")
+	}
+
+	identity, err := s.store.ResolveIdentity(ctx, zitiID)
+	if err != nil {
+		return nil, toStatusError(err)
+	}
+	if identity.ZitiServiceID == nil {
+		return nil, status.Errorf(codes.Internal, "managed identity %s missing ziti service id", zitiID)
+	}
+
+	if err := s.store.DeleteManagedIdentity(ctx, zitiID); err != nil {
+		return nil, toStatusError(err)
+	}
+
+	if err := s.ziti.DeleteIdentity(ctx, zitiID); err != nil {
+		if errors.Is(err, ziti.ErrIdentityNotFound) {
+			log.Printf("ziti identity %s already deleted", zitiID)
+		} else {
+			return nil, status.Errorf(codes.Internal, "delete ziti identity: %v", err)
+		}
+	}
+
+	zitiServiceID := req.GetZitiServiceId()
+	if err := s.ziti.DeleteService(ctx, zitiServiceID); err != nil {
+		if errors.Is(err, ziti.ErrServiceNotFound) {
+			log.Printf("ziti service %s already deleted", zitiServiceID)
+		} else {
+			return nil, status.Errorf(codes.Internal, "delete ziti service: %v", err)
+		}
+	}
+
+	return &zitimanagementv1.DeleteRunnerIdentityResponse{}, nil
+}
+
 func (s *Server) DeleteIdentity(ctx context.Context, req *zitimanagementv1.DeleteIdentityRequest) (*zitimanagementv1.DeleteIdentityResponse, error) {
 	zitiID := req.GetZitiIdentityId()
 	if zitiID == "" {
@@ -295,8 +371,6 @@ func serviceIdentityConfig(serviceType store.ServiceType) (string, []string, err
 		return fmt.Sprintf("svc-gateway-%s", suffix), []string{"gateway-hosts"}, nil
 	case store.ServiceTypeOrchestrator:
 		return fmt.Sprintf("svc-orchestrator-%s", suffix), []string{"orchestrators"}, nil
-	case store.ServiceTypeRunner:
-		return fmt.Sprintf("svc-runner-%s", suffix), []string{"runners"}, nil
 	case store.ServiceTypeLLMProxy:
 		return fmt.Sprintf("svc-llm-proxy-%s", suffix), []string{"llm-proxy-hosts"}, nil
 	case store.ServiceTypeUnspecified:

--- a/internal/store/types.go
+++ b/internal/store/types.go
@@ -16,7 +16,6 @@ const (
 	IdentityTypeUnspecified IdentityType = 0
 	IdentityTypeAgent       IdentityType = 1
 	IdentityTypeRunner      IdentityType = 2
-	IdentityTypeChannel     IdentityType = 3
 	IdentityTypeApp         IdentityType = 5 // Matches agynio.api.identity.v1.IdentityType enum values.
 )
 
@@ -26,7 +25,6 @@ const (
 	ServiceTypeUnspecified  ServiceType = 0
 	ServiceTypeGateway      ServiceType = 1
 	ServiceTypeOrchestrator ServiceType = 2
-	ServiceTypeRunner       ServiceType = 3
 	ServiceTypeLLMProxy     ServiceType = 4
 )
 

--- a/internal/ziti/client.go
+++ b/internal/ziti/client.go
@@ -320,6 +320,52 @@ func (c *Client) CreateAndEnrollAppIdentity(ctx context.Context, appID uuid.UUID
 	return zitiID, identityJSON, serviceID, nil
 }
 
+func (c *Client) CreateAndEnrollRunnerIdentity(ctx context.Context, runnerID uuid.UUID, roleAttributes []string) (string, []byte, string, string, error) {
+	name := fmt.Sprintf("runner-%s-%s", runnerID.String(), id.ShortUUID())
+	identityType := rest_model.IdentityTypeDevice
+	isAdmin := false
+	roleAttrs := rest_model.Attributes(roleAttributes)
+	externalID := runnerID.String()
+	params := identity.NewCreateIdentityParamsWithContext(ctx)
+	params.Identity = &rest_model.IdentityCreate{
+		Name:           &name,
+		Type:           &identityType,
+		IsAdmin:        &isAdmin,
+		RoleAttributes: &roleAttrs,
+		ExternalID:     &externalID,
+		Enrollment:     &rest_model.IdentityCreateEnrollment{Ott: true},
+	}
+
+	var created *identity.CreateIdentityCreated
+	err := c.withReauth(func() error {
+		var callErr error
+		created, callErr = c.identity.CreateIdentity(params, nil)
+		return callErr
+	})
+	if err != nil {
+		return "", nil, "", "", fmt.Errorf("create ziti identity: %w", err)
+	}
+	if created.Payload == nil || created.Payload.Data == nil {
+		return "", nil, "", "", errors.New("create ziti identity response missing data")
+	}
+	zitiID := created.Payload.Data.ID
+	if zitiID == "" {
+		return "", nil, "", "", errors.New("create ziti identity response missing id")
+	}
+
+	serviceName := fmt.Sprintf("runner-%s", runnerID.String())
+	serviceID, err := c.CreateService(ctx, serviceName, []string{"runner-services"})
+	if err != nil {
+		return "", nil, "", "", c.CleanupAppResources(ctx, zitiID, "", err)
+	}
+
+	identityJSON, err := c.enrollIdentity(ctx, zitiID)
+	if err != nil {
+		return "", nil, "", "", c.CleanupAppResources(ctx, zitiID, serviceID, err)
+	}
+	return zitiID, identityJSON, serviceName, serviceID, nil
+}
+
 func (c *Client) enrollIdentity(ctx context.Context, zitiIdentityID string) ([]byte, error) {
 	jwt, err := c.fetchEnrollmentJWT(ctx, zitiIdentityID)
 	if err != nil {


### PR DESCRIPTION
## Summary
- update buf.lock and regenerate stubs
- add runner identity creation/deletion support in server and ziti client
- remove runner service self-enrollment and channel identity type mappings

## Testing
- go build ./...
- go test ./...
- go vet ./...

Closes #27