### PR TITLE
Fix reenroll managed identity conflicts

### DIFF
--- a/internal/server/identity_reenroll_test.go
+++ b/internal/server/identity_reenroll_test.go
@@ -1,0 +1,198 @@
+package server
+
+import (
+	"context"
+	"errors"
+	"fmt"
+	"testing"
+	"time"
+
+	zitimanagementv1 "github.com/agynio/ziti-management/.gen/go/agynio/api/ziti_management/v1"
+	"github.com/agynio/ziti-management/internal/store"
+	"github.com/agynio/ziti-management/internal/ziti"
+	"github.com/google/uuid"
+)
+
+type fakeManagedIdentityStore struct {
+	managed     map[uuid.UUID]store.ManagedIdentity
+	deleteCalls []uuid.UUID
+}
+
+func newFakeManagedIdentityStore() *fakeManagedIdentityStore {
+	return &fakeManagedIdentityStore{managed: make(map[uuid.UUID]store.ManagedIdentity)}
+}
+
+func (f *fakeManagedIdentityStore) InsertManagedIdentity(_ context.Context, identity store.ManagedIdentity) error {
+	if _, exists := f.managed[identity.IdentityID]; exists {
+		return errors.New("managed identity already exists")
+	}
+	f.managed[identity.IdentityID] = identity
+	return nil
+}
+
+func (f *fakeManagedIdentityStore) DeleteManagedIdentity(_ context.Context, _ string) error {
+	return errors.New("unexpected delete managed identity")
+}
+
+func (f *fakeManagedIdentityStore) DeleteManagedIdentityByIdentityID(_ context.Context, identityID uuid.UUID) error {
+	delete(f.managed, identityID)
+	f.deleteCalls = append(f.deleteCalls, identityID)
+	return nil
+}
+
+func (f *fakeManagedIdentityStore) ResolveIdentity(_ context.Context, _ string) (store.ManagedIdentity, error) {
+	return store.ManagedIdentity{}, errors.New("unexpected resolve identity")
+}
+
+func (f *fakeManagedIdentityStore) ResolveIdentityByIdentityID(_ context.Context, _ uuid.UUID) (store.ManagedIdentity, error) {
+	return store.ManagedIdentity{}, errors.New("unexpected resolve identity by identity id")
+}
+
+func (f *fakeManagedIdentityStore) ListManagedIdentities(_ context.Context, _ store.ListFilter, _ int32, _ *store.PageCursor) (store.ListResult, error) {
+	return store.ListResult{}, errors.New("unexpected list managed identities")
+}
+
+func (f *fakeManagedIdentityStore) InsertServiceIdentity(_ context.Context, _ string, _ store.ServiceType, _ time.Time) error {
+	return errors.New("unexpected insert service identity")
+}
+
+func (f *fakeManagedIdentityStore) ExtendServiceIdentityLease(_ context.Context, _ string, _ time.Time) error {
+	return errors.New("unexpected extend service identity")
+}
+
+type fakeZitiClient struct {
+	appCount    int
+	runnerCount int
+}
+
+func (f *fakeZitiClient) CreateAgentIdentity(_ context.Context, _ uuid.UUID) (string, string, error) {
+	return "", "", errors.New("unexpected create agent identity")
+}
+
+func (f *fakeZitiClient) CreateAndEnrollAppIdentity(_ context.Context, _ uuid.UUID, _ string) (string, []byte, error) {
+	f.appCount++
+	zitiID := fmt.Sprintf("app-ziti-%d", f.appCount)
+	return zitiID, []byte(fmt.Sprintf("app-json-%d", f.appCount)), nil
+}
+
+func (f *fakeZitiClient) CreateAndEnrollRunnerIdentity(_ context.Context, _ uuid.UUID, _ []string) (string, []byte, error) {
+	f.runnerCount++
+	zitiID := fmt.Sprintf("runner-ziti-%d", f.runnerCount)
+	return zitiID, []byte(fmt.Sprintf("runner-json-%d", f.runnerCount)), nil
+}
+
+func (f *fakeZitiClient) CreateAndEnrollServiceIdentity(_ context.Context, _ string, _ []string) (string, []byte, error) {
+	return "", nil, errors.New("unexpected create service identity")
+}
+
+func (f *fakeZitiClient) CreateService(_ context.Context, _ string, _ []string) (string, error) {
+	return "", errors.New("unexpected create service")
+}
+
+func (f *fakeZitiClient) CreateServiceWithConfigs(_ context.Context, _ string, _ []string, _ *ziti.HostV1ConfigData, _ *ziti.InterceptV1ConfigData) (string, error) {
+	return "", errors.New("unexpected create service with configs")
+}
+
+func (f *fakeZitiClient) CreateServicePolicy(_ context.Context, _ string, _ string, _ []string, _ []string) (string, error) {
+	return "", errors.New("unexpected create service policy")
+}
+
+func (f *fakeZitiClient) CreateDeviceIdentity(_ context.Context, _ uuid.UUID, _ string) (string, string, error) {
+	return "", "", errors.New("unexpected create device identity")
+}
+
+func (f *fakeZitiClient) DeleteIdentity(_ context.Context, _ string) error {
+	return nil
+}
+
+func (f *fakeZitiClient) DeleteService(_ context.Context, _ string) error {
+	return nil
+}
+
+func (f *fakeZitiClient) DeleteServicePolicy(_ context.Context, _ string) error {
+	return nil
+}
+
+func TestCreateAppIdentityAllowsReenroll(t *testing.T) {
+	ctx := context.Background()
+	appID := uuid.New()
+	storeClient := newFakeManagedIdentityStore()
+	zitiClient := &fakeZitiClient{}
+	server := New(storeClient, zitiClient, time.Minute)
+
+	request := &zitimanagementv1.CreateAppIdentityRequest{
+		IdentityId: appID.String(),
+		Slug:       "app-slug",
+	}
+
+	firstResp, err := server.CreateAppIdentity(ctx, request)
+	if err != nil {
+		t.Fatalf("create app identity: %v", err)
+	}
+	secondResp, err := server.CreateAppIdentity(ctx, request)
+	if err != nil {
+		t.Fatalf("create app identity again: %v", err)
+	}
+
+	if len(storeClient.deleteCalls) != 2 {
+		t.Fatalf("expected 2 delete calls, got %d", len(storeClient.deleteCalls))
+	}
+	for _, deletedID := range storeClient.deleteCalls {
+		if deletedID != appID {
+			t.Fatalf("expected delete call for %s, got %s", appID, deletedID)
+		}
+	}
+
+	stored, ok := storeClient.managed[appID]
+	if !ok {
+		t.Fatalf("expected managed identity for %s", appID)
+	}
+	if stored.ZitiIdentityID != secondResp.GetZitiIdentityId() {
+		t.Fatalf("expected stored ziti id %q, got %q", secondResp.GetZitiIdentityId(), stored.ZitiIdentityID)
+	}
+	if firstResp.GetZitiIdentityId() == secondResp.GetZitiIdentityId() {
+		t.Fatalf("expected distinct ziti ids for reenroll")
+	}
+}
+
+func TestCreateRunnerIdentityAllowsReenroll(t *testing.T) {
+	ctx := context.Background()
+	runnerID := uuid.New()
+	storeClient := newFakeManagedIdentityStore()
+	zitiClient := &fakeZitiClient{}
+	server := New(storeClient, zitiClient, time.Minute)
+
+	request := &zitimanagementv1.CreateRunnerIdentityRequest{
+		RunnerId:       runnerID.String(),
+		RoleAttributes: []string{"runner"},
+	}
+
+	firstResp, err := server.CreateRunnerIdentity(ctx, request)
+	if err != nil {
+		t.Fatalf("create runner identity: %v", err)
+	}
+	secondResp, err := server.CreateRunnerIdentity(ctx, request)
+	if err != nil {
+		t.Fatalf("create runner identity again: %v", err)
+	}
+
+	if len(storeClient.deleteCalls) != 2 {
+		t.Fatalf("expected 2 delete calls, got %d", len(storeClient.deleteCalls))
+	}
+	for _, deletedID := range storeClient.deleteCalls {
+		if deletedID != runnerID {
+			t.Fatalf("expected delete call for %s, got %s", runnerID, deletedID)
+		}
+	}
+
+	stored, ok := storeClient.managed[runnerID]
+	if !ok {
+		t.Fatalf("expected managed identity for %s", runnerID)
+	}
+	if stored.ZitiIdentityID != secondResp.GetZitiIdentityId() {
+		t.Fatalf("expected stored ziti id %q, got %q", secondResp.GetZitiIdentityId(), stored.ZitiIdentityID)
+	}
+	if firstResp.GetZitiIdentityId() == secondResp.GetZitiIdentityId() {
+		t.Fatalf("expected distinct ziti ids for reenroll")
+	}
+}

