### PR TITLE
Fix identity re-enroll handling

### DIFF
--- a/internal/server/server.go
+++ b/internal/server/server.go
@@ -155,7 +155,7 @@ func (s *Server) CreateRunnerIdentity(ctx context.Context, req *zitimanagementv1
 	if err := s.store.InsertManagedIdentity(ctx, identity); err != nil {
 		cleanupErr := s.ziti.DeleteIdentity(ctx, zitiID)
 		if cleanupErr != nil && !errors.Is(cleanupErr, ziti.ErrIdentityNotFound) {
-			log.Printf("failed to cleanup ziti identity %s: %v", zitiID, cleanupErr)
+			log.Printf("failed to cleanup runner identity %s: %v", zitiID, cleanupErr)
 		}
 		return nil, status.Errorf(codes.Internal, "insert managed identity: %v", err)
 	}
@@ -167,17 +167,40 @@ func (s *Server) CreateRunnerIdentity(ctx context.Context, req *zitimanagementv1
 }
 
 func (s *Server) DeleteRunnerIdentity(ctx context.Context, req *zitimanagementv1.DeleteRunnerIdentityRequest) (*zitimanagementv1.DeleteRunnerIdentityResponse, error) {
-	identityID, err := parseUUID(req.GetIdentityId())
+	runnerID, err := parseUUID(req.GetIdentityId())
 	if err != nil {
 		return nil, status.Errorf(codes.InvalidArgument, "identity_id: %v", err)
 	}
-	zitiServiceID := req.GetZitiServiceId()
-	if zitiServiceID == "" {
-		return nil, status.Error(codes.InvalidArgument, "ziti_service_id is required")
+
+	identity, err := s.store.ResolveIdentityByIdentityID(ctx, runnerID)
+	if err != nil {
+		return nil, toStatusError(err)
 	}
 
-	if err := s.deleteManagedIdentityAndService(ctx, identityID, zitiServiceID); err != nil {
-		return nil, err
+	if err := s.store.DeleteManagedIdentity(ctx, identity.ZitiIdentityID); err != nil {
+		return nil, toStatusError(err)
+	}
+
+	if err := s.ziti.DeleteIdentity(ctx, identity.ZitiIdentityID); err != nil {
+		if errors.Is(err, ziti.ErrIdentityNotFound) {
+			log.Printf("ziti identity %s already deleted", identity.ZitiIdentityID)
+		} else {
+			return nil, status.Errorf(codes.Internal, "delete ziti identity: %v", err)
+		}
+	}
+
+	zitiServiceID := req.GetZitiServiceId()
+	if zitiServiceID == "" && identity.ZitiServiceID != nil {
+		zitiServiceID = *identity.ZitiServiceID
+	}
+	if zitiServiceID != "" {
+		if err := s.ziti.DeleteService(ctx, zitiServiceID); err != nil {
+			if errors.Is(err, ziti.ErrServiceNotFound) {
+				log.Printf("ziti service %s already deleted", zitiServiceID)
+			} else {
+				return nil, status.Errorf(codes.Internal, "delete ziti service: %v", err)
+			}
+		}
 	}
 
 	return &zitimanagementv1.DeleteRunnerIdentityResponse{}, nil
@@ -202,49 +225,44 @@ func (s *Server) DeleteIdentity(ctx context.Context, req *zitimanagementv1.Delet
 }
 
 func (s *Server) DeleteAppIdentity(ctx context.Context, req *zitimanagementv1.DeleteAppIdentityRequest) (*zitimanagementv1.DeleteAppIdentityResponse, error) {
-	identityID, err := parseUUID(req.GetIdentityId())
+	appID, err := parseUUID(req.GetIdentityId())
 	if err != nil {
 		return nil, status.Errorf(codes.InvalidArgument, "identity_id: %v", err)
 	}
-	zitiServiceID := req.GetZitiServiceId()
-	if zitiServiceID == "" {
-		return nil, status.Error(codes.InvalidArgument, "ziti_service_id is required")
-	}
 
-	if err := s.deleteManagedIdentityAndService(ctx, identityID, zitiServiceID); err != nil {
-		return nil, err
-	}
-
-	return &zitimanagementv1.DeleteAppIdentityResponse{}, nil
-}
-
-func (s *Server) deleteManagedIdentityAndService(ctx context.Context, identityID uuid.UUID, zitiServiceID string) error {
-	identity, err := s.store.ResolveIdentityByIdentityID(ctx, identityID)
+	identity, err := s.store.ResolveIdentityByIdentityID(ctx, appID)
 	if err != nil {
-		return toStatusError(err)
+		return nil, toStatusError(err)
 	}
 
 	if err := s.store.DeleteManagedIdentity(ctx, identity.ZitiIdentityID); err != nil {
-		return toStatusError(err)
+		return nil, toStatusError(err)
 	}
 
 	if err := s.ziti.DeleteIdentity(ctx, identity.ZitiIdentityID); err != nil {
 		if errors.Is(err, ziti.ErrIdentityNotFound) {
 			log.Printf("ziti identity %s already deleted", identity.ZitiIdentityID)
 		} else {
-			return status.Errorf(codes.Internal, "delete ziti identity: %v", err)
+			return nil, status.Errorf(codes.Internal, "delete ziti identity: %v", err)
 		}
 	}
 
+	zitiServiceID := req.GetZitiServiceId()
+	if zitiServiceID == "" && identity.ZitiServiceID != nil {
+		zitiServiceID = *identity.ZitiServiceID
+	}
+	if zitiServiceID == "" {
+		return nil, status.Errorf(codes.Internal, "managed identity %s missing ziti service id", identity.ZitiIdentityID)
+	}
 	if err := s.ziti.DeleteService(ctx, zitiServiceID); err != nil {
 		if errors.Is(err, ziti.ErrServiceNotFound) {
 			log.Printf("ziti service %s already deleted", zitiServiceID)
 		} else {
-			return status.Errorf(codes.Internal, "delete ziti service: %v", err)
+			return nil, status.Errorf(codes.Internal, "delete ziti service: %v", err)
 		}
 	}
 
-	return nil
+	return &zitimanagementv1.DeleteAppIdentityResponse{}, nil
 }
 
 func (s *Server) RequestServiceIdentity(ctx context.Context, req *zitimanagementv1.RequestServiceIdentityRequest) (*zitimanagementv1.RequestServiceIdentityResponse, error) {

--- a/internal/ziti/client.go
+++ b/internal/ziti/client.go
@@ -9,6 +9,7 @@ import (
 	"errors"
 	"fmt"
 	"os"
+	"strconv"
 	"sync"
 
 	"github.com/agynio/ziti-management/internal/id"
@@ -38,6 +39,7 @@ type identityService interface {
 	CreateIdentity(params *identity.CreateIdentityParams, authInfo runtime.ClientAuthInfoWriter, opts ...identity.ClientOption) (*identity.CreateIdentityCreated, error)
 	DeleteIdentity(params *identity.DeleteIdentityParams, authInfo runtime.ClientAuthInfoWriter, opts ...identity.ClientOption) (*identity.DeleteIdentityOK, error)
 	DetailIdentity(params *identity.DetailIdentityParams, authInfo runtime.ClientAuthInfoWriter, opts ...identity.ClientOption) (*identity.DetailIdentityOK, error)
+	ListIdentities(params *identity.ListIdentitiesParams, authInfo runtime.ClientAuthInfoWriter, opts ...identity.ClientOption) (*identity.ListIdentitiesOK, error)
 }
 
 type serviceService interface {
@@ -251,6 +253,78 @@ func (c *Client) createIdentity(ctx context.Context, identityCreate *rest_model.
 		}
 		return created.Payload, nil
 	})
+}
+
+func (c *Client) deleteIdentityByExternalID(ctx context.Context, externalID string) error {
+	identityIDs, err := c.listIdentityIDsByExternalID(ctx, externalID)
+	if err != nil {
+		return err
+	}
+	for _, identityID := range identityIDs {
+		if err := c.DeleteIdentity(ctx, identityID); err != nil && !errors.Is(err, ErrIdentityNotFound) {
+			return err
+		}
+	}
+	return nil
+}
+
+func (c *Client) listIdentityIDsByExternalID(ctx context.Context, externalID string) ([]string, error) {
+	if externalID == "" {
+		return nil, errors.New("external id is empty")
+	}
+	filter := fmt.Sprintf("externalId=%s", strconv.Quote(externalID))
+	limit := int64(100)
+	offset := int64(0)
+	identityIDs := make([]string, 0)
+
+	for {
+		params := identity.NewListIdentitiesParamsWithContext(ctx)
+		params.Filter = &filter
+		params.Limit = &limit
+		params.Offset = &offset
+
+		var listed *identity.ListIdentitiesOK
+		err := c.withReauth(func() error {
+			var callErr error
+			identityClient := c.identityClient()
+			listed, callErr = identityClient.ListIdentities(params, nil)
+			return callErr
+		})
+		if err != nil {
+			return nil, fmt.Errorf("list ziti identities: %w", err)
+		}
+		if listed.Payload == nil {
+			return nil, errors.New("list ziti identities response missing payload")
+		}
+		if listed.Payload.Meta == nil || listed.Payload.Meta.Pagination == nil {
+			return nil, errors.New("list ziti identities response missing pagination")
+		}
+		pagination := listed.Payload.Meta.Pagination
+		if pagination.TotalCount == nil || pagination.Limit == nil || pagination.Offset == nil {
+			return nil, errors.New("list ziti identities response missing pagination details")
+		}
+		totalCount := *pagination.TotalCount
+		if totalCount == 0 {
+			if len(listed.Payload.Data) == 0 {
+				return nil, nil
+			}
+			return nil, errors.New("list ziti identities response returned data with zero total count")
+		}
+		for _, identity := range listed.Payload.Data {
+			if identity == nil || identity.ID == nil {
+				return nil, errors.New("list ziti identities response missing identity id")
+			}
+			identityIDs = append(identityIDs, *identity.ID)
+		}
+		pageCount := int64(len(listed.Payload.Data))
+		if pageCount == 0 {
+			return nil, errors.New("list ziti identities response returned empty page")
+		}
+		if offset+pageCount >= totalCount {
+			return identityIDs, nil
+		}
+		offset += pageCount
+	}
 }
 
 func (c *Client) CreateAgentIdentity(ctx context.Context, agentID uuid.UUID) (string, string, error) {
@@ -531,6 +605,9 @@ func (c *Client) CreateAndEnrollAppIdentity(ctx context.Context, appID uuid.UUID
 	isAdmin := false
 	roleAttrs := rest_model.Attributes{roleAttributeApps}
 	externalID := appID.String()
+	if err := c.deleteIdentityByExternalID(ctx, externalID); err != nil {
+		return "", nil, fmt.Errorf("delete existing ziti identity: %w", err)
+	}
 	identityCreate := &rest_model.IdentityCreate{
 		Name:           &name,
 		Type:           &identityType,
@@ -549,6 +626,9 @@ func (c *Client) CreateAndEnrollRunnerIdentity(ctx context.Context, runnerID uui
 	isAdmin := false
 	roleAttrs := rest_model.Attributes(roleAttributes)
 	externalID := runnerID.String()
+	if err := c.deleteIdentityByExternalID(ctx, externalID); err != nil {
+		return "", nil, fmt.Errorf("delete existing ziti identity: %w", err)
+	}
 	identityCreate := &rest_model.IdentityCreate{
 		Name:           &name,
 		Type:           &identityType,

--- a/internal/ziti/client_test.go
+++ b/internal/ziti/client_test.go
@@ -4,6 +4,7 @@ import (
 	"context"
 	"errors"
 	"reflect"
+	"strconv"
 	"testing"
 
 	"github.com/go-openapi/runtime"
@@ -19,6 +20,7 @@ type fakeIdentityService struct {
 	createIdentityFunc func(params *identity.CreateIdentityParams) (*identity.CreateIdentityCreated, error)
 	deleteIdentityFunc func(params *identity.DeleteIdentityParams) (*identity.DeleteIdentityOK, error)
 	detailIdentityFunc func(params *identity.DetailIdentityParams) (*identity.DetailIdentityOK, error)
+	listIdentitiesFunc func(params *identity.ListIdentitiesParams) (*identity.ListIdentitiesOK, error)
 }
 
 func (f *fakeIdentityService) CreateIdentity(params *identity.CreateIdentityParams, _ runtime.ClientAuthInfoWriter, _ ...identity.ClientOption) (*identity.CreateIdentityCreated, error) {
@@ -40,6 +42,13 @@ func (f *fakeIdentityService) DetailIdentity(params *identity.DetailIdentityPara
 		return nil, errors.New("detail identity not stubbed")
 	}
 	return f.detailIdentityFunc(params)
+}
+
+func (f *fakeIdentityService) ListIdentities(params *identity.ListIdentitiesParams, _ runtime.ClientAuthInfoWriter, _ ...identity.ClientOption) (*identity.ListIdentitiesOK, error) {
+	if f.listIdentitiesFunc == nil {
+		return nil, errors.New("list identities not stubbed")
+	}
+	return f.listIdentitiesFunc(params)
 }
 
 type fakeServiceService struct {
@@ -557,4 +566,82 @@ func createConfigResponse(configID string) *config.CreateConfigCreated {
 
 func createServicePolicyResponse(policyID string) *service_policy.CreateServicePolicyCreated {
 	return &service_policy.CreateServicePolicyCreated{Payload: &rest_model.CreateEnvelope{Data: &rest_model.CreateLocation{ID: policyID}}}
+}
+
+func TestDeleteIdentityByExternalIDDeletesMatches(t *testing.T) {
+	ctx := context.Background()
+	externalID := uuid.New().String()
+	deleted := make([]string, 0)
+
+	fake := &fakeIdentityService{
+		listIdentitiesFunc: func(params *identity.ListIdentitiesParams) (*identity.ListIdentitiesOK, error) {
+			if params == nil || params.Filter == nil {
+				t.Fatalf("expected filter param")
+			}
+			expectedFilter := "externalId=" + strconv.Quote(externalID)
+			if *params.Filter != expectedFilter {
+				t.Fatalf("expected filter %q, got %q", expectedFilter, *params.Filter)
+			}
+			return listIdentitiesResponse([]string{"id-1", "id-2"}, 100, 0, 2), nil
+		},
+		deleteIdentityFunc: func(params *identity.DeleteIdentityParams) (*identity.DeleteIdentityOK, error) {
+			deleted = append(deleted, params.ID)
+			return &identity.DeleteIdentityOK{}, nil
+		},
+	}
+
+	client := &Client{identity: fake}
+	if err := client.deleteIdentityByExternalID(ctx, externalID); err != nil {
+		t.Fatalf("delete identity by external id: %v", err)
+	}
+	if len(deleted) != 2 {
+		t.Fatalf("expected 2 deletions, got %v", deleted)
+	}
+	if deleted[0] != "id-1" || deleted[1] != "id-2" {
+		t.Fatalf("unexpected deletions: %v", deleted)
+	}
+}
+
+func TestDeleteIdentityByExternalIDNoMatches(t *testing.T) {
+	ctx := context.Background()
+	externalID := uuid.New().String()
+	deleteCalled := false
+
+	fake := &fakeIdentityService{
+		listIdentitiesFunc: func(params *identity.ListIdentitiesParams) (*identity.ListIdentitiesOK, error) {
+			return listIdentitiesResponse(nil, 100, 0, 0), nil
+		},
+		deleteIdentityFunc: func(params *identity.DeleteIdentityParams) (*identity.DeleteIdentityOK, error) {
+			deleteCalled = true
+			return &identity.DeleteIdentityOK{}, nil
+		},
+	}
+
+	client := &Client{identity: fake}
+	if err := client.deleteIdentityByExternalID(ctx, externalID); err != nil {
+		t.Fatalf("delete identity by external id: %v", err)
+	}
+	if deleteCalled {
+		t.Fatalf("expected delete not called")
+	}
+}
+
+func listIdentitiesResponse(identityIDs []string, limit, offset, total int64) *identity.ListIdentitiesOK {
+	data := make(rest_model.IdentityList, len(identityIDs))
+	for i, identityID := range identityIDs {
+		id := identityID
+		data[i] = &rest_model.IdentityDetail{BaseEntity: rest_model.BaseEntity{ID: &id}}
+	}
+	return &identity.ListIdentitiesOK{
+		Payload: &rest_model.ListIdentitiesEnvelope{
+			Data: data,
+			Meta: &rest_model.Meta{
+				Pagination: &rest_model.Pagination{
+					Limit:      &limit,
+					Offset:     &offset,
+					TotalCount: &total,
+				},
+			},
+		},
+	}
 }


### PR DESCRIPTION
## Summary
- delete existing OpenZiti identities by externalId before app/runner enrollment
- remove per-runner service creation and align create/delete handlers with current protos
- add tests for externalId cleanup flow

## Testing
- buf generate buf.build/agynio/api --path agynio/api/ziti_management/v1
- go vet ./...
- go test ./...

Closes #39