### PR TITLE
fix: add service identity GC grace period

### DIFF
--- a/cmd/ziti-management/main.go
+++ b/cmd/ziti-management/main.go
@@ -74,7 +74,7 @@ func run() error {
 		grpcServer.GracefulStop()
 	}()
 
-	go gc.RunServiceIdentityGC(ctx, storeClient, zitiClient, cfg.ServiceIdentityGCInterval)
+	go gc.RunServiceIdentityGC(ctx, storeClient, zitiClient, cfg.ServiceIdentityGCInterval, cfg.ServiceIdentityGCGracePeriod)
 
 	log.Printf("ZitiManagementService listening on %s", cfg.GRPCAddress)
 

--- a/go.mod
+++ b/go.mod
@@ -7,6 +7,7 @@ require (
 	github.com/jackc/pgx/v5 v5.8.0
 	github.com/openziti/edge-api v0.27.5
 	github.com/openziti/sdk-golang v1.6.0
+	github.com/pashagolub/pgxmock/v4 v4.9.0
 	google.golang.org/grpc v1.79.1
 	google.golang.org/protobuf v1.36.11
 )

--- a/go.sum
+++ b/go.sum
@@ -357,6 +357,8 @@ github.com/orcaman/concurrent-map/v2 v2.0.1 h1:jOJ5Pg2w1oeB6PeDurIYf6k9PQ+aTITr/
 github.com/orcaman/concurrent-map/v2 v2.0.1/go.mod h1:9Eq3TG2oBe5FirmYWQfYO5iH1q0Jv47PLaNK++uCdOM=
 github.com/parallaxsecond/parsec-client-go v0.0.0-20221025095442-f0a77d263cf9 h1:mOvehYivJ4Aqu2CPe3D3lv8jhqOI9/1o0THxJHBE0qw=
 github.com/parallaxsecond/parsec-client-go v0.0.0-20221025095442-f0a77d263cf9/go.mod h1:gLH27qo/dvMhLTVVyMELpe3Tut7sOfkiDg7ZpeqKwsw=
+github.com/pashagolub/pgxmock/v4 v4.9.0 h1:itlO8nrVRnzkdMBXLs8pWUyyB2PC3Gku0WGIj/gGl7I=
+github.com/pashagolub/pgxmock/v4 v4.9.0/go.mod h1:9L57pC193h2aKRHVyiiE817avasIPZnPwPlw3JczWvM=
 github.com/pascaldekloe/goe v0.0.0-20180627143212-57f6aae5913c/go.mod h1:lzWF7FIEvWOWxwDKqyGYQf6ZUaNfKdP144TG7ZOy1lc=
 github.com/pborman/getopt v0.0.0-20170112200414-7148bc3a4c30/go.mod h1:85jBQOZwpVEaDAr341tbn15RS4fCAsIst0qp7i8ex1o=
 github.com/pelletier/go-toml v1.9.3/go.mod h1:u1nR/EPcESfeI/szUZKdtJ0xRNbUoANCkoOuaOx1Y+c=
@@ -408,6 +410,8 @@ github.com/stretchr/testify v1.4.0/go.mod h1:j7eGeouHqKxXV5pUuKE4zz7dFj8WfuZ+81P
 github.com/stretchr/testify v1.5.1/go.mod h1:5W2xD1RspED5o8YsWQXVCued0rvSQ+mT+I5cxcmMvtA=
 github.com/stretchr/testify v1.6.1/go.mod h1:6Fq8oRcR53rry900zMqJjRRixrwX3KX962/h/Wwjteg=
 github.com/stretchr/testify v1.7.0/go.mod h1:6Fq8oRcR53rry900zMqJjRRixrwX3KX962/h/Wwjteg=
+github.com/stretchr/testify v1.9.0 h1:HtqpIVDClZ4nwg75+f6Lvsy/wHu+3BoSGCbBAcpTsTg=
+github.com/stretchr/testify v1.9.0/go.mod h1:r2ic/lqez/lEtzL7wO/rwa5dbSLXVDPFyf8C91i36aY=
 github.com/stretchr/testify v1.11.1 h1:7s2iGBzp5EwR7/aIZr8ao5+dra3wiQyKjjFuvgVKu7U=
 github.com/stretchr/testify v1.11.1/go.mod h1:wZwfW3scLgRK+23gO65QZefKpKQRnfz6sD981Nm4B6U=
 github.com/subosito/gotenv v1.2.0/go.mod h1:N0PQaV/YGNqwC0u51sEeR/aUtSLEXKX9iv69rRypqCw=

