### PR TITLE
fix(release): pin buf inputs

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -25,6 +25,8 @@ jobs:
 
       - name: Set up Buf
         uses: bufbuild/buf-setup-action@v1
+        with:
+          version: '1.67.0'
 
       - name: Generate gRPC stubs
         run: |

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,6 +1,6 @@
 # syntax=docker/dockerfile:1.8
 ARG GO_VERSION=1.25
-ARG BUF_VERSION=1.66.0
+ARG BUF_VERSION=1.67.0
 
 FROM --platform=$BUILDPLATFORM golang:${GO_VERSION}-alpine AS buf
 ARG BUF_VERSION
@@ -21,7 +21,7 @@ RUN --mount=type=cache,target=/go/pkg/mod \
     --mount=type=cache,target=/root/.cache/go-build \
     go mod download
 
-COPY buf.gen.yaml buf.yaml ./
+COPY buf.gen.yaml buf.yaml buf.lock ./
 RUN buf generate buf.build/agynio/api --path agynio/api/ziti_management/v1
 
 COPY . .


### PR DESCRIPTION
## Summary
- include buf.lock in Docker build context
- bump BUF_VERSION to 1.67.0
- pin Buf version in CI setup

## Testing
- go build ./...
- go vet ./...
- go test ./...

Ref #35