### PR TITLE
fix(ziti): use workload id for agent identity

### DIFF
--- a/internal/server/identity_reenroll_test.go
+++ b/internal/server/identity_reenroll_test.go
@@ -71,7 +71,7 @@ type fakeZitiClient struct {
 	deleteIdentityIDs []string
 }
 
-func (f *fakeZitiClient) CreateAgentIdentity(_ context.Context, _ uuid.UUID) (string, string, error) {
+func (f *fakeZitiClient) CreateAgentIdentity(_ context.Context, _, _ uuid.UUID) (string, string, error) {
 	return "", "", errors.New("unexpected create agent identity")
 }
 

--- a/internal/server/server.go
+++ b/internal/server/server.go
@@ -31,7 +31,7 @@ type managedIdentityStore interface {
 }
 
 type zitiClient interface {
-	CreateAgentIdentity(ctx context.Context, agentID uuid.UUID) (string, string, error)
+	CreateAgentIdentity(ctx context.Context, agentID, workloadID uuid.UUID) (string, string, error)
 	CreateAndEnrollAppIdentity(ctx context.Context, appID uuid.UUID, slug string) (string, []byte, error)
 	CreateAndEnrollRunnerIdentity(ctx context.Context, runnerID uuid.UUID, roleAttributes []string) (string, []byte, error)
 	CreateAndEnrollServiceIdentity(ctx context.Context, name string, roleAttributes []string) (string, []byte, error)
@@ -67,7 +67,12 @@ func (s *Server) CreateAgentIdentity(ctx context.Context, req *zitimanagementv1.
 		return nil, status.Errorf(codes.InvalidArgument, "agent_id: %v", err)
 	}
 
-	zitiID, jwt, err := s.ziti.CreateAgentIdentity(ctx, agentID)
+	workloadID, err := parseUUID(req.GetWorkloadId())
+	if err != nil {
+		return nil, status.Errorf(codes.InvalidArgument, "workload_id: %v", err)
+	}
+
+	zitiID, jwt, err := s.ziti.CreateAgentIdentity(ctx, agentID, workloadID)
 	if err != nil {
 		return nil, status.Errorf(codes.Internal, "create ziti identity: %v", err)
 	}

--- a/internal/ziti/client.go
+++ b/internal/ziti/client.go
@@ -327,15 +327,16 @@ func (c *Client) listIdentityIDsByExternalID(ctx context.Context, externalID str
 	}
 }
 
-func (c *Client) CreateAgentIdentity(ctx context.Context, agentID uuid.UUID) (string, string, error) {
+func (c *Client) CreateAgentIdentity(ctx context.Context, agentID, workloadID uuid.UUID) (string, string, error) {
 	name := fmt.Sprintf("agent-%s-%s", agentID.String(), id.ShortUUID())
 	identityType := rest_model.IdentityTypeDevice
 	isAdmin := false
 	roleAttrs := rest_model.Attributes{
 		roleAttributeAgents,
 		fmt.Sprintf("agent-%s", agentID.String()),
+		fmt.Sprintf("workload-%s", workloadID.String()),
 	}
-	externalID := agentID.String()
+	externalID := workloadID.String()
 	identityCreate := &rest_model.IdentityCreate{
 		Name:           &name,
 		Type:           &identityType,

--- a/internal/ziti/client_test.go
+++ b/internal/ziti/client_test.go
@@ -111,6 +111,7 @@ func (f *fakeServicePolicyService) DeleteServicePolicy(params *service_policy.De
 func TestCreateAgentIdentityCreatesIdentity(t *testing.T) {
 	ctx := context.Background()
 	agentID := uuid.New()
+	workloadID := uuid.New()
 	createdID := "created-id"
 	jwt := "jwt-token"
 
@@ -120,7 +121,8 @@ func TestCreateAgentIdentityCreatesIdentity(t *testing.T) {
 			return nil, nil
 		},
 		createIdentityFunc: func(params *identity.CreateIdentityParams) (*identity.CreateIdentityCreated, error) {
-			assertCreateExternalID(t, params, agentID)
+			assertCreateExternalID(t, params, workloadID)
+			assertCreateAgentRoleAttributes(t, params, agentID, workloadID)
 			return createIdentityResponse(createdID), nil
 		},
 		detailIdentityFunc: func(params *identity.DetailIdentityParams) (*identity.DetailIdentityOK, error) {
@@ -132,7 +134,7 @@ func TestCreateAgentIdentityCreatesIdentity(t *testing.T) {
 	}
 
 	client := &Client{identity: fake}
-	zitiID, token, err := client.CreateAgentIdentity(ctx, agentID)
+	zitiID, token, err := client.CreateAgentIdentity(ctx, agentID, workloadID)
 	if err != nil {
 		t.Fatalf("create agent identity: %v", err)
 	}
@@ -147,12 +149,14 @@ func TestCreateAgentIdentityCreatesIdentity(t *testing.T) {
 func TestCreateAgentIdentityCreateFailure(t *testing.T) {
 	ctx := context.Background()
 	agentID := uuid.New()
+	workloadID := uuid.New()
 	createErr := errors.New("create failed")
 	var detailCalled bool
 
 	fake := &fakeIdentityService{
 		createIdentityFunc: func(params *identity.CreateIdentityParams) (*identity.CreateIdentityCreated, error) {
-			assertCreateExternalID(t, params, agentID)
+			assertCreateExternalID(t, params, workloadID)
+			assertCreateAgentRoleAttributes(t, params, agentID, workloadID)
 			return nil, createErr
 		},
 		detailIdentityFunc: func(params *identity.DetailIdentityParams) (*identity.DetailIdentityOK, error) {
@@ -162,7 +166,7 @@ func TestCreateAgentIdentityCreateFailure(t *testing.T) {
 	}
 
 	client := &Client{identity: fake}
-	_, _, err := client.CreateAgentIdentity(ctx, agentID)
+	_, _, err := client.CreateAgentIdentity(ctx, agentID, workloadID)
 	if err == nil {
 		t.Fatalf("expected create error")
 	}
@@ -536,13 +540,28 @@ func TestCreateDeviceIdentityCreateFailure(t *testing.T) {
 	}
 }
 
-func assertCreateExternalID(t *testing.T, params *identity.CreateIdentityParams, agentID uuid.UUID) {
+func assertCreateExternalID(t *testing.T, params *identity.CreateIdentityParams, expectedID uuid.UUID) {
 	t.Helper()
 	if params == nil || params.Identity == nil || params.Identity.ExternalID == nil {
 		t.Fatalf("expected create identity external id")
 	}
-	if *params.Identity.ExternalID != agentID.String() {
-		t.Fatalf("expected external id %q, got %q", agentID.String(), *params.Identity.ExternalID)
+	if *params.Identity.ExternalID != expectedID.String() {
+		t.Fatalf("expected external id %q, got %q", expectedID.String(), *params.Identity.ExternalID)
+	}
+}
+
+func assertCreateAgentRoleAttributes(t *testing.T, params *identity.CreateIdentityParams, agentID, workloadID uuid.UUID) {
+	t.Helper()
+	if params == nil || params.Identity == nil || params.Identity.RoleAttributes == nil {
+		t.Fatalf("expected create identity role attributes")
+	}
+	expectedRoleAttributes := rest_model.Attributes{
+		roleAttributeAgents,
+		"agent-" + agentID.String(),
+		"workload-" + workloadID.String(),
+	}
+	if !reflect.DeepEqual(*params.Identity.RoleAttributes, expectedRoleAttributes) {
+		t.Fatalf("unexpected role attributes: %#v", params.Identity.RoleAttributes)
 	}
 }
 


### PR DESCRIPTION
## Summary
- extend agent identity creation to pass workload IDs through server and ziti client
- update agent identity role attributes to include workload-specific tag
- adjust ziti client tests and fakes for the new workload ID parameter

## Testing
- go vet ./...
- go test ./...

Related to agynio/agents-orchestrator#124.