--- a/internal/config/config.go
+++ b/internal/config/config.go
@@ -16,6 +16,7 @@ type Config struct {
 	ZitiEnrollmentJWTFile     string
 	ServiceIdentityLeaseTTL   time.Duration
 	ServiceIdentityGCInterval time.Duration
+	ServiceIdentityGCGracePeriod time.Duration
 }
 
 func FromEnv() (Config, error) {
@@ -45,16 +46,21 @@ func FromEnv() (Config, error) {
 		return Config{}, fmt.Errorf("ZITI_CA_FILE must be set")
 	}
 	cfg.ZitiEnrollmentJWTFile = os.Getenv("ZITI_ENROLLMENT_JWT_FILE")
-	leaseTTL, err := durationFromEnv("SERVICE_IDENTITY_LEASE_TTL", 5*time.Minute)
+	leaseTTL, err := durationFromEnv("SERVICE_IDENTITY_LEASE_TTL", 10*time.Minute)
 	if err != nil {
 		return Config{}, err
 	}
-	gcInterval, err := durationFromEnv("SERVICE_IDENTITY_GC_INTERVAL", time.Minute)
+	gcInterval, err := durationFromEnv("SERVICE_IDENTITY_GC_INTERVAL", 2*time.Minute)
+	if err != nil {
+		return Config{}, err
+	}
+	gcGracePeriod, err := durationFromEnvAllowZero("SERVICE_IDENTITY_GC_GRACE_PERIOD", 10*time.Minute)
 	if err != nil {
 		return Config{}, err
 	}
 	cfg.ServiceIdentityLeaseTTL = leaseTTL
 	cfg.ServiceIdentityGCInterval = gcInterval
+	cfg.ServiceIdentityGCGracePeriod = gcGracePeriod
 	return cfg, nil
 }
 
@@ -69,6 +75,21 @@ func durationFromEnv(key string, defaultValue time.Duration) (time.Duration, err
 	}
 	if parsed <= 0 {
 		return 0, fmt.Errorf("%s must be greater than 0", key)
+	}
+	return parsed, nil
+}
+
+func durationFromEnvAllowZero(key string, defaultValue time.Duration) (time.Duration, error) {
+	value := os.Getenv(key)
+	if value == "" {
+		return defaultValue, nil
+	}
+	parsed, err := time.ParseDuration(value)
+	if err != nil {
+		return 0, fmt.Errorf("%s must be a valid duration: %w", key, err)
+	}
+	if parsed < 0 {
+		return 0, fmt.Errorf("%s must be greater than or equal to 0", key)
 	}
 	return parsed, nil
 }

--- a/internal/gc/gc.go
+++ b/internal/gc/gc.go
@@ -10,12 +10,12 @@ import (
 	"github.com/agynio/ziti-management/internal/ziti"
 )
 
