### PR TITLE
Add CreateService RPC and reenroll cleanup

### DIFF
--- a/buf.lock
+++ b/buf.lock
@@ -4,8 +4,8 @@ deps:
   - remote: buf.build
     owner: agynio
     repository: api
-    commit: 8352aa52d6d24a16a83fcaac76a44348
-    digest: shake256:f6f74b097b9349ff456e23e8763f9fc0f99bc8e45402eaeb573351544e717ac1f0ceeb8851c6a0f224af6ea33e665ecc9ecb85e2246219b45c3a4bde6d820857
+    commit: b67ca28ce2c94ca1a95f27e18051641b
+    digest: shake256:fc939b54bfabac248969211ca6f70d6c4efe48c6e971644470c1a1eb2e49719208d270ce7b7319bace0ac279a1a8b2e842b146204a3d2600ab974c807c727ea3
   - remote: buf.build
     owner: opentelemetry
     repository: opentelemetry

--- a/internal/server/converter.go
+++ b/internal/server/converter.go
@@ -43,6 +43,8 @@ func fromProtoServiceType(value zitimanagementv1.ServiceType) (store.ServiceType
 		return store.ServiceTypeGateway, nil
 	case zitimanagementv1.ServiceType_SERVICE_TYPE_ORCHESTRATOR:
 		return store.ServiceTypeOrchestrator, nil
+	case zitimanagementv1.ServiceType(store.ServiceTypeRunner):
+		return store.ServiceTypeRunner, nil
 	case zitimanagementv1.ServiceType_SERVICE_TYPE_LLM_PROXY:
 		return store.ServiceTypeLLMProxy, nil
 	case zitimanagementv1.ServiceType_SERVICE_TYPE_UNSPECIFIED:

--- a/internal/server/converter.go
+++ b/internal/server/converter.go
@@ -28,8 +28,6 @@ func fromProtoIdentityType(value identityv1.IdentityType) (store.IdentityType, e
 		return store.IdentityTypeAgent, nil
 	case identityv1.IdentityType_IDENTITY_TYPE_RUNNER:
 		return store.IdentityTypeRunner, nil
-	case identityv1.IdentityType_IDENTITY_TYPE_CHANNEL:
-		return store.IdentityTypeChannel, nil
 	case identityv1.IdentityType_IDENTITY_TYPE_APP:
 		return store.IdentityTypeApp, nil
 	case identityv1.IdentityType_IDENTITY_TYPE_UNSPECIFIED:
@@ -45,8 +43,6 @@ func fromProtoServiceType(value zitimanagementv1.ServiceType) (store.ServiceType
 		return store.ServiceTypeGateway, nil
 	case zitimanagementv1.ServiceType_SERVICE_TYPE_ORCHESTRATOR:
 		return store.ServiceTypeOrchestrator, nil
-	case zitimanagementv1.ServiceType_SERVICE_TYPE_RUNNER:
-		return store.ServiceTypeRunner, nil
 	case zitimanagementv1.ServiceType_SERVICE_TYPE_LLM_PROXY:
 		return store.ServiceTypeLLMProxy, nil
 	case zitimanagementv1.ServiceType_SERVICE_TYPE_UNSPECIFIED:
@@ -62,8 +58,6 @@ func toProtoIdentityType(value store.IdentityType) (identityv1.IdentityType, err
 		return identityv1.IdentityType_IDENTITY_TYPE_AGENT, nil
 	case store.IdentityTypeRunner:
 		return identityv1.IdentityType_IDENTITY_TYPE_RUNNER, nil
-	case store.IdentityTypeChannel:
-		return identityv1.IdentityType_IDENTITY_TYPE_CHANNEL, nil
 	case store.IdentityTypeApp:
 		return identityv1.IdentityType_IDENTITY_TYPE_APP, nil
 	case store.IdentityTypeUnspecified:

--- a/internal/server/converter.go
+++ b/internal/server/converter.go
@@ -28,6 +28,8 @@ func fromProtoIdentityType(value identityv1.IdentityType) (store.IdentityType, e
 		return store.IdentityTypeAgent, nil
 	case identityv1.IdentityType_IDENTITY_TYPE_RUNNER:
 		return store.IdentityTypeRunner, nil
+	case identityv1.IdentityType_IDENTITY_TYPE_CHANNEL:
+		return store.IdentityTypeChannel, nil
 	case identityv1.IdentityType_IDENTITY_TYPE_APP:
 		return store.IdentityTypeApp, nil
 	case identityv1.IdentityType_IDENTITY_TYPE_UNSPECIFIED:
@@ -58,6 +60,8 @@ func toProtoIdentityType(value store.IdentityType) (identityv1.IdentityType, err
 		return identityv1.IdentityType_IDENTITY_TYPE_AGENT, nil
 	case store.IdentityTypeRunner:
 		return identityv1.IdentityType_IDENTITY_TYPE_RUNNER, nil
+	case store.IdentityTypeChannel:
+		return identityv1.IdentityType_IDENTITY_TYPE_CHANNEL, nil
 	case store.IdentityTypeApp:
 		return identityv1.IdentityType_IDENTITY_TYPE_APP, nil
 	case store.IdentityTypeUnspecified:

--- a/internal/server/converter.go
+++ b/internal/server/converter.go
@@ -45,6 +45,8 @@ func fromProtoServiceType(value zitimanagementv1.ServiceType) (store.ServiceType
 		return store.ServiceTypeGateway, nil
 	case zitimanagementv1.ServiceType_SERVICE_TYPE_ORCHESTRATOR:
 		return store.ServiceTypeOrchestrator, nil
+	case zitimanagementv1.ServiceType_SERVICE_TYPE_RUNNER:
+		return store.ServiceTypeRunner, nil
 	case zitimanagementv1.ServiceType_SERVICE_TYPE_LLM_PROXY:
 		return store.ServiceTypeLLMProxy, nil
 	case zitimanagementv1.ServiceType_SERVICE_TYPE_UNSPECIFIED:

--- a/internal/server/converter_test.go
+++ b/internal/server/converter_test.go
@@ -27,6 +27,11 @@ func TestFromProtoServiceType(t *testing.T) {
 			want:  store.ServiceTypeOrchestrator,
 		},
 		{
+			name:  "runner",
+			input: zitimanagementv1.ServiceType(store.ServiceTypeRunner),
+			want:  store.ServiceTypeRunner,
+		},
+		{
 			name:  "llm proxy",
 			input: zitimanagementv1.ServiceType_SERVICE_TYPE_LLM_PROXY,
 			want:  store.ServiceTypeLLMProxy,

--- a/internal/server/converter_test.go
+++ b/internal/server/converter_test.go
@@ -27,11 +27,6 @@ func TestFromProtoServiceType(t *testing.T) {
 			want:  store.ServiceTypeOrchestrator,
 		},
 		{
-			name:  "runner",
-			input: zitimanagementv1.ServiceType_SERVICE_TYPE_RUNNER,
-			want:  store.ServiceTypeRunner,
-		},
-		{
 			name:  "llm proxy",
 			input: zitimanagementv1.ServiceType_SERVICE_TYPE_LLM_PROXY,
 			want:  store.ServiceTypeLLMProxy,

--- a/internal/server/converter_test.go
+++ b/internal/server/converter_test.go
@@ -27,6 +27,11 @@ func TestFromProtoServiceType(t *testing.T) {
 			want:  store.ServiceTypeOrchestrator,
 		},
 		{
+			name:  "runner",
+			input: zitimanagementv1.ServiceType_SERVICE_TYPE_RUNNER,
+			want:  store.ServiceTypeRunner,
+		},
+		{
 			name:  "llm proxy",
 			input: zitimanagementv1.ServiceType_SERVICE_TYPE_LLM_PROXY,
 			want:  store.ServiceTypeLLMProxy,

--- a/internal/server/server.go
+++ b/internal/server/server.go
@@ -70,7 +70,6 @@ func (s *Server) CreateAppIdentity(ctx context.Context, req *zitimanagementv1.Cr
 	if slug == "" {
 		return nil, status.Error(codes.InvalidArgument, "slug is required")
 	}
-
 	zitiID, identityJSON, err := s.createManagedIdentity(ctx, appID, store.IdentityTypeApp, func() (string, []byte, error) {
 		createdID, createdJSON, createErr := s.ziti.CreateAndEnrollAppIdentity(ctx, appID, slug)
 		if createErr != nil {

--- a/internal/server/server.go
+++ b/internal/server/server.go
@@ -369,9 +369,6 @@ func (s *Server) resolveManagedIdentity(ctx context.Context, zitiID string) (sto
 }
 
 func parseManagedIdentityID(value string) (uuid.UUID, bool) {
-	if identityID, err := uuid.Parse(value); err == nil {
-		return identityID, true
-	}
 	const agentPrefix = "agent-"
 	const uuidLength = 36
 	// Legacy lookup: agent identity names embed the platform UUID.

--- a/internal/server/server.go
+++ b/internal/server/server.go
@@ -369,6 +369,9 @@ func (s *Server) resolveManagedIdentity(ctx context.Context, zitiID string) (sto
 }
 
 func parseManagedIdentityID(value string) (uuid.UUID, bool) {
+	if identityID, err := uuid.Parse(value); err == nil {
+		return identityID, true
+	}
 	const agentPrefix = "agent-"
 	const uuidLength = 36
 	// Legacy lookup: agent identity names embed the platform UUID.

--- a/internal/server/server.go
+++ b/internal/server/server.go
@@ -71,29 +71,42 @@ func (s *Server) CreateAppIdentity(ctx context.Context, req *zitimanagementv1.Cr
 		return nil, status.Error(codes.InvalidArgument, "slug is required")
 	}
 
-	zitiID, identityJSON, serviceID, err := s.ziti.CreateAndEnrollAppIdentity(ctx, appID, slug)
-	if err != nil {
-		return nil, status.Errorf(codes.Internal, "create app identity: %v", err)
-	}
-
-	identity := store.ManagedIdentity{
-		ZitiIdentityID: zitiID,
-		IdentityID:     appID,
-		IdentityType:   store.IdentityTypeApp,
-		ZitiServiceID:  &serviceID,
-	}
-	if err := s.store.InsertManagedIdentity(ctx, identity); err != nil {
-		cleanupErr := s.ziti.CleanupAppResources(ctx, zitiID, serviceID, err)
-		if cleanupErr != err {
-			log.Printf("failed to cleanup app resources for %s: %v", zitiID, cleanupErr)
+	zitiID, identityJSON, err := s.createManagedIdentity(ctx, appID, store.IdentityTypeApp, func() (string, []byte, error) {
+		createdID, createdJSON, createErr := s.ziti.CreateAndEnrollAppIdentity(ctx, appID, slug)
+		if createErr != nil {
+			return "", nil, status.Errorf(codes.Internal, "create app identity: %v", createErr)
 		}
-		return nil, status.Errorf(codes.Internal, "insert managed identity: %v", err)
+		return createdID, createdJSON, nil
+	})
+	if err != nil {
+		return nil, err
 	}
 
 	return &zitimanagementv1.CreateAppIdentityResponse{
 		ZitiIdentityId: zitiID,
 		IdentityJson:   identityJSON,
-		ZitiServiceId:  serviceID,
+	}, nil
+}
+
+func (s *Server) CreateService(ctx context.Context, req *zitimanagementv1.CreateServiceRequest) (*zitimanagementv1.CreateServiceResponse, error) {
+	name := strings.TrimSpace(req.GetName())
+	if name == "" {
+		return nil, status.Error(codes.InvalidArgument, "name is required")
+	}
+
+	roleAttributes := req.GetRoleAttributes()
+	if len(roleAttributes) == 0 {
+		return nil, status.Error(codes.InvalidArgument, "role_attributes is required")
+	}
+
+	serviceID, err := s.ziti.CreateService(ctx, name, roleAttributes)
+	if err != nil {
+		return nil, status.Errorf(codes.Internal, "create ziti service: %v", err)
+	}
+
+	return &zitimanagementv1.CreateServiceResponse{
+		ZitiServiceId:   serviceID,
+		ZitiServiceName: name,
 	}, nil
 }
 
@@ -108,71 +121,73 @@ func (s *Server) CreateRunnerIdentity(ctx context.Context, req *zitimanagementv1
 		return nil, status.Error(codes.InvalidArgument, "role_attributes is required")
 	}
 
-	zitiID, identityJSON, serviceName, serviceID, err := s.ziti.CreateAndEnrollRunnerIdentity(ctx, runnerID, roleAttributes)
+	zitiID, identityJSON, err := s.createManagedIdentity(ctx, runnerID, store.IdentityTypeRunner, func() (string, []byte, error) {
+		createdID, createdJSON, createErr := s.ziti.CreateAndEnrollRunnerIdentity(ctx, runnerID, roleAttributes)
+		if createErr != nil {
+			return "", nil, status.Errorf(codes.Internal, "create runner identity: %v", createErr)
+		}
+		return createdID, createdJSON, nil
+	})
 	if err != nil {
-		return nil, status.Errorf(codes.Internal, "create runner identity: %v", err)
+		return nil, err
+	}
+
+	return &zitimanagementv1.CreateRunnerIdentityResponse{
+		ZitiIdentityId: zitiID,
+		IdentityJson:   identityJSON,
+	}, nil
+}
+
+func (s *Server) createManagedIdentity(
+	ctx context.Context,
+	identityID uuid.UUID,
+	identityType store.IdentityType,
+	createFn func() (string, []byte, error),
+) (string, []byte, error) {
+	serviceID, err := s.cleanupManagedIdentity(ctx, identityID)
+	if err != nil {
+		return "", nil, err
+	}
+
+	zitiID, identityJSON, err := createFn()
+	if err != nil {
+		return "", nil, err
 	}
 
 	identity := store.ManagedIdentity{
 		ZitiIdentityID: zitiID,
-		IdentityID:     runnerID,
-		IdentityType:   store.IdentityTypeRunner,
-		ZitiServiceID:  &serviceID,
+		IdentityID:     identityID,
+		IdentityType:   identityType,
+		ZitiServiceID:  serviceID,
 	}
 	if err := s.store.InsertManagedIdentity(ctx, identity); err != nil {
-		cleanupErr := s.ziti.CleanupAppResources(ctx, zitiID, serviceID, err)
-		if cleanupErr != err {
-			log.Printf("failed to cleanup runner resources for %s: %v", zitiID, cleanupErr)
+		cleanupErr := s.ziti.DeleteIdentity(ctx, zitiID)
+		if cleanupErr != nil && !errors.Is(cleanupErr, ziti.ErrIdentityNotFound) {
+			log.Printf("failed to cleanup ziti identity %s: %v", zitiID, cleanupErr)
 		}
-		return nil, status.Errorf(codes.Internal, "insert managed identity: %v", err)
+		return "", nil, status.Errorf(codes.Internal, "insert managed identity: %v", err)
 	}
 
-	return &zitimanagementv1.CreateRunnerIdentityResponse{
-		ZitiIdentityId:  zitiID,
-		IdentityJson:    identityJSON,
-		ZitiServiceId:   serviceID,
-		ZitiServiceName: serviceName,
-	}, nil
+	return zitiID, identityJSON, nil
 }
 
 func (s *Server) DeleteRunnerIdentity(ctx context.Context, req *zitimanagementv1.DeleteRunnerIdentityRequest) (*zitimanagementv1.DeleteRunnerIdentityResponse, error) {
-	zitiID := req.GetZitiIdentityId()
-	if zitiID == "" {
-		return nil, status.Error(codes.InvalidArgument, "ziti_identity_id is required")
-	}
-
-	identity, err := s.store.ResolveIdentity(ctx, zitiID)
+	identityID, err := parseUUID(req.GetIdentityId())
 	if err != nil {
-		return nil, toStatusError(err)
-	}
-	if identity.ZitiServiceID == nil {
-		return nil, status.Errorf(codes.Internal, "managed identity %s missing ziti service id", zitiID)
+		return nil, status.Errorf(codes.InvalidArgument, "identity_id: %v", err)
 	}
 
-	if err := s.store.DeleteManagedIdentity(ctx, zitiID); err != nil {
-		return nil, toStatusError(err)
+	zitiServiceID := strings.TrimSpace(req.GetZitiServiceId())
+	if zitiServiceID == "" {
+		return nil, status.Error(codes.InvalidArgument, "ziti_service_id is required")
 	}
 
-	if err := s.ziti.DeleteIdentity(ctx, zitiID); err != nil {
-		if errors.Is(err, ziti.ErrIdentityNotFound) {
-			log.Printf("ziti identity %s already deleted", zitiID)
-		} else {
-			return nil, status.Errorf(codes.Internal, "delete ziti identity: %v", err)
-		}
-	}
-
-	zitiServiceID := *identity.ZitiServiceID
-	if err := s.ziti.DeleteService(ctx, zitiServiceID); err != nil {
-		if errors.Is(err, ziti.ErrServiceNotFound) {
-			log.Printf("ziti service %s already deleted", zitiServiceID)
-		} else {
-			return nil, status.Errorf(codes.Internal, "delete ziti service: %v", err)
-		}
+	if err := s.deleteIdentityAndService(ctx, identityID, zitiServiceID); err != nil {
+		return nil, err
 	}
 
 	return &zitimanagementv1.DeleteRunnerIdentityResponse{}, nil
 }
-
 func (s *Server) DeleteIdentity(ctx context.Context, req *zitimanagementv1.DeleteIdentityRequest) (*zitimanagementv1.DeleteIdentityResponse, error) {
 	zitiID := req.GetZitiIdentityId()
 	if zitiID == "" {
@@ -192,39 +207,54 @@ func (s *Server) DeleteIdentity(ctx context.Context, req *zitimanagementv1.Delet
 }
 
 func (s *Server) DeleteAppIdentity(ctx context.Context, req *zitimanagementv1.DeleteAppIdentityRequest) (*zitimanagementv1.DeleteAppIdentityResponse, error) {
-	zitiID := req.GetZitiIdentityId()
-	if zitiID == "" {
-		return nil, status.Error(codes.InvalidArgument, "ziti_identity_id is required")
-	}
-	identity, err := s.store.ResolveIdentity(ctx, zitiID)
+	identityID, err := parseUUID(req.GetIdentityId())
 	if err != nil {
-		return nil, toStatusError(err)
-	}
-	if identity.ZitiServiceID == nil {
-		return nil, status.Errorf(codes.Internal, "managed identity %s missing ziti service id", zitiID)
+		return nil, status.Errorf(codes.InvalidArgument, "identity_id: %v", err)
 	}
 
-	if err := s.store.DeleteManagedIdentity(ctx, zitiID); err != nil {
-		return nil, toStatusError(err)
+	zitiServiceID := strings.TrimSpace(req.GetZitiServiceId())
+	if zitiServiceID == "" {
+		return nil, status.Error(codes.InvalidArgument, "ziti_service_id is required")
 	}
 
-	if err := s.ziti.DeleteIdentity(ctx, zitiID); err != nil {
-		if errors.Is(err, ziti.ErrIdentityNotFound) {
-			log.Printf("ziti identity %s already deleted", zitiID)
+	if err := s.deleteIdentityAndService(ctx, identityID, zitiServiceID); err != nil {
+		return nil, err
+	}
+
+	return &zitimanagementv1.DeleteAppIdentityResponse{}, nil
+}
+
+func (s *Server) deleteIdentityAndService(ctx context.Context, identityID uuid.UUID, zitiServiceID string) error {
+	identity, err := s.store.ResolveIdentityByIdentityID(ctx, identityID)
+	if err != nil {
+		if errors.Is(err, store.ErrManagedIdentityNotFound) {
+			log.Printf("managed identity for identity_id %s not found; skipping identity cleanup", identityID.String())
 		} else {
-			return nil, status.Errorf(codes.Internal, "delete ziti identity: %v", err)
+			return toStatusError(err)
+		}
+	} else {
+		if err := s.store.DeleteManagedIdentity(ctx, identity.ZitiIdentityID); err != nil {
+			return toStatusError(err)
+		}
+
+		if err := s.ziti.DeleteIdentity(ctx, identity.ZitiIdentityID); err != nil {
+			if errors.Is(err, ziti.ErrIdentityNotFound) {
+				log.Printf("ziti identity %s already deleted", identity.ZitiIdentityID)
+			} else {
+				return status.Errorf(codes.Internal, "delete ziti identity: %v", err)
+			}
 		}
 	}
-	zitiServiceID := *identity.ZitiServiceID
+
 	if err := s.ziti.DeleteService(ctx, zitiServiceID); err != nil {
 		if errors.Is(err, ziti.ErrServiceNotFound) {
 			log.Printf("ziti service %s already deleted", zitiServiceID)
 		} else {
-			return nil, status.Errorf(codes.Internal, "delete ziti service: %v", err)
+			return status.Errorf(codes.Internal, "delete ziti service: %v", err)
 		}
 	}
 
-	return &zitimanagementv1.DeleteAppIdentityResponse{}, nil
+	return nil
 }
 
 func (s *Server) RequestServiceIdentity(ctx context.Context, req *zitimanagementv1.RequestServiceIdentityRequest) (*zitimanagementv1.RequestServiceIdentityResponse, error) {
@@ -343,6 +373,8 @@ func (s *Server) resolveManagedIdentity(ctx context.Context, zitiID string) (sto
 func parseManagedIdentityID(value string) (uuid.UUID, bool) {
 	const agentPrefix = "agent-"
 	const uuidLength = 36
+	// Legacy lookup: agent identity names embed the platform UUID.
+	// Keep this heuristic until the API exposes an explicit identity_id.
 	if strings.HasPrefix(value, agentPrefix) && len(value) >= len(agentPrefix)+uuidLength {
 		candidate := value[len(agentPrefix) : len(agentPrefix)+uuidLength]
 		if identityID, err := uuid.Parse(candidate); err == nil {

--- a/internal/server/server.go
+++ b/internal/server/server.go
@@ -244,6 +244,7 @@ func (s *Server) deleteIdentityAndService(ctx context.Context, identityID uuid.U
 			}
 		}
 	}
+
 	if err := s.ziti.DeleteService(ctx, zitiServiceID); err != nil {
 		if errors.Is(err, ziti.ErrServiceNotFound) {
 			log.Printf("ziti service %s already deleted", zitiServiceID)

--- a/internal/server/server.go
+++ b/internal/server/server.go
@@ -244,7 +244,6 @@ func (s *Server) deleteIdentityAndService(ctx context.Context, identityID uuid.U
 			}
 		}
 	}
-
 	if err := s.ziti.DeleteService(ctx, zitiServiceID); err != nil {
 		if errors.Is(err, ziti.ErrServiceNotFound) {
 			log.Printf("ziti service %s already deleted", zitiServiceID)

--- a/internal/server/server.go
+++ b/internal/server/server.go
@@ -188,6 +188,7 @@ func (s *Server) DeleteRunnerIdentity(ctx context.Context, req *zitimanagementv1
 
 	return &zitimanagementv1.DeleteRunnerIdentityResponse{}, nil
 }
+
 func (s *Server) DeleteIdentity(ctx context.Context, req *zitimanagementv1.DeleteIdentityRequest) (*zitimanagementv1.DeleteIdentityResponse, error) {
 	zitiID := req.GetZitiIdentityId()
 	if zitiID == "" {
@@ -211,7 +212,6 @@ func (s *Server) DeleteAppIdentity(ctx context.Context, req *zitimanagementv1.De
 	if err != nil {
 		return nil, status.Errorf(codes.InvalidArgument, "identity_id: %v", err)
 	}
-
 	zitiServiceID := strings.TrimSpace(req.GetZitiServiceId())
 	if zitiServiceID == "" {
 		return nil, status.Error(codes.InvalidArgument, "ziti_service_id is required")
@@ -245,7 +245,6 @@ func (s *Server) deleteIdentityAndService(ctx context.Context, identityID uuid.U
 			}
 		}
 	}
-
 	if err := s.ziti.DeleteService(ctx, zitiServiceID); err != nil {
 		if errors.Is(err, ziti.ErrServiceNotFound) {
 			log.Printf("ziti service %s already deleted", zitiServiceID)

--- a/internal/server/server.go
+++ b/internal/server/server.go
@@ -369,6 +369,9 @@ func (s *Server) resolveManagedIdentity(ctx context.Context, zitiID string) (sto
 }
 
 func parseManagedIdentityID(value string) (uuid.UUID, bool) {
+	if identityID, err := uuid.Parse(value); err == nil {
+		return identityID, true
+	}
 	const agentPrefix = "agent-"
 	const uuidLength = 36
 	// Legacy lookup: agent identity names embed the platform UUID.
@@ -400,6 +403,8 @@ func serviceIdentityConfig(serviceType store.ServiceType) (string, []string, err
 		return fmt.Sprintf("svc-gateway-%s", suffix), []string{"gateway-hosts"}, nil
 	case store.ServiceTypeOrchestrator:
 		return fmt.Sprintf("svc-orchestrator-%s", suffix), []string{"orchestrators"}, nil
+	case store.ServiceTypeRunner:
+		return fmt.Sprintf("svc-runner-%s", suffix), []string{"runners"}, nil
 	case store.ServiceTypeLLMProxy:
 		return fmt.Sprintf("svc-llm-proxy-%s", suffix), []string{"llm-proxy-hosts"}, nil
 	case store.ServiceTypeUnspecified:

--- a/internal/server/server.go
+++ b/internal/server/server.go
@@ -361,6 +361,30 @@ func (s *Server) ResolveIdentity(ctx context.Context, req *zitimanagementv1.Reso
 	}, nil
 }
 
+func (s *Server) cleanupManagedIdentity(ctx context.Context, identityID uuid.UUID) (*string, error) {
+	identity, err := s.store.ResolveIdentityByIdentityID(ctx, identityID)
+	if err != nil {
+		if errors.Is(err, store.ErrManagedIdentityNotFound) {
+			return nil, nil
+		}
+		return nil, toStatusError(err)
+	}
+
+	if err := s.ziti.DeleteIdentity(ctx, identity.ZitiIdentityID); err != nil {
+		if errors.Is(err, ziti.ErrIdentityNotFound) {
+			log.Printf("ziti identity %s already deleted", identity.ZitiIdentityID)
+		} else {
+			return nil, status.Errorf(codes.Internal, "delete ziti identity: %v", err)
+		}
+	}
+
+	if err := s.store.DeleteManagedIdentity(ctx, identity.ZitiIdentityID); err != nil {
+		return nil, toStatusError(err)
+	}
+
+	return identity.ZitiServiceID, nil
+}
+
 func (s *Server) resolveManagedIdentity(ctx context.Context, zitiID string) (store.ManagedIdentity, error) {
 	if identityID, ok := parseManagedIdentityID(zitiID); ok {
 		return s.store.ResolveIdentityByIdentityID(ctx, identityID)

--- a/internal/server/server_test.go
+++ b/internal/server/server_test.go
@@ -82,8 +82,7 @@ func TestParseManagedIdentityID(t *testing.T) {
 		{
 			name:  "uuid",
 			value: identityID.String(),
-			want:  identityID,
-			ok:    true,
+			ok:    false,
 		},
 		{
 			name:  "agent prefix with suffix",

--- a/internal/server/server_test.go
+++ b/internal/server/server_test.go
@@ -82,7 +82,8 @@ func TestParseManagedIdentityID(t *testing.T) {
 		{
 			name:  "uuid",
 			value: identityID.String(),
-			ok:    false,
+			want:  identityID,
+			ok:    true,
 		},
 		{
 			name:  "agent prefix with suffix",

--- a/internal/server/server_test.go
+++ b/internal/server/server_test.go
@@ -82,17 +82,18 @@ func TestParseManagedIdentityID(t *testing.T) {
 		{
 			name:  "uuid",
 			value: identityID.String(),
-			ok:    false,
-		},
-		{
-			name:  "agent prefix",
-			value: "agent-" + identityID.String(),
 			want:  identityID,
 			ok:    true,
 		},
 		{
 			name:  "agent prefix with suffix",
 			value: "agent-" + identityID.String() + "-abcd1234",
+			want:  identityID,
+			ok:    true,
+		},
+		{
+			name:  "agent prefix",
+			value: "agent-" + identityID.String(),
 			want:  identityID,
 			ok:    true,
 		},

--- a/internal/store/types.go
+++ b/internal/store/types.go
@@ -16,6 +16,7 @@ const (
 	IdentityTypeUnspecified IdentityType = 0
 	IdentityTypeAgent       IdentityType = 1
 	IdentityTypeRunner      IdentityType = 2
+	IdentityTypeChannel     IdentityType = 3
 	IdentityTypeApp         IdentityType = 5 // Matches agynio.api.identity.v1.IdentityType enum values.
 )
 

--- a/internal/store/types.go
+++ b/internal/store/types.go
@@ -25,6 +25,7 @@ const (
 	ServiceTypeUnspecified  ServiceType = 0
 	ServiceTypeGateway      ServiceType = 1
 	ServiceTypeOrchestrator ServiceType = 2
+	ServiceTypeRunner       ServiceType = 3
 	ServiceTypeLLMProxy     ServiceType = 4
 )
 

--- a/internal/store/types.go
+++ b/internal/store/types.go
@@ -26,6 +26,7 @@ const (
 	ServiceTypeUnspecified  ServiceType = 0
 	ServiceTypeGateway      ServiceType = 1
 	ServiceTypeOrchestrator ServiceType = 2
+	ServiceTypeRunner       ServiceType = 3
 	ServiceTypeLLMProxy     ServiceType = 4
 )
 

--- a/internal/store/types.go
+++ b/internal/store/types.go
@@ -16,7 +16,6 @@ const (
 	IdentityTypeUnspecified IdentityType = 0
 	IdentityTypeAgent       IdentityType = 1
 	IdentityTypeRunner      IdentityType = 2
-	IdentityTypeChannel     IdentityType = 3
 	IdentityTypeApp         IdentityType = 5 // Matches agynio.api.identity.v1.IdentityType enum values.
 )
 
@@ -26,7 +25,6 @@ const (
 	ServiceTypeUnspecified  ServiceType = 0
 	ServiceTypeGateway      ServiceType = 1
 	ServiceTypeOrchestrator ServiceType = 2
-	ServiceTypeRunner       ServiceType = 3
 	ServiceTypeLLMProxy     ServiceType = 4
 )
 

--- a/internal/ziti/client.go
+++ b/internal/ziti/client.go
@@ -347,52 +347,6 @@ func (c *Client) CreateAndEnrollRunnerIdentity(ctx context.Context, runnerID uui
 	return c.createAndEnrollIdentity(ctx, params)
 }
 
-func (c *Client) CreateAndEnrollRunnerIdentity(ctx context.Context, runnerID uuid.UUID, roleAttributes []string) (string, []byte, string, string, error) {
-	name := fmt.Sprintf("runner-%s-%s", runnerID.String(), id.ShortUUID())
-	identityType := rest_model.IdentityTypeDevice
-	isAdmin := false
-	roleAttrs := rest_model.Attributes(roleAttributes)
-	externalID := runnerID.String()
-	params := identity.NewCreateIdentityParamsWithContext(ctx)
-	params.Identity = &rest_model.IdentityCreate{
-		Name:           &name,
-		Type:           &identityType,
-		IsAdmin:        &isAdmin,
-		RoleAttributes: &roleAttrs,
-		ExternalID:     &externalID,
-		Enrollment:     &rest_model.IdentityCreateEnrollment{Ott: true},
-	}
-
-	var created *identity.CreateIdentityCreated
-	err := c.withReauth(func() error {
-		var callErr error
-		created, callErr = c.identity.CreateIdentity(params, nil)
-		return callErr
-	})
-	if err != nil {
-		return "", nil, "", "", fmt.Errorf("create ziti identity: %w", err)
-	}
-	if created.Payload == nil || created.Payload.Data == nil {
-		return "", nil, "", "", errors.New("create ziti identity response missing data")
-	}
-	zitiID := created.Payload.Data.ID
-	if zitiID == "" {
-		return "", nil, "", "", errors.New("create ziti identity response missing id")
-	}
-
-	serviceName := fmt.Sprintf("runner-%s", runnerID.String())
-	serviceID, err := c.CreateService(ctx, serviceName, []string{"runner-services"})
-	if err != nil {
-		return "", nil, "", "", c.CleanupAppResources(ctx, zitiID, "", err)
-	}
-
-	identityJSON, err := c.enrollIdentity(ctx, zitiID)
-	if err != nil {
-		return "", nil, "", "", c.CleanupAppResources(ctx, zitiID, serviceID, err)
-	}
-	return zitiID, identityJSON, serviceName, serviceID, nil
-}
-
 func (c *Client) enrollIdentity(ctx context.Context, zitiIdentityID string) ([]byte, error) {
 	jwt, err := c.fetchEnrollmentJWT(ctx, zitiIdentityID)
 	if err != nil {

--- a/internal/ziti/client.go
+++ b/internal/ziti/client.go
@@ -343,7 +343,6 @@ func (c *Client) CreateAndEnrollRunnerIdentity(ctx context.Context, runnerID uui
 		ExternalID:     &externalID,
 		Enrollment:     &rest_model.IdentityCreateEnrollment{Ott: true},
 	}
-
 	return c.createAndEnrollIdentity(ctx, params)
 }
 
@@ -406,7 +405,6 @@ func (c *Client) cleanupServiceIdentity(ctx context.Context, zitiIdentityID stri
 	}
 	return fmt.Errorf("%w; cleanup failed: %w", err, cleanupErr)
 }
-
 func (c *Client) DeleteIdentity(ctx context.Context, zitiIdentityID string) error {
 	params := identity.NewDeleteIdentityParamsWithContext(ctx)
 	params.ID = zitiIdentityID

--- a/internal/ziti/client.go
+++ b/internal/ziti/client.go
@@ -37,13 +37,14 @@ type serviceService interface {
 }
 
 type Client struct {
-	mu            sync.Mutex
-	identity      identityService
-	service       serviceService
-	controllerURL string
-	certFile      string
-	keyFile       string
-	caFile        string
+	mu               sync.Mutex
+	identity         identityService
+	service          serviceService
+	controllerURL    string
+	certFile         string
+	keyFile          string
+	caFile           string
+	reauthenticateFn func() error
 }
 
 func NewClient(controllerURL, certFile, keyFile, caFile string) (*Client, error) {
@@ -127,6 +128,7 @@ func (c *Client) serviceClient() serviceService {
 func (c *Client) reauthenticate() error {
 	c.mu.Lock()
 	defer c.mu.Unlock()
+
 	clientCert, privateKey, err := loadClientCredentials(c.certFile, c.keyFile)
 	if err != nil {
 		return err
@@ -149,7 +151,15 @@ func (c *Client) withReauth(operation func() error) error {
 	if err == nil || !isUnauthorized(err) {
 		return err
 	}
-	if reauthErr := c.reauthenticate(); reauthErr != nil {
+	reauthFn := c.reauthenticate
+	if c.reauthenticateFn != nil {
+		reauthFn = func() error {
+			c.mu.Lock()
+			defer c.mu.Unlock()
+			return c.reauthenticateFn()
+		}
+	}
+	if reauthErr := reauthFn(); reauthErr != nil {
 		return fmt.Errorf("reauthenticate ziti client: %w", reauthErr)
 	}
 	return operation()
@@ -270,6 +280,10 @@ func (c *Client) CreateAndEnrollServiceIdentity(ctx context.Context, name string
 		Enrollment:     &rest_model.IdentityCreateEnrollment{Ott: true},
 	}
 
+	return c.createAndEnrollIdentity(ctx, params)
+}
+
+func (c *Client) createAndEnrollIdentity(ctx context.Context, params *identity.CreateIdentityParams) (string, []byte, error) {
 	var created *identity.CreateIdentityCreated
 	err := c.withReauth(func() error {
 		var callErr error
@@ -295,7 +309,7 @@ func (c *Client) CreateAndEnrollServiceIdentity(ctx context.Context, name string
 	return zitiID, identityJSON, nil
 }
 
-func (c *Client) CreateAndEnrollAppIdentity(ctx context.Context, appID uuid.UUID, slug string) (string, []byte, string, error) {
+func (c *Client) CreateAndEnrollAppIdentity(ctx context.Context, appID uuid.UUID, slug string) (string, []byte, error) {
 	name := fmt.Sprintf("app-%s-%s", slug, id.ShortUUID())
 	identityType := rest_model.IdentityTypeDevice
 	isAdmin := false
@@ -311,37 +325,10 @@ func (c *Client) CreateAndEnrollAppIdentity(ctx context.Context, appID uuid.UUID
 		Enrollment:     &rest_model.IdentityCreateEnrollment{Ott: true},
 	}
 
-	var created *identity.CreateIdentityCreated
-	err := c.withReauth(func() error {
-		var callErr error
-		identityClient := c.identityClient()
-		created, callErr = identityClient.CreateIdentity(params, nil)
-		return callErr
-	})
-	if err != nil {
-		return "", nil, "", fmt.Errorf("create ziti identity: %w", err)
-	}
-	if created.Payload == nil || created.Payload.Data == nil {
-		return "", nil, "", errors.New("create ziti identity response missing data")
-	}
-	zitiID := created.Payload.Data.ID
-	if zitiID == "" {
-		return "", nil, "", errors.New("create ziti identity response missing id")
-	}
-
-	serviceID, err := c.CreateService(ctx, name, []string{"app-services"})
-	if err != nil {
-		return "", nil, "", c.CleanupAppResources(ctx, zitiID, "", err)
-	}
-
-	identityJSON, err := c.enrollIdentity(ctx, zitiID)
-	if err != nil {
-		return "", nil, "", c.CleanupAppResources(ctx, zitiID, serviceID, err)
-	}
-	return zitiID, identityJSON, serviceID, nil
+	return c.createAndEnrollIdentity(ctx, params)
 }
 
-func (c *Client) CreateAndEnrollRunnerIdentity(ctx context.Context, runnerID uuid.UUID, roleAttributes []string) (string, []byte, string, string, error) {
+func (c *Client) CreateAndEnrollRunnerIdentity(ctx context.Context, runnerID uuid.UUID, roleAttributes []string) (string, []byte, error) {
 	name := fmt.Sprintf("runner-%s-%s", runnerID.String(), id.ShortUUID())
 	identityType := rest_model.IdentityTypeDevice
 	isAdmin := false
@@ -357,35 +344,7 @@ func (c *Client) CreateAndEnrollRunnerIdentity(ctx context.Context, runnerID uui
 		Enrollment:     &rest_model.IdentityCreateEnrollment{Ott: true},
 	}
 
-	var created *identity.CreateIdentityCreated
-	err := c.withReauth(func() error {
-		var callErr error
-		identityClient := c.identityClient()
-		created, callErr = identityClient.CreateIdentity(params, nil)
-		return callErr
-	})
-	if err != nil {
-		return "", nil, "", "", fmt.Errorf("create ziti identity: %w", err)
-	}
-	if created.Payload == nil || created.Payload.Data == nil {
-		return "", nil, "", "", errors.New("create ziti identity response missing data")
-	}
-	zitiID := created.Payload.Data.ID
-	if zitiID == "" {
-		return "", nil, "", "", errors.New("create ziti identity response missing id")
-	}
-
-	serviceName := fmt.Sprintf("runner-%s", runnerID.String())
-	serviceID, err := c.CreateService(ctx, serviceName, []string{"runner-services"})
-	if err != nil {
-		return "", nil, "", "", c.CleanupAppResources(ctx, zitiID, "", err)
-	}
-
-	identityJSON, err := c.enrollIdentity(ctx, zitiID)
-	if err != nil {
-		return "", nil, "", "", c.CleanupAppResources(ctx, zitiID, serviceID, err)
-	}
-	return zitiID, identityJSON, serviceName, serviceID, nil
+	return c.createAndEnrollIdentity(ctx, params)
 }
 
 func (c *Client) enrollIdentity(ctx context.Context, zitiIdentityID string) ([]byte, error) {
@@ -394,7 +353,10 @@ func (c *Client) enrollIdentity(ctx context.Context, zitiIdentityID string) ([]b
 		return nil, err
 	}
 
-	claims, _, err := enroll.ParseToken(jwt)
+	parseToken := parseEnrollmentToken
+	enrollFn := enrollIdentity
+
+	claims, _, err := parseToken(jwt)
 	if err != nil {
 		return nil, fmt.Errorf("parse enrollment token: %w", err)
 	}
@@ -403,7 +365,7 @@ func (c *Client) enrollIdentity(ctx context.Context, zitiIdentityID string) ([]b
 	if err := keyAlg.Set("EC"); err != nil {
 		return nil, fmt.Errorf("set key algorithm: %w", err)
 	}
-	config, err := enroll.Enroll(enroll.EnrollmentFlags{Token: claims, KeyAlg: keyAlg})
+	config, err := enrollFn(enroll.EnrollmentFlags{Token: claims, KeyAlg: keyAlg})
 	if err != nil {
 		return nil, fmt.Errorf("enroll identity: %w", err)
 	}
@@ -443,21 +405,6 @@ func (c *Client) cleanupServiceIdentity(ctx context.Context, zitiIdentityID stri
 		return err
 	}
 	return fmt.Errorf("%w; cleanup failed: %w", err, cleanupErr)
-}
-
-func (c *Client) CleanupAppResources(ctx context.Context, zitiIdentityID, zitiServiceID string, err error) error {
-	identityErr := c.DeleteIdentity(ctx, zitiIdentityID)
-	if identityErr != nil && !errors.Is(identityErr, ErrIdentityNotFound) {
-		err = fmt.Errorf("%w; cleanup identity failed: %w", err, identityErr)
-	}
-	if zitiServiceID == "" {
-		return err
-	}
-	serviceErr := c.DeleteService(ctx, zitiServiceID)
-	if serviceErr != nil && !errors.Is(serviceErr, ErrServiceNotFound) {
-		err = fmt.Errorf("%w; cleanup service failed: %w", err, serviceErr)
-	}
-	return err
 }
 
 func (c *Client) DeleteIdentity(ctx context.Context, zitiIdentityID string) error {

--- a/internal/ziti/client.go
+++ b/internal/ziti/client.go
@@ -347,6 +347,52 @@ func (c *Client) CreateAndEnrollRunnerIdentity(ctx context.Context, runnerID uui
 	return c.createAndEnrollIdentity(ctx, params)
 }
 
+func (c *Client) CreateAndEnrollRunnerIdentity(ctx context.Context, runnerID uuid.UUID, roleAttributes []string) (string, []byte, string, string, error) {
+	name := fmt.Sprintf("runner-%s-%s", runnerID.String(), id.ShortUUID())
+	identityType := rest_model.IdentityTypeDevice
+	isAdmin := false
+	roleAttrs := rest_model.Attributes(roleAttributes)
+	externalID := runnerID.String()
+	params := identity.NewCreateIdentityParamsWithContext(ctx)
+	params.Identity = &rest_model.IdentityCreate{
+		Name:           &name,
+		Type:           &identityType,
+		IsAdmin:        &isAdmin,
+		RoleAttributes: &roleAttrs,
+		ExternalID:     &externalID,
+		Enrollment:     &rest_model.IdentityCreateEnrollment{Ott: true},
+	}
+
+	var created *identity.CreateIdentityCreated
+	err := c.withReauth(func() error {
+		var callErr error
+		created, callErr = c.identity.CreateIdentity(params, nil)
+		return callErr
+	})
+	if err != nil {
+		return "", nil, "", "", fmt.Errorf("create ziti identity: %w", err)
+	}
+	if created.Payload == nil || created.Payload.Data == nil {
+		return "", nil, "", "", errors.New("create ziti identity response missing data")
+	}
+	zitiID := created.Payload.Data.ID
+	if zitiID == "" {
+		return "", nil, "", "", errors.New("create ziti identity response missing id")
+	}
+
+	serviceName := fmt.Sprintf("runner-%s", runnerID.String())
+	serviceID, err := c.CreateService(ctx, serviceName, []string{"runner-services"})
+	if err != nil {
+		return "", nil, "", "", c.CleanupAppResources(ctx, zitiID, "", err)
+	}
+
+	identityJSON, err := c.enrollIdentity(ctx, zitiID)
+	if err != nil {
+		return "", nil, "", "", c.CleanupAppResources(ctx, zitiID, serviceID, err)
+	}
+	return zitiID, identityJSON, serviceName, serviceID, nil
+}
+
 func (c *Client) enrollIdentity(ctx context.Context, zitiIdentityID string) ([]byte, error) {
 	jwt, err := c.fetchEnrollmentJWT(ctx, zitiIdentityID)
 	if err != nil {

--- a/internal/ziti/client.go
+++ b/internal/ziti/client.go
@@ -343,6 +343,7 @@ func (c *Client) CreateAndEnrollRunnerIdentity(ctx context.Context, runnerID uui
 		ExternalID:     &externalID,
 		Enrollment:     &rest_model.IdentityCreateEnrollment{Ott: true},
 	}
+
 	return c.createAndEnrollIdentity(ctx, params)
 }
 
@@ -405,6 +406,7 @@ func (c *Client) cleanupServiceIdentity(ctx context.Context, zitiIdentityID stri
 	}
 	return fmt.Errorf("%w; cleanup failed: %w", err, cleanupErr)
 }
+
 func (c *Client) DeleteIdentity(ctx context.Context, zitiIdentityID string) error {
 	params := identity.NewDeleteIdentityParamsWithContext(ctx)
 	params.ID = zitiIdentityID

--- a/internal/ziti/client_test.go
+++ b/internal/ziti/client_test.go
@@ -3,12 +3,18 @@ package ziti
 import (
 	"context"
 	"errors"
+	"reflect"
+	"strings"
 	"testing"
 
 	"github.com/go-openapi/runtime"
+	"github.com/golang-jwt/jwt/v5"
 	"github.com/google/uuid"
 	"github.com/openziti/edge-api/rest_management_api_client/identity"
+	"github.com/openziti/edge-api/rest_management_api_client/service"
 	"github.com/openziti/edge-api/rest_model"
+	sdkziti "github.com/openziti/sdk-golang/ziti"
+	"github.com/openziti/sdk-golang/ziti/enroll"
 )
 
 type fakeIdentityService struct {
@@ -36,6 +42,25 @@ func (f *fakeIdentityService) DetailIdentity(params *identity.DetailIdentityPara
 		return nil, errors.New("detail identity not stubbed")
 	}
 	return f.detailIdentityFunc(params)
+}
+
+type fakeServiceService struct {
+	createServiceFunc func(params *service.CreateServiceParams) (*service.CreateServiceCreated, error)
+	deleteServiceFunc func(params *service.DeleteServiceParams) (*service.DeleteServiceOK, error)
+}
+
+func (f *fakeServiceService) CreateService(params *service.CreateServiceParams, _ runtime.ClientAuthInfoWriter, _ ...service.ClientOption) (*service.CreateServiceCreated, error) {
+	if f.createServiceFunc == nil {
+		return nil, errors.New("create service not stubbed")
+	}
+	return f.createServiceFunc(params)
+}
+
+func (f *fakeServiceService) DeleteService(params *service.DeleteServiceParams, _ runtime.ClientAuthInfoWriter, _ ...service.ClientOption) (*service.DeleteServiceOK, error) {
+	if f.deleteServiceFunc == nil {
+		return nil, errors.New("delete service not stubbed")
+	}
+	return f.deleteServiceFunc(params)
 }
 
 func TestCreateAgentIdentityCreatesIdentity(t *testing.T) {
@@ -104,6 +129,331 @@ func TestCreateAgentIdentityCreateFailure(t *testing.T) {
 	}
 }
 
+func TestCreateAndEnrollRunnerIdentity(t *testing.T) {
+	ctx := context.Background()
+	runnerID := uuid.New()
+	createdID := "runner-created-id"
+	jwtToken := "jwt-token"
+	roleAttributes := []string{"runner-services", "extra"}
+	enrollCalled := false
+
+	stubClientEnrollment(t, func(token string) (*sdkziti.EnrollmentClaims, *jwt.Token, error) {
+		if token != jwtToken {
+			t.Fatalf("expected jwt %q, got %q", jwtToken, token)
+		}
+		return &sdkziti.EnrollmentClaims{}, nil, nil
+	}, func(flags enroll.EnrollmentFlags) (*sdkziti.Config, error) {
+		enrollCalled = true
+		if flags.Token == nil {
+			t.Fatalf("expected enrollment claims")
+		}
+		if !flags.KeyAlg.EC() {
+			t.Fatalf("expected EC key algorithm")
+		}
+		return &sdkziti.Config{}, nil
+	})
+
+	fake := &fakeIdentityService{
+		deleteIdentityFunc: func(params *identity.DeleteIdentityParams) (*identity.DeleteIdentityOK, error) {
+			t.Fatalf("delete identity should not be called: %#v", params)
+			return nil, nil
+		},
+		createIdentityFunc: func(params *identity.CreateIdentityParams) (*identity.CreateIdentityCreated, error) {
+			assertCreateIdentityParams(t, params, runnerID, roleAttributes, "runner-"+runnerID.String()+"-")
+			return createIdentityResponse(createdID), nil
+		},
+		detailIdentityFunc: func(params *identity.DetailIdentityParams) (*identity.DetailIdentityOK, error) {
+			if params == nil || params.ID != createdID {
+				t.Fatalf("expected detail identity id %q, got %#v", createdID, params)
+			}
+			return detailIdentityResponse(jwtToken), nil
+		},
+	}
+
+	client := &Client{identity: fake}
+	zitiID, identityJSON, err := client.CreateAndEnrollRunnerIdentity(ctx, runnerID, roleAttributes)
+	if err != nil {
+		t.Fatalf("create runner identity: %v", err)
+	}
+	if zitiID != createdID {
+		t.Fatalf("expected identity id %q, got %q", createdID, zitiID)
+	}
+	if len(identityJSON) == 0 {
+		t.Fatalf("expected identity json")
+	}
+	if !enrollCalled {
+		t.Fatalf("expected enroll called")
+	}
+}
+
+func TestCreateAndEnrollRunnerIdentityEnrollFailureCleansUp(t *testing.T) {
+	ctx := context.Background()
+	runnerID := uuid.New()
+	createdID := "runner-created-id"
+	jwtToken := "jwt-token"
+	roleAttributes := []string{"runner-services"}
+	parseErr := errors.New("parse failed")
+	deleteCalled := false
+
+	stubClientEnrollment(t, func(token string) (*sdkziti.EnrollmentClaims, *jwt.Token, error) {
+		if token != jwtToken {
+			t.Fatalf("expected jwt %q, got %q", jwtToken, token)
+		}
+		return nil, nil, parseErr
+	}, func(flags enroll.EnrollmentFlags) (*sdkziti.Config, error) {
+		t.Fatalf("enroll should not be called")
+		return nil, nil
+	})
+
+	fake := &fakeIdentityService{
+		deleteIdentityFunc: func(params *identity.DeleteIdentityParams) (*identity.DeleteIdentityOK, error) {
+			deleteCalled = true
+			if params == nil || params.ID != createdID {
+				t.Fatalf("expected delete identity id %q, got %#v", createdID, params)
+			}
+			return &identity.DeleteIdentityOK{}, nil
+		},
+		createIdentityFunc: func(params *identity.CreateIdentityParams) (*identity.CreateIdentityCreated, error) {
+			assertCreateIdentityParams(t, params, runnerID, roleAttributes, "runner-"+runnerID.String()+"-")
+			return createIdentityResponse(createdID), nil
+		},
+		detailIdentityFunc: func(params *identity.DetailIdentityParams) (*identity.DetailIdentityOK, error) {
+			return detailIdentityResponse(jwtToken), nil
+		},
+	}
+
+	client := &Client{identity: fake}
+	_, _, err := client.CreateAndEnrollRunnerIdentity(ctx, runnerID, roleAttributes)
+	if err == nil {
+		t.Fatalf("expected error")
+	}
+	if !strings.Contains(err.Error(), "parse enrollment token") {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	if !deleteCalled {
+		t.Fatalf("expected cleanup delete")
+	}
+}
+
+func TestCreateAndEnrollAppIdentity(t *testing.T) {
+	ctx := context.Background()
+	appID := uuid.New()
+	createdID := "app-created-id"
+	slug := "example"
+	jwtToken := "jwt-token"
+	enrollCalled := false
+
+	stubClientEnrollment(t, func(token string) (*sdkziti.EnrollmentClaims, *jwt.Token, error) {
+		if token != jwtToken {
+			t.Fatalf("expected jwt %q, got %q", jwtToken, token)
+		}
+		return &sdkziti.EnrollmentClaims{}, nil, nil
+	}, func(flags enroll.EnrollmentFlags) (*sdkziti.Config, error) {
+		enrollCalled = true
+		if flags.Token == nil {
+			t.Fatalf("expected enrollment claims")
+		}
+		if !flags.KeyAlg.EC() {
+			t.Fatalf("expected EC key algorithm")
+		}
+		return &sdkziti.Config{}, nil
+	})
+
+	fake := &fakeIdentityService{
+		deleteIdentityFunc: func(params *identity.DeleteIdentityParams) (*identity.DeleteIdentityOK, error) {
+			t.Fatalf("delete identity should not be called: %#v", params)
+			return nil, nil
+		},
+		createIdentityFunc: func(params *identity.CreateIdentityParams) (*identity.CreateIdentityCreated, error) {
+			assertCreateIdentityParams(t, params, appID, []string{"apps"}, "app-"+slug+"-")
+			return createIdentityResponse(createdID), nil
+		},
+		detailIdentityFunc: func(params *identity.DetailIdentityParams) (*identity.DetailIdentityOK, error) {
+			if params == nil || params.ID != createdID {
+				t.Fatalf("expected detail identity id %q, got %#v", createdID, params)
+			}
+			return detailIdentityResponse(jwtToken), nil
+		},
+	}
+
+	client := &Client{identity: fake}
+	zitiID, identityJSON, err := client.CreateAndEnrollAppIdentity(ctx, appID, slug)
+	if err != nil {
+		t.Fatalf("create app identity: %v", err)
+	}
+	if zitiID != createdID {
+		t.Fatalf("expected identity id %q, got %q", createdID, zitiID)
+	}
+	if len(identityJSON) == 0 {
+		t.Fatalf("expected identity json")
+	}
+	if !enrollCalled {
+		t.Fatalf("expected enroll called")
+	}
+}
+
+func TestCreateAndEnrollAppIdentityEnrollFailureCleansUp(t *testing.T) {
+	ctx := context.Background()
+	appID := uuid.New()
+	createdID := "app-created-id"
+	slug := "example"
+	jwtToken := "jwt-token"
+	parseErr := errors.New("parse failed")
+	deleteCalled := false
+
+	stubClientEnrollment(t, func(token string) (*sdkziti.EnrollmentClaims, *jwt.Token, error) {
+		if token != jwtToken {
+			t.Fatalf("expected jwt %q, got %q", jwtToken, token)
+		}
+		return nil, nil, parseErr
+	}, func(flags enroll.EnrollmentFlags) (*sdkziti.Config, error) {
+		t.Fatalf("enroll should not be called")
+		return nil, nil
+	})
+
+	fake := &fakeIdentityService{
+		deleteIdentityFunc: func(params *identity.DeleteIdentityParams) (*identity.DeleteIdentityOK, error) {
+			deleteCalled = true
+			if params == nil || params.ID != createdID {
+				t.Fatalf("expected delete identity id %q, got %#v", createdID, params)
+			}
+			return &identity.DeleteIdentityOK{}, nil
+		},
+		createIdentityFunc: func(params *identity.CreateIdentityParams) (*identity.CreateIdentityCreated, error) {
+			assertCreateIdentityParams(t, params, appID, []string{"apps"}, "app-"+slug+"-")
+			return createIdentityResponse(createdID), nil
+		},
+		detailIdentityFunc: func(params *identity.DetailIdentityParams) (*identity.DetailIdentityOK, error) {
+			return detailIdentityResponse(jwtToken), nil
+		},
+	}
+
+	client := &Client{identity: fake}
+	_, _, err := client.CreateAndEnrollAppIdentity(ctx, appID, slug)
+	if err == nil {
+		t.Fatalf("expected error")
+	}
+	if !strings.Contains(err.Error(), "parse enrollment token") {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	if !deleteCalled {
+		t.Fatalf("expected cleanup delete")
+	}
+}
+
+func TestCreateService(t *testing.T) {
+	ctx := context.Background()
+	serviceID := "service-id"
+	name := "runner-abc"
+	roles := []string{"runner-services"}
+
+	fake := &fakeServiceService{
+		createServiceFunc: func(params *service.CreateServiceParams) (*service.CreateServiceCreated, error) {
+			if params == nil || params.Service == nil || params.Service.Name == nil {
+				t.Fatalf("expected service name")
+			}
+			if *params.Service.Name != name {
+				t.Fatalf("expected name %q, got %q", name, *params.Service.Name)
+			}
+			if !reflect.DeepEqual(params.Service.RoleAttributes, roles) {
+				t.Fatalf("expected roles %v, got %v", roles, params.Service.RoleAttributes)
+			}
+			if params.Service.EncryptionRequired == nil || !*params.Service.EncryptionRequired {
+				t.Fatalf("expected encryption required")
+			}
+			return createServiceResponse(serviceID), nil
+		},
+	}
+
+	client := &Client{service: fake}
+	createdID, err := client.CreateService(ctx, name, roles)
+	if err != nil {
+		t.Fatalf("create service: %v", err)
+	}
+	if createdID != serviceID {
+		t.Fatalf("expected service id %q, got %q", serviceID, createdID)
+	}
+}
+
+func TestDeleteService(t *testing.T) {
+	ctx := context.Background()
+	serviceID := "service-id"
+	deleteCalled := false
+
+	fake := &fakeServiceService{
+		deleteServiceFunc: func(params *service.DeleteServiceParams) (*service.DeleteServiceOK, error) {
+			deleteCalled = true
+			if params == nil || params.ID != serviceID {
+				t.Fatalf("expected delete service id %q, got %#v", serviceID, params)
+			}
+			return &service.DeleteServiceOK{}, nil
+		},
+	}
+
+	client := &Client{service: fake}
+	if err := client.DeleteService(ctx, serviceID); err != nil {
+		t.Fatalf("delete service: %v", err)
+	}
+	if !deleteCalled {
+		t.Fatalf("expected delete called")
+	}
+}
+
+func TestDeleteServiceNotFound(t *testing.T) {
+	ctx := context.Background()
+	serviceID := "service-id"
+
+	fake := &fakeServiceService{
+		deleteServiceFunc: func(params *service.DeleteServiceParams) (*service.DeleteServiceOK, error) {
+			return nil, &service.DeleteServiceNotFound{}
+		},
+	}
+
+	client := &Client{service: fake}
+	if err := client.DeleteService(ctx, serviceID); err == nil {
+		t.Fatalf("expected error")
+	} else if !errors.Is(err, ErrServiceNotFound) {
+		t.Fatalf("expected ErrServiceNotFound, got %v", err)
+	}
+}
+
+type unauthorizedError struct{}
+
+func (unauthorizedError) Error() string {
+	return "unauthorized"
+}
+
+func (unauthorizedError) IsCode(code int) bool {
+	return code == 401
+}
+
+func TestWithReauthRetriesOnUnauthorized(t *testing.T) {
+	client := &Client{}
+	reauthCalled := 0
+	client.reauthenticateFn = func() error {
+		reauthCalled++
+		return nil
+	}
+
+	callCount := 0
+	err := client.withReauth(func() error {
+		callCount++
+		if callCount == 1 {
+			return unauthorizedError{}
+		}
+		return nil
+	})
+	if err != nil {
+		t.Fatalf("withReauth returned error: %v", err)
+	}
+	if callCount != 2 {
+		t.Fatalf("expected 2 attempts, got %d", callCount)
+	}
+	if reauthCalled != 1 {
+		t.Fatalf("expected reauth once, got %d", reauthCalled)
+	}
+}
+
 func assertCreateExternalID(t *testing.T, params *identity.CreateIdentityParams, agentID uuid.UUID) {
 	t.Helper()
 	if params == nil || params.Identity == nil || params.Identity.ExternalID == nil {
@@ -111,6 +461,28 @@ func assertCreateExternalID(t *testing.T, params *identity.CreateIdentityParams,
 	}
 	if *params.Identity.ExternalID != agentID.String() {
 		t.Fatalf("expected external id %q, got %q", agentID.String(), *params.Identity.ExternalID)
+	}
+}
+
+func assertCreateIdentityParams(t *testing.T, params *identity.CreateIdentityParams, identityID uuid.UUID, roles []string, namePrefix string) {
+	t.Helper()
+	if params == nil || params.Identity == nil || params.Identity.Name == nil {
+		t.Fatalf("expected identity params")
+	}
+	if !strings.HasPrefix(*params.Identity.Name, namePrefix) {
+		t.Fatalf("expected name prefix %q, got %q", namePrefix, *params.Identity.Name)
+	}
+	if params.Identity.ExternalID == nil {
+		t.Fatalf("expected external id")
+	}
+	if *params.Identity.ExternalID != identityID.String() {
+		t.Fatalf("expected external id %q, got %q", identityID.String(), *params.Identity.ExternalID)
+	}
+	if params.Identity.RoleAttributes == nil {
+		t.Fatalf("expected role attributes")
+	}
+	if !reflect.DeepEqual([]string(*params.Identity.RoleAttributes), roles) {
+		t.Fatalf("expected roles %v, got %v", roles, []string(*params.Identity.RoleAttributes))
 	}
 }
 
@@ -122,4 +494,25 @@ func detailIdentityResponse(jwt string) *identity.DetailIdentityOK {
 	return &identity.DetailIdentityOK{Payload: &rest_model.DetailIdentityEnvelope{Data: &rest_model.IdentityDetail{Enrollment: &rest_model.IdentityEnrollments{
 		Ott: &rest_model.IdentityEnrollmentsOtt{JWT: jwt},
 	}}}}
+}
+
+func createServiceResponse(serviceID string) *service.CreateServiceCreated {
+	return &service.CreateServiceCreated{Payload: &rest_model.CreateEnvelope{Data: &rest_model.CreateLocation{ID: serviceID}}}
+}
+
+func stubClientEnrollment(
+	t *testing.T,
+	parse func(string) (*sdkziti.EnrollmentClaims, *jwt.Token, error),
+	enrollFn func(enroll.EnrollmentFlags) (*sdkziti.Config, error),
+) {
+	t.Helper()
+
+	originalParse := parseEnrollmentToken
+	originalEnroll := enrollIdentity
+	parseEnrollmentToken = parse
+	enrollIdentity = enrollFn
+	t.Cleanup(func() {
+		parseEnrollmentToken = originalParse
+		enrollIdentity = originalEnroll
+	})
 }

--- a/migrations/0006_make_identity_id_unique.sql
+++ b/migrations/0006_make_identity_id_unique.sql
@@ -1,0 +1,2 @@
+DROP INDEX IF EXISTS idx_managed_identities_identity_id;
+CREATE UNIQUE INDEX IF NOT EXISTS idx_managed_identities_identity_id ON managed_identities (identity_id);


### PR DESCRIPTION
## Summary
- add CreateService RPC handler tied to ziti client services
- make runner/app identity creation idempotent without service creation
- update deletion flows to use identity_id lookup and refresh buf.lock

## Testing
- go vet ./...
- go test ./...

Closes #31