### PR TITLE
feat: persist workload id

### DIFF
--- a/internal/server/identity_reenroll_test.go
+++ b/internal/server/identity_reenroll_test.go
@@ -69,10 +69,22 @@ type fakeZitiClient struct {
 	appCount          int
 	runnerCount       int
 	deleteIdentityIDs []string
+	agentCalls        []agentCall
+	createAgentErr    error
 }
 
-func (f *fakeZitiClient) CreateAgentIdentity(_ context.Context, _, _ uuid.UUID) (string, string, error) {
-	return "", "", errors.New("unexpected create agent identity")
+type agentCall struct {
+	agentID    uuid.UUID
+	workloadID uuid.UUID
+}
+
+func (f *fakeZitiClient) CreateAgentIdentity(_ context.Context, agentID, workloadID uuid.UUID) (string, string, error) {
+	call := agentCall{agentID: agentID, workloadID: workloadID}
+	f.agentCalls = append(f.agentCalls, call)
+	if f.createAgentErr != nil {
+		return "", "", f.createAgentErr
+	}
+	return fmt.Sprintf("agent-ziti-%d", len(f.agentCalls)), fmt.Sprintf("agent-jwt-%d", len(f.agentCalls)), nil
 }
 
 func (f *fakeZitiClient) CreateAndEnrollAppIdentity(_ context.Context, _ uuid.UUID, _ string) (string, []byte, error) {
@@ -263,5 +275,46 @@ func TestCreateRunnerIdentityDeleteFailureCleansUp(t *testing.T) {
 	}
 	if len(storeClient.managed) != 0 {
 		t.Fatalf("expected no managed identities persisted")
+	}
+}
+
+func TestCreateAgentIdentityStoresWorkloadID(t *testing.T) {
+	ctx := context.Background()
+	agentID := uuid.New()
+	workloadID := uuid.New()
+	storeClient := newFakeManagedIdentityStore()
+	zitiClient := &fakeZitiClient{}
+	server := New(storeClient, zitiClient, time.Minute)
+
+	request := &zitimanagementv1.CreateAgentIdentityRequest{
+		AgentId:    agentID.String(),
+		WorkloadId: workloadID.String(),
+	}
+
+	resp, err := server.CreateAgentIdentity(ctx, request)
+	if err != nil {
+		t.Fatalf("create agent identity: %v", err)
+	}
+	if resp.GetZitiIdentityId() != "agent-ziti-1" {
+		t.Fatalf("expected agent-ziti-1, got %q", resp.GetZitiIdentityId())
+	}
+	if len(zitiClient.agentCalls) != 1 {
+		t.Fatalf("expected 1 agent call, got %d", len(zitiClient.agentCalls))
+	}
+	if zitiClient.agentCalls[0].agentID != agentID {
+		t.Fatalf("expected agent id %s, got %s", agentID, zitiClient.agentCalls[0].agentID)
+	}
+	if zitiClient.agentCalls[0].workloadID != workloadID {
+		t.Fatalf("expected workload id %s, got %s", workloadID, zitiClient.agentCalls[0].workloadID)
+	}
+	stored, ok := storeClient.managed[agentID]
+	if !ok {
+		t.Fatalf("expected managed identity for %s", agentID)
+	}
+	if stored.WorkloadID == nil {
+		t.Fatalf("expected workload id to be stored")
+	}
+	if *stored.WorkloadID != workloadID {
+		t.Fatalf("expected workload id %s, got %s", workloadID, *stored.WorkloadID)
 	}
 }

--- a/internal/server/resolve_identity_test.go
+++ b/internal/server/resolve_identity_test.go
@@ -1,0 +1,74 @@
+package server
+
+import (
+	"context"
+	"errors"
+	"testing"
+	"time"
+
+	zitimanagementv1 "github.com/agynio/ziti-management/.gen/go/agynio/api/ziti_management/v1"
+	"github.com/agynio/ziti-management/internal/store"
+	"github.com/google/uuid"
+)
+
+type resolveIdentityStore struct {
+	identity store.ManagedIdentity
+}
+
+func (s *resolveIdentityStore) InsertManagedIdentity(_ context.Context, _ store.ManagedIdentity) error {
+	return errors.New("unexpected insert managed identity")
+}
+
+func (s *resolveIdentityStore) DeleteManagedIdentity(_ context.Context, _ string) error {
+	return errors.New("unexpected delete managed identity")
+}
+
+func (s *resolveIdentityStore) DeleteManagedIdentityByIdentityID(_ context.Context, _ uuid.UUID) error {
+	return errors.New("unexpected delete managed identity by identity id")
+}
+
+func (s *resolveIdentityStore) ResolveIdentity(_ context.Context, zitiIdentityID string) (store.ManagedIdentity, error) {
+	if zitiIdentityID != s.identity.ZitiIdentityID {
+		return store.ManagedIdentity{}, store.ErrManagedIdentityNotFound
+	}
+	return s.identity, nil
+}
+
+func (s *resolveIdentityStore) ResolveIdentityByIdentityID(_ context.Context, _ uuid.UUID) (store.ManagedIdentity, error) {
+	return store.ManagedIdentity{}, errors.New("unexpected resolve identity by identity id")
+}
+
+func (s *resolveIdentityStore) ListManagedIdentities(_ context.Context, _ store.ListFilter, _ int32, _ *store.PageCursor) (store.ListResult, error) {
+	return store.ListResult{}, errors.New("unexpected list managed identities")
+}
+
+func (s *resolveIdentityStore) InsertServiceIdentity(_ context.Context, _ string, _ store.ServiceType, _ time.Time) error {
+	return errors.New("unexpected insert service identity")
+}
+
+func (s *resolveIdentityStore) ExtendServiceIdentityLease(_ context.Context, _ string, _ time.Time) error {
+	return errors.New("unexpected extend service identity")
+}
+
+func TestResolveIdentityIncludesWorkloadID(t *testing.T) {
+	ctx := context.Background()
+	identityID := uuid.New()
+	workloadID := uuid.New()
+	storeClient := &resolveIdentityStore{
+		identity: store.ManagedIdentity{
+			ZitiIdentityID: "ziti-identity",
+			IdentityID:     identityID,
+			WorkloadID:     &workloadID,
+			IdentityType:   store.IdentityTypeAgent,
+		},
+	}
+	server := New(storeClient, &fakeZitiClient{}, time.Minute)
+
+	resp, err := server.ResolveIdentity(ctx, &zitimanagementv1.ResolveIdentityRequest{ZitiIdentityId: "ziti-identity"})
+	if err != nil {
+		t.Fatalf("resolve identity: %v", err)
+	}
+	if resp.GetWorkloadId() != workloadID.String() {
+		t.Fatalf("expected workload id %s, got %s", workloadID, resp.GetWorkloadId())
+	}
+}

--- a/internal/server/server.go
+++ b/internal/server/server.go
@@ -80,6 +80,7 @@ func (s *Server) CreateAgentIdentity(ctx context.Context, req *zitimanagementv1.
 	identity := store.ManagedIdentity{
 		ZitiIdentityID: zitiID,
 		IdentityID:     agentID,
+		WorkloadID:     &workloadID,
 		IdentityType:   store.IdentityTypeAgent,
 	}
 	if err := s.store.InsertManagedIdentity(ctx, identity); err != nil {
@@ -498,10 +499,15 @@ func (s *Server) ResolveIdentity(ctx context.Context, req *zitimanagementv1.Reso
 	if err != nil {
 		return nil, status.Errorf(codes.Internal, "identity_type: %v", err)
 	}
-	return &zitimanagementv1.ResolveIdentityResponse{
+	resp := &zitimanagementv1.ResolveIdentityResponse{
 		IdentityId:   identity.IdentityID.String(),
 		IdentityType: identityType,
-	}, nil
+	}
+	if identity.WorkloadID != nil {
+		workloadID := identity.WorkloadID.String()
+		resp.WorkloadId = &workloadID
+	}
+	return resp, nil
 }
 
 func (s *Server) resolveManagedIdentity(ctx context.Context, zitiID string) (store.ManagedIdentity, error) {

--- a/internal/store/store.go
+++ b/internal/store/store.go
@@ -21,9 +21,10 @@ func NewStore(pool *pgxpool.Pool) *Store {
 }
 
 func (s *Store) InsertManagedIdentity(ctx context.Context, identity ManagedIdentity) error {
-	_, err := s.pool.Exec(ctx, `INSERT INTO managed_identities (ziti_identity_id, identity_id, identity_type, ziti_service_id) VALUES ($1, $2, $3, $4)`,
+	_, err := s.pool.Exec(ctx, `INSERT INTO managed_identities (ziti_identity_id, identity_id, workload_id, identity_type, ziti_service_id) VALUES ($1, $2, $3, $4, $5)`,
 		identity.ZitiIdentityID,
 		identity.IdentityID,
+		identity.WorkloadID,
 		identity.IdentityType,
 		identity.ZitiServiceID,
 	)
@@ -53,9 +54,9 @@ func (s *Store) DeleteManagedIdentityByIdentityID(ctx context.Context, identityI
 }
 
 func (s *Store) ResolveIdentity(ctx context.Context, zitiIdentityID string) (ManagedIdentity, error) {
-	row := s.pool.QueryRow(ctx, `SELECT identity_id, identity_type, ziti_service_id, created_at FROM managed_identities WHERE ziti_identity_id = $1`, zitiIdentityID)
+	row := s.pool.QueryRow(ctx, `SELECT identity_id, workload_id, identity_type, ziti_service_id, created_at FROM managed_identities WHERE ziti_identity_id = $1`, zitiIdentityID)
 	identity := ManagedIdentity{ZitiIdentityID: zitiIdentityID}
-	if err := row.Scan(&identity.IdentityID, &identity.IdentityType, &identity.ZitiServiceID, &identity.CreatedAt); err != nil {
+	if err := row.Scan(&identity.IdentityID, &identity.WorkloadID, &identity.IdentityType, &identity.ZitiServiceID, &identity.CreatedAt); err != nil {
 		if errors.Is(err, pgx.ErrNoRows) {
 			return ManagedIdentity{}, ErrManagedIdentityNotFound
 		}
@@ -65,9 +66,9 @@ func (s *Store) ResolveIdentity(ctx context.Context, zitiIdentityID string) (Man
 }
 
 func (s *Store) ResolveIdentityByIdentityID(ctx context.Context, identityID uuid.UUID) (ManagedIdentity, error) {
-	row := s.pool.QueryRow(ctx, `SELECT ziti_identity_id, identity_type, ziti_service_id, created_at FROM managed_identities WHERE identity_id = $1`, identityID)
+	row := s.pool.QueryRow(ctx, `SELECT ziti_identity_id, workload_id, identity_type, ziti_service_id, created_at FROM managed_identities WHERE identity_id = $1`, identityID)
 	identity := ManagedIdentity{IdentityID: identityID}
-	if err := row.Scan(&identity.ZitiIdentityID, &identity.IdentityType, &identity.ZitiServiceID, &identity.CreatedAt); err != nil {
+	if err := row.Scan(&identity.ZitiIdentityID, &identity.WorkloadID, &identity.IdentityType, &identity.ZitiServiceID, &identity.CreatedAt); err != nil {
 		if errors.Is(err, pgx.ErrNoRows) {
 			return ManagedIdentity{}, ErrManagedIdentityNotFound
 		}
@@ -90,7 +91,7 @@ func (s *Store) ListManagedIdentities(ctx context.Context, filter ListFilter, pa
 		clauses = append(clauses, fmt.Sprintf("ziti_identity_id > $%d", len(args)))
 	}
 
-	query := "SELECT ziti_identity_id, identity_id, identity_type, ziti_service_id, created_at FROM managed_identities"
+	query := "SELECT ziti_identity_id, identity_id, workload_id, identity_type, ziti_service_id, created_at FROM managed_identities"
 	if len(clauses) > 0 {
 		query += " WHERE " + strings.Join(clauses, " AND ")
 	}
@@ -106,7 +107,7 @@ func (s *Store) ListManagedIdentities(ctx context.Context, filter ListFilter, pa
 	identities := make([]ManagedIdentity, 0)
 	for rows.Next() {
 		var identity ManagedIdentity
-		if err := rows.Scan(&identity.ZitiIdentityID, &identity.IdentityID, &identity.IdentityType, &identity.ZitiServiceID, &identity.CreatedAt); err != nil {
+		if err := rows.Scan(&identity.ZitiIdentityID, &identity.IdentityID, &identity.WorkloadID, &identity.IdentityType, &identity.ZitiServiceID, &identity.CreatedAt); err != nil {
 			return ListResult{}, fmt.Errorf("scan managed identity: %w", err)
 		}
 		identities = append(identities, identity)

--- a/internal/store/types.go
+++ b/internal/store/types.go
@@ -31,6 +31,7 @@ const (
 type ManagedIdentity struct {
 	ZitiIdentityID string
 	IdentityID     uuid.UUID
+	WorkloadID     *uuid.UUID
 	IdentityType   IdentityType
 	ZitiServiceID  *string
 	CreatedAt      time.Time

--- a/migrations/0007_add_workload_id.sql
+++ b/migrations/0007_add_workload_id.sql
@@ -1,0 +1,1 @@
+ALTER TABLE managed_identities ADD COLUMN workload_id UUID;


### PR DESCRIPTION
## Summary
- add workload_id column for managed agent identities
- persist workload_id on agent identity creation and return it on resolve
- cover workload_id persistence and resolve response in tests

## Testing
- buf generate ../api --template buf.gen.yaml
- go vet ./...
- go test ./...

## Related
- agynio/gateway#152