-func RunServiceIdentityGC(ctx context.Context, storeClient *store.Store, zitiClient *ziti.Client, interval time.Duration) {
+func RunServiceIdentityGC(ctx context.Context, storeClient *store.Store, zitiClient *ziti.Client, interval time.Duration, gracePeriod time.Duration) {
 	ticker := time.NewTicker(interval)
 	defer ticker.Stop()
 
 	for {
-		if err := sweepServiceIdentities(ctx, storeClient, zitiClient); err != nil {
+		if err := sweepServiceIdentities(ctx, storeClient, zitiClient, gracePeriod); err != nil {
 			log.Printf("service identity GC sweep failed: %v", err)
 		}
 		select {
@@ -26,8 +26,8 @@ func RunServiceIdentityGC(ctx context.Context, storeClient *store.Store, zitiCli
 	}
 }
 
-func sweepServiceIdentities(ctx context.Context, storeClient *store.Store, zitiClient *ziti.Client) error {
-	identities, err := storeClient.ListExpiredServiceIdentities(ctx)
+func sweepServiceIdentities(ctx context.Context, storeClient *store.Store, zitiClient *ziti.Client, gracePeriod time.Duration) error {
+	identities, err := storeClient.ListExpiredServiceIdentities(ctx, gracePeriod)
 	if err != nil {
 		return err
 	}

--- a/internal/store/store.go
+++ b/internal/store/store.go
@@ -9,14 +9,20 @@ import (
 
 	"github.com/google/uuid"
 	"github.com/jackc/pgx/v5"
-	"github.com/jackc/pgx/v5/pgxpool"
+	"github.com/jackc/pgx/v5/pgconn"
 )
 
 type Store struct {
-	pool *pgxpool.Pool
+	pool dbPool
 }
 
-func NewStore(pool *pgxpool.Pool) *Store {
+type dbPool interface {
+	Exec(ctx context.Context, sql string, arguments ...any) (pgconn.CommandTag, error)
+	Query(ctx context.Context, sql string, args ...any) (pgx.Rows, error)
+	QueryRow(ctx context.Context, sql string, args ...any) pgx.Row
+}
+
+func NewStore(pool dbPool) *Store {
 	return &Store{pool: pool}
 }
 
@@ -142,8 +148,8 @@ func (s *Store) ExtendServiceIdentityLease(ctx context.Context, zitiIdentityID s
 	return nil
 }
 
-func (s *Store) ListExpiredServiceIdentities(ctx context.Context) ([]ServiceIdentity, error) {
-	rows, err := s.pool.Query(ctx, `SELECT ziti_identity_id, service_type, lease_expires_at, created_at FROM service_identities WHERE lease_expires_at < NOW() ORDER BY lease_expires_at ASC`)
+func (s *Store) ListExpiredServiceIdentities(ctx context.Context, gracePeriod time.Duration) ([]ServiceIdentity, error) {
+	rows, err := s.pool.Query(ctx, `SELECT ziti_identity_id, service_type, lease_expires_at, created_at FROM service_identities WHERE lease_expires_at < NOW() - $1::interval ORDER BY lease_expires_at ASC`, gracePeriod)
 	if err != nil {
 		return nil, fmt.Errorf("list expired service identities: %w", err)
 	}

--- a/internal/store/store_test.go
+++ b/internal/store/store_test.go
@@ -1,0 +1,56 @@
+package store
+
+import (
+	"context"
+	"testing"
+	"time"
+
+	"github.com/pashagolub/pgxmock/v4"
+)
+
+func TestListExpiredServiceIdentitiesGracePeriod(t *testing.T) {
+	ctx := context.Background()
+	pool, err := pgxmock.NewPool()
+	if err != nil {
+		t.Fatalf("create pool mock: %v", err)
+	}
+	defer pool.Close()
+
+	gracePeriod := 10 * time.Minute
+	leaseExpiresAt := time.Now().Add(-gracePeriod - time.Minute)
+	createdAt := time.Now().Add(-2 * time.Hour)
+
+	rows := pgxmock.NewRows([]string{"ziti_identity_id", "service_type", "lease_expires_at", "created_at"}).
+		AddRow("identity-1", ServiceTypeRunner, leaseExpiresAt, createdAt)
+
+	pool.ExpectQuery(`SELECT ziti_identity_id, service_type, lease_expires_at, created_at FROM service_identities WHERE lease_expires_at < NOW\(\) - \$1::interval ORDER BY lease_expires_at ASC`).
+		WithArgs(gracePeriod).
+		WillReturnRows(rows)
+
+	storeClient := NewStore(pool)
+	identities, err := storeClient.ListExpiredServiceIdentities(ctx, gracePeriod)
+	if err != nil {
+		t.Fatalf("list expired service identities: %v", err)
+	}
+
+	if len(identities) != 1 {
+		t.Fatalf("expected 1 identity, got %d", len(identities))
+	}
+	identity := identities[0]
+	if identity.ZitiIdentityID != "identity-1" {
+		t.Fatalf("expected ziti identity id identity-1, got %s", identity.ZitiIdentityID)
+	}
+	if identity.ServiceType != ServiceTypeRunner {
+		t.Fatalf("expected service type %v, got %v", ServiceTypeRunner, identity.ServiceType)
+	}
+	if !identity.LeaseExpiresAt.Equal(leaseExpiresAt) {
+		t.Fatalf("expected lease expiry %v, got %v", leaseExpiresAt, identity.LeaseExpiresAt)
+	}
+	if !identity.CreatedAt.Equal(createdAt) {
+		t.Fatalf("expected created at %v, got %v", createdAt, identity.CreatedAt)
+	}
+
+	if err := pool.ExpectationsWereMet(); err != nil {
+		t.Fatalf("expectations were not met: %v", err)
+	}
+}


### PR DESCRIPTION
## Summary
- update GC defaults and add grace period config parsing
- pass grace period through GC sweep to the store query
- add store test covering grace period query usage

## Testing
- buf generate buf.build/agynio/api --template buf.gen.yaml --path agynio/api/ziti_management/v1
- go build ./...
- go vet ./...
- go test ./...

Ref #108