### PR TITLE
feat: add tracing service type

### DIFF
--- a/internal/server/converter.go
+++ b/internal/server/converter.go
@@ -49,6 +49,8 @@ func fromProtoServiceType(value zitimanagementv1.ServiceType) (store.ServiceType
 		return store.ServiceTypeOrchestrator, nil
 	case zitimanagementv1.ServiceType_SERVICE_TYPE_LLM_PROXY:
 		return store.ServiceTypeLLMProxy, nil
+	case zitimanagementv1.ServiceType_SERVICE_TYPE_TRACING:
+		return store.ServiceTypeTracing, nil
 	case zitimanagementv1.ServiceType_SERVICE_TYPE_UNSPECIFIED:
 		return store.ServiceTypeUnspecified, fmt.Errorf("service type unspecified")
 	default:

--- a/internal/server/converter_test.go
+++ b/internal/server/converter_test.go
@@ -34,6 +34,11 @@ func TestFromProtoServiceType(t *testing.T) {
 			want:  store.ServiceTypeLLMProxy,
 		},
 		{
+			name:  "tracing",
+			input: zitimanagementv1.ServiceType_SERVICE_TYPE_TRACING,
+			want:  store.ServiceTypeTracing,
+		},
+		{
 			name:    "unspecified",
 			input:   zitimanagementv1.ServiceType_SERVICE_TYPE_UNSPECIFIED,
 			want:    store.ServiceTypeUnspecified,

--- a/internal/server/server.go
+++ b/internal/server/server.go
@@ -572,6 +572,8 @@ func serviceIdentityConfig(serviceType store.ServiceType) (string, []string, err
 		return fmt.Sprintf("svc-orchestrator-%s", suffix), []string{"orchestrators"}, nil
 	case store.ServiceTypeLLMProxy:
 		return fmt.Sprintf("svc-llm-proxy-%s", suffix), []string{"llm-proxy-hosts"}, nil
+	case store.ServiceTypeTracing:
+		return fmt.Sprintf("svc-tracing-%s", suffix), []string{"tracing-hosts"}, nil
 	case store.ServiceTypeUnspecified:
 		return "", nil, fmt.Errorf("service type unspecified")
 	default:

--- a/internal/server/server_test.go
+++ b/internal/server/server_test.go
@@ -23,6 +23,12 @@ func TestServiceIdentityConfig(t *testing.T) {
 			wantRoles:  []string{"llm-proxy-hosts"},
 		},
 		{
+			name:       "tracing",
+			service:    store.ServiceTypeTracing,
+			wantPrefix: "svc-tracing-",
+			wantRoles:  []string{"tracing-hosts"},
+		},
+		{
 			name:    "unspecified",
 			service: store.ServiceTypeUnspecified,
 			wantErr: "service type unspecified",

--- a/internal/store/types.go
+++ b/internal/store/types.go
@@ -26,6 +26,7 @@ const (
 	ServiceTypeGateway      ServiceType = 1
 	ServiceTypeOrchestrator ServiceType = 2
 	ServiceTypeLLMProxy     ServiceType = 4
+	ServiceTypeTracing      ServiceType = 5
 )
 
 type ManagedIdentity struct {


### PR DESCRIPTION
## Summary
- add tracing service type constant and mappings
- update service identity config for tracing roles
- extend tests for tracing service type

## Testing
- buf generate buf.build/agynio/api --path agynio/api/ziti_management/v1
- go vet ./...
- go test ./...

Related to #10