--- a/internal/server/identity_reenroll_test.go
+++ b/internal/server/identity_reenroll_test.go
@@ -4,6 +4,7 @@ import (
 	"context"
 	"errors"
 	"fmt"
+	"strings"
 	"testing"
 	"time"
 
@@ -14,8 +15,9 @@ import (
 )
 
 type fakeManagedIdentityStore struct {
-	managed     map[uuid.UUID]store.ManagedIdentity
-	deleteCalls []uuid.UUID
+	managed               map[uuid.UUID]store.ManagedIdentity
+	deleteCalls           []uuid.UUID
+	deleteByIdentityIDErr error
 }
 
 func newFakeManagedIdentityStore() *fakeManagedIdentityStore {
@@ -35,8 +37,11 @@ func (f *fakeManagedIdentityStore) DeleteManagedIdentity(_ context.Context, _ st
 }
 
 func (f *fakeManagedIdentityStore) DeleteManagedIdentityByIdentityID(_ context.Context, identityID uuid.UUID) error {
-	delete(f.managed, identityID)
 	f.deleteCalls = append(f.deleteCalls, identityID)
+	if f.deleteByIdentityIDErr != nil {
+		return f.deleteByIdentityIDErr
+	}
+	delete(f.managed, identityID)
 	return nil
 }
 
@@ -61,8 +66,9 @@ func (f *fakeManagedIdentityStore) ExtendServiceIdentityLease(_ context.Context,
 }
 
 type fakeZitiClient struct {
-	appCount    int
-	runnerCount int
+	appCount          int
+	runnerCount       int
+	deleteIdentityIDs []string
 }
 
 func (f *fakeZitiClient) CreateAgentIdentity(_ context.Context, _ uuid.UUID) (string, string, error) {
@@ -101,7 +107,8 @@ func (f *fakeZitiClient) CreateDeviceIdentity(_ context.Context, _ uuid.UUID, _ 
 	return "", "", errors.New("unexpected create device identity")
 }
 
-func (f *fakeZitiClient) DeleteIdentity(_ context.Context, _ string) error {
+func (f *fakeZitiClient) DeleteIdentity(_ context.Context, zitiID string) error {
+	f.deleteIdentityIDs = append(f.deleteIdentityIDs, zitiID)
 	return nil
 }
 
@@ -155,6 +162,37 @@ func TestCreateAppIdentityAllowsReenroll(t *testing.T) {
 	}
 }
 
+func TestCreateAppIdentityDeleteFailureCleansUp(t *testing.T) {
+	ctx := context.Background()
+	appID := uuid.New()
+	storeClient := newFakeManagedIdentityStore()
+	storeClient.deleteByIdentityIDErr = errors.New("delete failed")
+	zitiClient := &fakeZitiClient{}
+	server := New(storeClient, zitiClient, time.Minute)
+
+	request := &zitimanagementv1.CreateAppIdentityRequest{
+		IdentityId: appID.String(),
+		Slug:       "app-slug",
+	}
+
+	_, err := server.CreateAppIdentity(ctx, request)
+	if err == nil {
+		t.Fatalf("expected error")
+	}
+	if !strings.Contains(err.Error(), "delete managed identity") {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	if len(zitiClient.deleteIdentityIDs) != 1 {
+		t.Fatalf("expected 1 cleanup call, got %d", len(zitiClient.deleteIdentityIDs))
+	}
+	if zitiClient.deleteIdentityIDs[0] != "app-ziti-1" {
+		t.Fatalf("expected cleanup for app-ziti-1, got %s", zitiClient.deleteIdentityIDs[0])
+	}
+	if len(storeClient.managed) != 0 {
+		t.Fatalf("expected no managed identities persisted")
+	}
+}
+
 func TestCreateRunnerIdentityAllowsReenroll(t *testing.T) {
 	ctx := context.Background()
 	runnerID := uuid.New()
@@ -194,5 +232,36 @@ func TestCreateRunnerIdentityAllowsReenroll(t *testing.T) {
 	}
 	if firstResp.GetZitiIdentityId() == secondResp.GetZitiIdentityId() {
 		t.Fatalf("expected distinct ziti ids for reenroll")
+	}
+}
+
+func TestCreateRunnerIdentityDeleteFailureCleansUp(t *testing.T) {
+	ctx := context.Background()
+	runnerID := uuid.New()
+	storeClient := newFakeManagedIdentityStore()
+	storeClient.deleteByIdentityIDErr = errors.New("delete failed")
+	zitiClient := &fakeZitiClient{}
+	server := New(storeClient, zitiClient, time.Minute)
+
+	request := &zitimanagementv1.CreateRunnerIdentityRequest{
+		RunnerId:       runnerID.String(),
+		RoleAttributes: []string{"runner"},
+	}
+
+	_, err := server.CreateRunnerIdentity(ctx, request)
+	if err == nil {
+		t.Fatalf("expected error")
+	}
+	if !strings.Contains(err.Error(), "delete managed identity") {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	if len(zitiClient.deleteIdentityIDs) != 1 {
+		t.Fatalf("expected 1 cleanup call, got %d", len(zitiClient.deleteIdentityIDs))
+	}
+	if zitiClient.deleteIdentityIDs[0] != "runner-ziti-1" {
+		t.Fatalf("expected cleanup for runner-ziti-1, got %s", zitiClient.deleteIdentityIDs[0])
+	}
+	if len(storeClient.managed) != 0 {
+		t.Fatalf("expected no managed identities persisted")
 	}
 }

--- a/internal/server/server.go
+++ b/internal/server/server.go
@@ -51,6 +51,12 @@ type Server struct {
 	serviceIdentityLeaseTTL time.Duration
 }
 
+func (s *Server) cleanupZitiIdentity(ctx context.Context, zitiID, label string) {
+	if err := s.ziti.DeleteIdentity(ctx, zitiID); err != nil && !errors.Is(err, ziti.ErrIdentityNotFound) {
+		log.Printf("failed to cleanup %s %s: %v", label, zitiID, err)
+	}
+}
+
 func New(store managedIdentityStore, zitiClient zitiClient, serviceIdentityLeaseTTL time.Duration) *Server {
 	return &Server{store: store, ziti: zitiClient, serviceIdentityLeaseTTL: serviceIdentityLeaseTTL}
 }
@@ -72,10 +78,7 @@ func (s *Server) CreateAgentIdentity(ctx context.Context, req *zitimanagementv1.
 		IdentityType:   store.IdentityTypeAgent,
 	}
 	if err := s.store.InsertManagedIdentity(ctx, identity); err != nil {
-		cleanupErr := s.ziti.DeleteIdentity(ctx, zitiID)
-		if cleanupErr != nil && !errors.Is(cleanupErr, ziti.ErrIdentityNotFound) {
-			log.Printf("failed to cleanup ziti identity %s: %v", zitiID, cleanupErr)
-		}
+		s.cleanupZitiIdentity(ctx, zitiID, "ziti identity")
 		return nil, status.Errorf(codes.Internal, "insert managed identity: %v", err)
 	}
 
@@ -107,17 +110,11 @@ func (s *Server) CreateAppIdentity(ctx context.Context, req *zitimanagementv1.Cr
 		IdentityType:   store.IdentityTypeApp,
 	}
 	if err := s.store.DeleteManagedIdentityByIdentityID(ctx, appID); err != nil {
-		cleanupErr := s.ziti.DeleteIdentity(ctx, zitiID)
-		if cleanupErr != nil && !errors.Is(cleanupErr, ziti.ErrIdentityNotFound) {
-			log.Printf("failed to cleanup ziti identity %s: %v", zitiID, cleanupErr)
-		}
+		s.cleanupZitiIdentity(ctx, zitiID, "ziti identity")
 		return nil, status.Errorf(codes.Internal, "delete managed identity: %v", err)
 	}
 	if err := s.store.InsertManagedIdentity(ctx, identity); err != nil {
-		cleanupErr := s.ziti.DeleteIdentity(ctx, zitiID)
-		if cleanupErr != nil && !errors.Is(cleanupErr, ziti.ErrIdentityNotFound) {
-			log.Printf("failed to cleanup ziti identity %s: %v", zitiID, cleanupErr)
-		}
+		s.cleanupZitiIdentity(ctx, zitiID, "ziti identity")
 		return nil, status.Errorf(codes.Internal, "insert managed identity: %v", err)
 	}
 
@@ -185,17 +182,11 @@ func (s *Server) CreateRunnerIdentity(ctx context.Context, req *zitimanagementv1
 		IdentityType:   store.IdentityTypeRunner,
 	}
 	if err := s.store.DeleteManagedIdentityByIdentityID(ctx, runnerID); err != nil {
-		cleanupErr := s.ziti.DeleteIdentity(ctx, zitiID)
-		if cleanupErr != nil && !errors.Is(cleanupErr, ziti.ErrIdentityNotFound) {
-			log.Printf("failed to cleanup runner identity %s: %v", zitiID, cleanupErr)
-		}
+		s.cleanupZitiIdentity(ctx, zitiID, "runner identity")
 		return nil, status.Errorf(codes.Internal, "delete managed identity: %v", err)
 	}
 	if err := s.store.InsertManagedIdentity(ctx, identity); err != nil {
-		cleanupErr := s.ziti.DeleteIdentity(ctx, zitiID)
-		if cleanupErr != nil && !errors.Is(cleanupErr, ziti.ErrIdentityNotFound) {
-			log.Printf("failed to cleanup runner identity %s: %v", zitiID, cleanupErr)
-		}
+		s.cleanupZitiIdentity(ctx, zitiID, "runner identity")
 		return nil, status.Errorf(codes.Internal, "insert managed identity: %v", err)
 	}
 
@@ -322,10 +313,7 @@ func (s *Server) RequestServiceIdentity(ctx context.Context, req *zitimanagement
 
 	leaseExpiresAt := time.Now().Add(s.serviceIdentityLeaseTTL)
 	if err := s.store.InsertServiceIdentity(ctx, zitiID, serviceType, leaseExpiresAt); err != nil {
-		cleanupErr := s.ziti.DeleteIdentity(ctx, zitiID)
-		if cleanupErr != nil && !errors.Is(cleanupErr, ziti.ErrIdentityNotFound) {
-			log.Printf("failed to cleanup ziti identity %s: %v", zitiID, cleanupErr)
-		}
+		s.cleanupZitiIdentity(ctx, zitiID, "service identity")
 		return nil, status.Errorf(codes.Internal, "insert service identity: %v", err)
 	}
 

--- a/internal/server/server.go
+++ b/internal/server/server.go
@@ -19,14 +19,39 @@ import (
 	"github.com/agynio/ziti-management/internal/ziti"
 )
 
+type managedIdentityStore interface {
+	InsertManagedIdentity(ctx context.Context, identity store.ManagedIdentity) error
+	DeleteManagedIdentity(ctx context.Context, zitiIdentityID string) error
+	DeleteManagedIdentityByIdentityID(ctx context.Context, identityID uuid.UUID) error
+	ResolveIdentity(ctx context.Context, zitiIdentityID string) (store.ManagedIdentity, error)
+	ResolveIdentityByIdentityID(ctx context.Context, identityID uuid.UUID) (store.ManagedIdentity, error)
+	ListManagedIdentities(ctx context.Context, filter store.ListFilter, pageSize int32, cursor *store.PageCursor) (store.ListResult, error)
+	InsertServiceIdentity(ctx context.Context, zitiIdentityID string, serviceType store.ServiceType, leaseExpiresAt time.Time) error
+	ExtendServiceIdentityLease(ctx context.Context, zitiIdentityID string, leaseExpiresAt time.Time) error
+}
+
+type zitiClient interface {
+	CreateAgentIdentity(ctx context.Context, agentID uuid.UUID) (string, string, error)
+	CreateAndEnrollAppIdentity(ctx context.Context, appID uuid.UUID, slug string) (string, []byte, error)
+	CreateAndEnrollRunnerIdentity(ctx context.Context, runnerID uuid.UUID, roleAttributes []string) (string, []byte, error)
+	CreateAndEnrollServiceIdentity(ctx context.Context, name string, roleAttributes []string) (string, []byte, error)
+	CreateService(ctx context.Context, name string, roleAttributes []string) (string, error)
+	CreateServiceWithConfigs(ctx context.Context, name string, roleAttributes []string, hostV1 *ziti.HostV1ConfigData, interceptV1 *ziti.InterceptV1ConfigData) (string, error)
+	CreateServicePolicy(ctx context.Context, name, policyType string, identityRoles, serviceRoles []string) (string, error)
+	CreateDeviceIdentity(ctx context.Context, userIdentityID uuid.UUID, name string) (string, string, error)
+	DeleteIdentity(ctx context.Context, zitiIdentityID string) error
+	DeleteService(ctx context.Context, serviceID string) error
+	DeleteServicePolicy(ctx context.Context, policyID string) error
+}
+
 type Server struct {
 	zitimanagementv1.UnimplementedZitiManagementServiceServer
-	store                   *store.Store
-	ziti                    *ziti.Client
+	store                   managedIdentityStore
+	ziti                    zitiClient
 	serviceIdentityLeaseTTL time.Duration
 }
 
-func New(store *store.Store, zitiClient *ziti.Client, serviceIdentityLeaseTTL time.Duration) *Server {
+func New(store managedIdentityStore, zitiClient zitiClient, serviceIdentityLeaseTTL time.Duration) *Server {
 	return &Server{store: store, ziti: zitiClient, serviceIdentityLeaseTTL: serviceIdentityLeaseTTL}
 }
 
@@ -80,6 +105,13 @@ func (s *Server) CreateAppIdentity(ctx context.Context, req *zitimanagementv1.Cr
 		ZitiIdentityID: zitiID,
 		IdentityID:     appID,
 		IdentityType:   store.IdentityTypeApp,
+	}
+	if err := s.store.DeleteManagedIdentityByIdentityID(ctx, appID); err != nil {
+		cleanupErr := s.ziti.DeleteIdentity(ctx, zitiID)
+		if cleanupErr != nil && !errors.Is(cleanupErr, ziti.ErrIdentityNotFound) {
+			log.Printf("failed to cleanup ziti identity %s: %v", zitiID, cleanupErr)
+		}
+		return nil, status.Errorf(codes.Internal, "delete managed identity: %v", err)
 	}
 	if err := s.store.InsertManagedIdentity(ctx, identity); err != nil {
 		cleanupErr := s.ziti.DeleteIdentity(ctx, zitiID)
@@ -151,6 +183,13 @@ func (s *Server) CreateRunnerIdentity(ctx context.Context, req *zitimanagementv1
 		ZitiIdentityID: zitiID,
 		IdentityID:     runnerID,
 		IdentityType:   store.IdentityTypeRunner,
+	}
+	if err := s.store.DeleteManagedIdentityByIdentityID(ctx, runnerID); err != nil {
+		cleanupErr := s.ziti.DeleteIdentity(ctx, zitiID)
+		if cleanupErr != nil && !errors.Is(cleanupErr, ziti.ErrIdentityNotFound) {
+			log.Printf("failed to cleanup runner identity %s: %v", zitiID, cleanupErr)
+		}
+		return nil, status.Errorf(codes.Internal, "delete managed identity: %v", err)
 	}
 	if err := s.store.InsertManagedIdentity(ctx, identity); err != nil {
 		cleanupErr := s.ziti.DeleteIdentity(ctx, zitiID)

--- a/internal/store/store.go
+++ b/internal/store/store.go
@@ -44,6 +44,14 @@ func (s *Store) DeleteManagedIdentity(ctx context.Context, zitiIdentityID string
 	return nil
 }
 
+func (s *Store) DeleteManagedIdentityByIdentityID(ctx context.Context, identityID uuid.UUID) error {
+	_, err := s.pool.Exec(ctx, `DELETE FROM managed_identities WHERE identity_id = $1`, identityID)
+	if err != nil {
+		return fmt.Errorf("delete managed identity by identity id: %w", err)
+	}
+	return nil
+}
+
 func (s *Store) ResolveIdentity(ctx context.Context, zitiIdentityID string) (ManagedIdentity, error) {
 	row := s.pool.QueryRow(ctx, `SELECT identity_id, identity_type, ziti_service_id, created_at FROM managed_identities WHERE ziti_identity_id = $1`, zitiIdentityID)
 	identity := ManagedIdentity{ZitiIdentityID: zitiIdentityID}


### PR DESCRIPTION
## Summary
- add DeleteManagedIdentityByIdentityID to clear stale identity rows before inserts
- call identity-id cleanup in CreateAppIdentity/CreateRunnerIdentity
- add regression tests for double-create enroll flows

## Testing
- buf generate buf.build/agynio/api --template buf.gen.yaml --path agynio/api/ziti_management/v1/ziti_management.proto
- go vet ./...
- go test ./...

Closes #39