### PR TITLE
fix: gate identity name resolve

### DIFF
--- a/cmd/ziti-management/main.go
+++ b/cmd/ziti-management/main.go
@@ -62,7 +62,7 @@ func run() error {
 
 	storeClient := store.NewStore(pool)
 	grpcServer := grpc.NewServer()
-	zitimanagementv1.RegisterZitiManagementServiceServer(grpcServer, server.New(storeClient, zitiClient, cfg.ServiceIdentityLeaseTTL))
+	zitimanagementv1.RegisterZitiManagementServiceServer(grpcServer, server.New(storeClient, zitiClient, cfg.ServiceIdentityLeaseTTL, cfg.ZitiIdentityNameResolve))
 
 	lis, err := net.Listen("tcp", cfg.GRPCAddress)
 	if err != nil {

--- a/internal/config/config.go
+++ b/internal/config/config.go
@@ -3,6 +3,7 @@ package config
 import (
 	"fmt"
 	"os"
+	"strconv"
 	"time"
 )
 
@@ -14,6 +15,7 @@ type Config struct {
 	ZitiKeyFile               string
 	ZitiCAFile                string
 	ZitiEnrollmentJWTFile     string
+	ZitiIdentityNameResolve   bool
 	ServiceIdentityLeaseTTL   time.Duration
 	ServiceIdentityGCInterval time.Duration
 }
@@ -45,6 +47,11 @@ func FromEnv() (Config, error) {
 		return Config{}, fmt.Errorf("ZITI_CA_FILE must be set")
 	}
 	cfg.ZitiEnrollmentJWTFile = os.Getenv("ZITI_ENROLLMENT_JWT_FILE")
+	resolveByName, err := boolFromEnv("ZITI_IDENTITY_NAME_RESOLVE", false)
+	if err != nil {
+		return Config{}, err
+	}
+	cfg.ZitiIdentityNameResolve = resolveByName
 	leaseTTL, err := durationFromEnv("SERVICE_IDENTITY_LEASE_TTL", 5*time.Minute)
 	if err != nil {
 		return Config{}, err
@@ -69,6 +76,18 @@ func durationFromEnv(key string, defaultValue time.Duration) (time.Duration, err
 	}
 	if parsed <= 0 {
 		return 0, fmt.Errorf("%s must be greater than 0", key)
+	}
+	return parsed, nil
+}
+
+func boolFromEnv(key string, defaultValue bool) (bool, error) {
+	value := os.Getenv(key)
+	if value == "" {
+		return defaultValue, nil
+	}
+	parsed, err := strconv.ParseBool(value)
+	if err != nil {
+		return false, fmt.Errorf("%s must be a valid boolean: %w", key, err)
 	}
 	return parsed, nil
 }

--- a/internal/server/identity_reenroll_test.go
+++ b/internal/server/identity_reenroll_test.go
@@ -137,7 +137,7 @@ func TestCreateAppIdentityAllowsReenroll(t *testing.T) {
 	appID := uuid.New()
 	storeClient := newFakeManagedIdentityStore()
 	zitiClient := &fakeZitiClient{}
-	server := New(storeClient, zitiClient, time.Minute)
+	server := New(storeClient, zitiClient, time.Minute, false)
 
 	request := &zitimanagementv1.CreateAppIdentityRequest{
 		IdentityId: appID.String(),
@@ -180,7 +180,7 @@ func TestCreateAppIdentityDeleteFailureCleansUp(t *testing.T) {
 	storeClient := newFakeManagedIdentityStore()
 	storeClient.deleteByIdentityIDErr = errors.New("delete failed")
 	zitiClient := &fakeZitiClient{}
-	server := New(storeClient, zitiClient, time.Minute)
+	server := New(storeClient, zitiClient, time.Minute, false)
 
 	request := &zitimanagementv1.CreateAppIdentityRequest{
 		IdentityId: appID.String(),
@@ -210,7 +210,7 @@ func TestCreateRunnerIdentityAllowsReenroll(t *testing.T) {
 	runnerID := uuid.New()
 	storeClient := newFakeManagedIdentityStore()
 	zitiClient := &fakeZitiClient{}
-	server := New(storeClient, zitiClient, time.Minute)
+	server := New(storeClient, zitiClient, time.Minute, false)
 
 	request := &zitimanagementv1.CreateRunnerIdentityRequest{
 		RunnerId:       runnerID.String(),
@@ -253,7 +253,7 @@ func TestCreateRunnerIdentityDeleteFailureCleansUp(t *testing.T) {
 	storeClient := newFakeManagedIdentityStore()
 	storeClient.deleteByIdentityIDErr = errors.New("delete failed")
 	zitiClient := &fakeZitiClient{}
-	server := New(storeClient, zitiClient, time.Minute)
+	server := New(storeClient, zitiClient, time.Minute, false)
 
 	request := &zitimanagementv1.CreateRunnerIdentityRequest{
 		RunnerId:       runnerID.String(),
@@ -284,7 +284,7 @@ func TestCreateAgentIdentityStoresWorkloadID(t *testing.T) {
 	workloadID := uuid.New()
 	storeClient := newFakeManagedIdentityStore()
 	zitiClient := &fakeZitiClient{}
-	server := New(storeClient, zitiClient, time.Minute)
+	server := New(storeClient, zitiClient, time.Minute, false)
 
 	request := &zitimanagementv1.CreateAgentIdentityRequest{
 		AgentId:    agentID.String(),

--- a/internal/server/resolve_identity_test.go
+++ b/internal/server/resolve_identity_test.go
@@ -3,12 +3,15 @@ package server
 import (
 	"context"
 	"errors"
+	"fmt"
 	"testing"
 	"time"
 
 	zitimanagementv1 "github.com/agynio/ziti-management/.gen/go/agynio/api/ziti_management/v1"
 	"github.com/agynio/ziti-management/internal/store"
 	"github.com/google/uuid"
+	"google.golang.org/grpc/codes"
+	"google.golang.org/grpc/status"
 )
 
 type resolveIdentityStore struct {
@@ -50,6 +53,55 @@ func (s *resolveIdentityStore) ExtendServiceIdentityLease(_ context.Context, _ s
 	return errors.New("unexpected extend service identity")
 }
 
+type resolveIdentityFallbackStore struct {
+	resolveResult   store.ManagedIdentity
+	resolveErr      error
+	resolveByResult store.ManagedIdentity
+	resolveByErr    error
+	resolveByCalled bool
+	resolveByInput  uuid.UUID
+}
+
+func (s *resolveIdentityFallbackStore) InsertManagedIdentity(_ context.Context, _ store.ManagedIdentity) error {
+	return errors.New("unexpected insert managed identity")
+}
+
+func (s *resolveIdentityFallbackStore) DeleteManagedIdentity(_ context.Context, _ string) error {
+	return errors.New("unexpected delete managed identity")
+}
+
+func (s *resolveIdentityFallbackStore) DeleteManagedIdentityByIdentityID(_ context.Context, _ uuid.UUID) error {
+	return errors.New("unexpected delete managed identity by identity id")
+}
+
+func (s *resolveIdentityFallbackStore) ResolveIdentity(_ context.Context, _ string) (store.ManagedIdentity, error) {
+	if s.resolveErr != nil {
+		return store.ManagedIdentity{}, s.resolveErr
+	}
+	return s.resolveResult, nil
+}
+
+func (s *resolveIdentityFallbackStore) ResolveIdentityByIdentityID(_ context.Context, identityID uuid.UUID) (store.ManagedIdentity, error) {
+	s.resolveByCalled = true
+	s.resolveByInput = identityID
+	if s.resolveByErr != nil {
+		return store.ManagedIdentity{}, s.resolveByErr
+	}
+	return s.resolveByResult, nil
+}
+
+func (s *resolveIdentityFallbackStore) ListManagedIdentities(_ context.Context, _ store.ListFilter, _ int32, _ *store.PageCursor) (store.ListResult, error) {
+	return store.ListResult{}, errors.New("unexpected list managed identities")
+}
+
+func (s *resolveIdentityFallbackStore) InsertServiceIdentity(_ context.Context, _ string, _ store.ServiceType, _ time.Time) error {
+	return errors.New("unexpected insert service identity")
+}
+
+func (s *resolveIdentityFallbackStore) ExtendServiceIdentityLease(_ context.Context, _ string, _ time.Time) error {
+	return errors.New("unexpected extend service identity")
+}
+
 func TestResolveIdentityIncludesWorkloadID(t *testing.T) {
 	ctx := context.Background()
 	identityID := uuid.New()
@@ -62,7 +114,7 @@ func TestResolveIdentityIncludesWorkloadID(t *testing.T) {
 			IdentityType:   store.IdentityTypeAgent,
 		},
 	}
-	server := New(storeClient, &fakeZitiClient{}, time.Minute)
+	server := New(storeClient, &fakeZitiClient{}, time.Minute, false)
 
 	resp, err := server.ResolveIdentity(ctx, &zitimanagementv1.ResolveIdentityRequest{ZitiIdentityId: "ziti-identity"})
 	if err != nil {
@@ -70,5 +122,67 @@ func TestResolveIdentityIncludesWorkloadID(t *testing.T) {
 	}
 	if resp.GetWorkloadId() != workloadID.String() {
 		t.Fatalf("expected workload id %s, got %s", workloadID, resp.GetWorkloadId())
+	}
+}
+
+func TestResolveIdentityNameFallbackDisabled(t *testing.T) {
+	ctx := context.Background()
+	storeClient := &resolveIdentityFallbackStore{
+		resolveErr:   store.ErrManagedIdentityNotFound,
+		resolveByErr: errors.New("unexpected resolve identity by identity id"),
+	}
+	server := New(storeClient, &fakeZitiClient{}, time.Minute, false)
+
+	_, err := server.ResolveIdentity(ctx, &zitimanagementv1.ResolveIdentityRequest{ZitiIdentityId: fmt.Sprintf("agent-%s-suffix", uuid.New())})
+	if status.Code(err) != codes.NotFound {
+		t.Fatalf("expected not found, got %v", err)
+	}
+	if storeClient.resolveByCalled {
+		t.Fatalf("expected no resolve by identity id call")
+	}
+}
+
+func TestResolveIdentityNameFallbackEnabled(t *testing.T) {
+	ctx := context.Background()
+	agentID := uuid.New()
+	storeClient := &resolveIdentityFallbackStore{
+		resolveErr: store.ErrManagedIdentityNotFound,
+		resolveByResult: store.ManagedIdentity{
+			ZitiIdentityID: "ziti-identity",
+			IdentityID:     agentID,
+			IdentityType:   store.IdentityTypeAgent,
+		},
+	}
+	server := New(storeClient, &fakeZitiClient{}, time.Minute, true)
+
+	resp, err := server.ResolveIdentity(ctx, &zitimanagementv1.ResolveIdentityRequest{ZitiIdentityId: fmt.Sprintf("agent-%s-suffix", agentID)})
+	if err != nil {
+		t.Fatalf("resolve identity: %v", err)
+	}
+	if resp.GetIdentityId() != agentID.String() {
+		t.Fatalf("expected identity id %s, got %s", agentID, resp.GetIdentityId())
+	}
+	if !storeClient.resolveByCalled {
+		t.Fatalf("expected resolve by identity id call")
+	}
+	if storeClient.resolveByInput != agentID {
+		t.Fatalf("expected resolve by identity id %s, got %s", agentID, storeClient.resolveByInput)
+	}
+}
+
+func TestResolveIdentityNameFallbackSkipsNonMatching(t *testing.T) {
+	ctx := context.Background()
+	storeClient := &resolveIdentityFallbackStore{
+		resolveErr:   store.ErrManagedIdentityNotFound,
+		resolveByErr: errors.New("unexpected resolve identity by identity id"),
+	}
+	server := New(storeClient, &fakeZitiClient{}, time.Minute, true)
+
+	_, err := server.ResolveIdentity(ctx, &zitimanagementv1.ResolveIdentityRequest{ZitiIdentityId: "agent-not-a-uuid"})
+	if status.Code(err) != codes.NotFound {
+		t.Fatalf("expected not found, got %v", err)
+	}
+	if storeClient.resolveByCalled {
+		t.Fatalf("expected no resolve by identity id call")
 	}
 }

--- a/internal/server/server.go
+++ b/internal/server/server.go
@@ -49,6 +49,7 @@ type Server struct {
 	store                   managedIdentityStore
 	ziti                    zitiClient
 	serviceIdentityLeaseTTL time.Duration
+	resolveIdentityName     bool
 }
 
 func (s *Server) cleanupZitiIdentity(ctx context.Context, zitiID, label string) {
@@ -57,8 +58,13 @@ func (s *Server) cleanupZitiIdentity(ctx context.Context, zitiID, label string) 
 	}
 }
 
-func New(store managedIdentityStore, zitiClient zitiClient, serviceIdentityLeaseTTL time.Duration) *Server {
-	return &Server{store: store, ziti: zitiClient, serviceIdentityLeaseTTL: serviceIdentityLeaseTTL}
+func New(store managedIdentityStore, zitiClient zitiClient, serviceIdentityLeaseTTL time.Duration, resolveIdentityName bool) *Server {
+	return &Server{
+		store:                   store,
+		ziti:                    zitiClient,
+		serviceIdentityLeaseTTL: serviceIdentityLeaseTTL,
+		resolveIdentityName:     resolveIdentityName,
+	}
 }
 
 func (s *Server) CreateAgentIdentity(ctx context.Context, req *zitimanagementv1.CreateAgentIdentityRequest) (*zitimanagementv1.CreateAgentIdentityResponse, error) {
@@ -493,8 +499,44 @@ func (s *Server) ResolveIdentity(ctx context.Context, req *zitimanagementv1.Reso
 	}
 	identity, err := s.store.ResolveIdentity(ctx, zitiID)
 	if err != nil {
+		if s.resolveIdentityName && errors.Is(err, store.ErrManagedIdentityNotFound) {
+			agentID, ok := parseAgentIdentityName(zitiID)
+			if ok {
+				identity, err = s.store.ResolveIdentityByIdentityID(ctx, agentID)
+				if err != nil {
+					return nil, toStatusError(err)
+				}
+				return resolveIdentityResponse(identity)
+			}
+		}
 		return nil, toStatusError(err)
 	}
+	return resolveIdentityResponse(identity)
+}
+
+const agentIdentityNamePrefix = "agent-"
+const agentIdentityUUIDLength = 36
+
+func parseAgentIdentityName(value string) (uuid.UUID, bool) {
+	if !strings.HasPrefix(value, agentIdentityNamePrefix) {
+		return uuid.UUID{}, false
+	}
+	trimmed := value[len(agentIdentityNamePrefix):]
+	if len(trimmed) < agentIdentityUUIDLength {
+		return uuid.UUID{}, false
+	}
+	candidate := trimmed[:agentIdentityUUIDLength]
+	if len(trimmed) > agentIdentityUUIDLength && trimmed[agentIdentityUUIDLength] != '-' {
+		return uuid.UUID{}, false
+	}
+	agentID, err := uuid.Parse(candidate)
+	if err != nil {
+		return uuid.UUID{}, false
+	}
+	return agentID, true
+}
+
+func resolveIdentityResponse(identity store.ManagedIdentity) (*zitimanagementv1.ResolveIdentityResponse, error) {
 	identityType, err := toProtoIdentityType(identity.IdentityType)
 	if err != nil {
 		return nil, status.Errorf(codes.Internal, "identity_type: %v", err)


### PR DESCRIPTION
## Summary
- add ZITI_IDENTITY_NAME_RESOLVE config and thread it into the server
- restore agent identity-name fallback in ResolveIdentity behind the flag
- cover fallback enabled/disabled behavior with tests

## Testing
- buf generate buf.build/agynio/api --path agynio/api/ziti_management/v1
- go vet ./...
- go test ./...

Refs #46