### PR TITLE
fix(ziti): resolve config type ids

### DIFF
--- a/internal/ziti/client.go
+++ b/internal/ziti/client.go
@@ -49,7 +49,9 @@ type serviceService interface {
 
 type configService interface {
 	CreateConfig(params *config.CreateConfigParams, authInfo runtime.ClientAuthInfoWriter, opts ...config.ClientOption) (*config.CreateConfigCreated, error)
+	CreateConfigType(params *config.CreateConfigTypeParams, authInfo runtime.ClientAuthInfoWriter, opts ...config.ClientOption) (*config.CreateConfigTypeCreated, error)
 	DeleteConfig(params *config.DeleteConfigParams, authInfo runtime.ClientAuthInfoWriter, opts ...config.ClientOption) (*config.DeleteConfigOK, error)
+	ListConfigTypes(params *config.ListConfigTypesParams, authInfo runtime.ClientAuthInfoWriter, opts ...config.ClientOption) (*config.ListConfigTypesOK, error)
 }
 
 type servicePolicyService interface {
@@ -58,16 +60,18 @@ type servicePolicyService interface {
 }
 
 type Client struct {
-	mu               sync.Mutex
-	identity         identityService
-	service          serviceService
-	config           configService
-	servicePolicy    servicePolicyService
-	controllerURL    string
-	certFile         string
-	keyFile          string
-	caFile           string
-	reauthenticateFn func() error
+	mu                sync.Mutex
+	identity          identityService
+	service           serviceService
+	config            configService
+	servicePolicy     servicePolicyService
+	controllerURL     string
+	certFile          string
+	keyFile           string
+	caFile            string
+	reauthenticateFn  func() error
+	configTypeIDs     map[string]string
+	configTypesLoaded bool
 }
 
 func NewClient(controllerURL, certFile, keyFile, caFile string) (*Client, error) {
@@ -400,7 +404,7 @@ func (c *Client) CreateServiceWithConfigs(ctx context.Context, name string, role
 			"address":  hostV1.Address,
 			"port":     hostV1.Port,
 		}
-		configID, err := c.createConfig(ctx, "host.v1", fmt.Sprintf("%s-host-v1", name), data)
+		configID, err := c.createConfig(ctx, hostV1ConfigType, fmt.Sprintf("%s-host-v1", name), data)
 		if err != nil {
 			return "", err
 		}
@@ -419,7 +423,7 @@ func (c *Client) CreateServiceWithConfigs(ctx context.Context, name string, role
 			"addresses":  interceptV1.Addresses,
 			"portRanges": portRanges,
 		}
-		configID, err := c.createConfig(ctx, "intercept.v1", fmt.Sprintf("%s-intercept-v1", name), data)
+		configID, err := c.createConfig(ctx, interceptV1ConfigType, fmt.Sprintf("%s-intercept-v1", name), data)
 		if err != nil {
 			return "", c.cleanupConfigs(ctx, configIDs, err)
 		}
@@ -456,7 +460,118 @@ func (c *Client) createService(ctx context.Context, name string, roleAttributes 
 	})
 }
 
-func (c *Client) createConfig(ctx context.Context, configTypeID, name string, data map[string]any) (string, error) {
+func (c *Client) configTypeID(ctx context.Context, name string) (string, error) {
+	if name == "" {
+		return "", errors.New("config type name is empty")
+	}
+	if id, ok, loaded := c.cachedConfigTypeID(name); ok {
+		return id, nil
+	} else if !loaded {
+		if err := c.refreshConfigTypes(ctx); err != nil {
+			return "", err
+		}
+		if id, ok, _ := c.cachedConfigTypeID(name); ok {
+			return id, nil
+		}
+	}
+
+	schema, ok := configTypeSchema(name)
+	if !ok {
+		return "", fmt.Errorf("config type %q not found", name)
+	}
+	if err := c.createConfigType(ctx, name, schema); err != nil {
+		return "", err
+	}
+	if err := c.refreshConfigTypes(ctx); err != nil {
+		return "", err
+	}
+	if id, ok, _ := c.cachedConfigTypeID(name); ok {
+		return id, nil
+	}
+	return "", fmt.Errorf("config type %q not found after create", name)
+}
+
+func (c *Client) cachedConfigTypeID(name string) (string, bool, bool) {
+	c.mu.Lock()
+	defer c.mu.Unlock()
+	if c.configTypeIDs == nil {
+		return "", false, c.configTypesLoaded
+	}
+	id, ok := c.configTypeIDs[name]
+	return id, ok, c.configTypesLoaded
+}
+
+func (c *Client) refreshConfigTypes(ctx context.Context) error {
+	configTypes, err := c.listConfigTypes(ctx)
+	if err != nil {
+		return err
+	}
+
+	configTypeIDs := make(map[string]string, len(configTypes))
+	for _, configType := range configTypes {
+		if configType == nil || configType.Name == nil || configType.ID == nil {
+			continue
+		}
+		configTypeIDs[*configType.Name] = *configType.ID
+	}
+
+	c.mu.Lock()
+	c.configTypeIDs = configTypeIDs
+	c.configTypesLoaded = true
+	c.mu.Unlock()
+	return nil
+}
+
+func (c *Client) listConfigTypes(ctx context.Context) ([]*rest_model.ConfigTypeDetail, error) {
+	params := config.NewListConfigTypesParamsWithContext(ctx)
+	var payload *rest_model.ListConfigTypesEnvelope
+	err := c.withReauth(func() error {
+		configClient := c.configClient()
+		listed, callErr := configClient.ListConfigTypes(params, nil)
+		if callErr != nil {
+			return callErr
+		}
+		if listed == nil {
+			payload = nil
+			return nil
+		}
+		payload = listed.Payload
+		return nil
+	})
+	if err != nil {
+		return nil, fmt.Errorf("list ziti config types: %w", err)
+	}
+	if payload == nil {
+		return nil, errors.New("list ziti config types response missing data")
+	}
+	return payload.Data, nil
+}
+
+func (c *Client) createConfigType(ctx context.Context, name string, schema json.RawMessage) error {
+	params := config.NewCreateConfigTypeParamsWithContext(ctx)
+	params.ConfigType = &rest_model.ConfigTypeCreate{
+		Name:   &name,
+		Schema: schema,
+	}
+	_, err := c.createWithReauth("config type", func() (*rest_model.CreateEnvelope, error) {
+		configClient := c.configClient()
+		created, callErr := configClient.CreateConfigType(params, nil)
+		if callErr != nil {
+			return nil, callErr
+		}
+		if created == nil {
+			return nil, nil
+		}
+		return created.Payload, nil
+	})
+	return err
+}
+
+func (c *Client) createConfig(ctx context.Context, configTypeName, name string, data map[string]any) (string, error) {
+	configTypeID, err := c.configTypeID(ctx, configTypeName)
+	if err != nil {
+		return "", fmt.Errorf("resolve config type %q: %w", configTypeName, err)
+	}
 	params := config.NewCreateConfigParamsWithContext(ctx)
 	params.Config = &rest_model.ConfigCreate{
 		ConfigTypeID: &configTypeID,

--- a/internal/ziti/client.go
+++ b/internal/ziti/client.go
@@ -465,14 +465,17 @@ func (c *Client) configTypeID(ctx context.Context, name string) (string, error) 
 		return "", errors.New("config type name is empty")
 	}
 	if id, ok, loaded := c.cachedConfigTypeID(name); ok {
-		return id, nil
+		return normalizeConfigTypeID(name, id), nil
 	} else if !loaded {
 		if err := c.refreshConfigTypes(ctx); err != nil {
 			return "", err
 		}
 		if id, ok, _ := c.cachedConfigTypeID(name); ok {
-			return id, nil
+			return normalizeConfigTypeID(name, id), nil
 		}
+	}
+	if knownID, ok := knownConfigTypeID(name); ok {
+		return knownID, nil
 	}
 
 	schema, ok := configTypeSchema(name)
@@ -486,7 +489,7 @@ func (c *Client) configTypeID(ctx context.Context, name string) (string, error) 
 		return "", err
 	}
 	if id, ok, _ := c.cachedConfigTypeID(name); ok {
-		return id, nil
+		return normalizeConfigTypeID(name, id), nil
 	}
 	return "", fmt.Errorf("config type %q not found after create", name)
 }

--- a/internal/ziti/client_test.go
+++ b/internal/ziti/client_test.go
@@ -248,8 +248,8 @@ func TestCreateServiceWithConfigs(t *testing.T) {
 			}},
 		}
 		configIDs := []string{"host-config", "intercept-config"}
-		hostTypeID := "host-type-id"
-		interceptTypeID := "intercept-type-id"
+		hostTypeID := hostV1ConfigTypeID
+		interceptTypeID := interceptV1ConfigTypeID
 		hostTypeName := hostV1ConfigType
 		interceptTypeName := interceptV1ConfigType
 		serviceID := "service-id"
@@ -365,8 +365,8 @@ func TestCreateServiceWithConfigs(t *testing.T) {
 		serviceErr := errors.New("service create failed")
 		deleted := make([]string, 0, 2)
 		configIDs := []string{"host-config", "intercept-config"}
-		hostTypeID := "host-type-id"
-		interceptTypeID := "intercept-type-id"
+		hostTypeID := hostV1ConfigTypeID
+		interceptTypeID := interceptV1ConfigTypeID
 		hostTypeName := hostV1ConfigType
 		interceptTypeName := interceptV1ConfigType
 		callIndex := 0

--- a/internal/ziti/client_test.go
+++ b/internal/ziti/client_test.go
@@ -71,8 +71,10 @@ func (f *fakeServiceService) DeleteService(params *service.DeleteServiceParams, 
 }
 
 type fakeConfigService struct {
-	createConfigFunc func(params *config.CreateConfigParams) (*config.CreateConfigCreated, error)
-	deleteConfigFunc func(params *config.DeleteConfigParams) (*config.DeleteConfigOK, error)
+	createConfigFunc     func(params *config.CreateConfigParams) (*config.CreateConfigCreated, error)
+	createConfigTypeFunc func(params *config.CreateConfigTypeParams) (*config.CreateConfigTypeCreated, error)
+	deleteConfigFunc     func(params *config.DeleteConfigParams) (*config.DeleteConfigOK, error)
+	listConfigTypesFunc  func(params *config.ListConfigTypesParams) (*config.ListConfigTypesOK, error)
 }
 
 func (f *fakeConfigService) CreateConfig(params *config.CreateConfigParams, _ runtime.ClientAuthInfoWriter, _ ...config.ClientOption) (*config.CreateConfigCreated, error) {
@@ -82,11 +84,25 @@ func (f *fakeConfigService) CreateConfig(params *config.CreateConfigParams, _ ru
 	return f.createConfigFunc(params)
 }
 
+func (f *fakeConfigService) CreateConfigType(params *config.CreateConfigTypeParams, _ runtime.ClientAuthInfoWriter, _ ...config.ClientOption) (*config.CreateConfigTypeCreated, error) {
+	if f.createConfigTypeFunc == nil {
+		return nil, errors.New("create config type not stubbed")
+	}
+	return f.createConfigTypeFunc(params)
+}
+
 func (f *fakeConfigService) DeleteConfig(params *config.DeleteConfigParams, _ runtime.ClientAuthInfoWriter, _ ...config.ClientOption) (*config.DeleteConfigOK, error) {
 	if f.deleteConfigFunc == nil {
 		return nil, errors.New("delete config not stubbed")
 	}
 	return f.deleteConfigFunc(params)
+}
+
+func (f *fakeConfigService) ListConfigTypes(params *config.ListConfigTypesParams, _ runtime.ClientAuthInfoWriter, _ ...config.ClientOption) (*config.ListConfigTypesOK, error) {
+	if f.listConfigTypesFunc == nil {
+		return nil, errors.New("list config types not stubbed")
+	}
+	return f.listConfigTypesFunc(params)
 }
 
 type fakeServicePolicyService struct {
@@ -232,6 +248,10 @@ func TestCreateServiceWithConfigs(t *testing.T) {
 			}},
 		}
 		configIDs := []string{"host-config", "intercept-config"}
+		hostTypeID := "host-type-id"
+		interceptTypeID := "intercept-type-id"
+		hostTypeName := hostV1ConfigType
+		interceptTypeName := interceptV1ConfigType
 		serviceID := "service-id"
 		callIndex := 0
 
@@ -250,7 +270,7 @@ func TestCreateServiceWithConfigs(t *testing.T) {
 
 				switch callIndex {
 				case 0:
-					if *params.Config.ConfigTypeID != "host.v1" {
+					if *params.Config.ConfigTypeID != hostTypeID {
 						t.Fatalf("unexpected config type: %s", *params.Config.ConfigTypeID)
 					}
 					if *params.Config.Name != "svc-host-v1" {
@@ -265,7 +285,7 @@ func TestCreateServiceWithConfigs(t *testing.T) {
 						t.Fatalf("unexpected host config data: %#v", data)
 					}
 				case 1:
-					if *params.Config.ConfigTypeID != "intercept.v1" {
+					if *params.Config.ConfigTypeID != interceptTypeID {
 						t.Fatalf("unexpected config type: %s", *params.Config.ConfigTypeID)
 					}
 					if *params.Config.Name != "svc-intercept-v1" {
@@ -288,6 +308,25 @@ func TestCreateServiceWithConfigs(t *testing.T) {
 				configID := configIDs[callIndex]
 				callIndex++
 				return createConfigResponse(configID), nil
+			},
+			createConfigTypeFunc: func(params *config.CreateConfigTypeParams) (*config.CreateConfigTypeCreated, error) {
+				t.Fatalf("create config type should not be called: %#v", params)
+				return nil, nil
+			},
+			listConfigTypesFunc: func(params *config.ListConfigTypesParams) (*config.ListConfigTypesOK, error) {
+				return &config.ListConfigTypesOK{Payload: &rest_model.ListConfigTypesEnvelope{
+					Data: rest_model.ConfigTypeList{
+						{
+							BaseEntity: rest_model.BaseEntity{ID: &hostTypeID},
+							Name:       &hostTypeName,
+						},
+						{
+							BaseEntity: rest_model.BaseEntity{ID: &interceptTypeID},
+							Name:       &interceptTypeName,
+						},
+					},
+					Meta: &rest_model.Meta{},
+				}}, nil
 			},
 		}
 
@@ -326,6 +365,10 @@ func TestCreateServiceWithConfigs(t *testing.T) {
 		serviceErr := errors.New("service create failed")
 		deleted := make([]string, 0, 2)
 		configIDs := []string{"host-config", "intercept-config"}
+		hostTypeID := "host-type-id"
+		interceptTypeID := "intercept-type-id"
+		hostTypeName := hostV1ConfigType
+		interceptTypeName := interceptV1ConfigType
 		callIndex := 0
 
 		fakeConfig := &fakeConfigService{
@@ -334,12 +377,31 @@ func TestCreateServiceWithConfigs(t *testing.T) {
 				callIndex++
 				return createConfigResponse(configID), nil
 			},
+			createConfigTypeFunc: func(params *config.CreateConfigTypeParams) (*config.CreateConfigTypeCreated, error) {
+				t.Fatalf("create config type should not be called: %#v", params)
+				return nil, nil
+			},
 			deleteConfigFunc: func(params *config.DeleteConfigParams) (*config.DeleteConfigOK, error) {
 				if params == nil {
 					t.Fatalf("expected delete config params")
 				}
 				deleted = append(deleted, params.ID)
 				return &config.DeleteConfigOK{}, nil
+			},
+			listConfigTypesFunc: func(params *config.ListConfigTypesParams) (*config.ListConfigTypesOK, error) {
+				return &config.ListConfigTypesOK{Payload: &rest_model.ListConfigTypesEnvelope{
+					Data: rest_model.ConfigTypeList{
+						{
+							BaseEntity: rest_model.BaseEntity{ID: &hostTypeID},
+							Name:       &hostTypeName,
+						},
+						{
+							BaseEntity: rest_model.BaseEntity{ID: &interceptTypeID},
+							Name:       &interceptTypeName,
+						},
+					},
+					Meta: &rest_model.Meta{},
+				}}, nil
 			},
 		}
 

--- a/internal/ziti/config_types.go
+++ b/internal/ziti/config_types.go
@@ -6,8 +6,10 @@ import (
 )
 
 const (
-	hostV1ConfigType      = "host.v1"
-	interceptV1ConfigType = "intercept.v1"
+	hostV1ConfigType        = "host.v1"
+	interceptV1ConfigType   = "intercept.v1"
+	hostV1ConfigTypeID      = "NH5p4FpGR"
+	interceptV1ConfigTypeID = "g7cIWbcGg"
 )
 
 //go:embed schemas/host.v1.json
@@ -25,4 +27,24 @@ func configTypeSchema(name string) (json.RawMessage, bool) {
 	default:
 		return nil, false
 	}
+}
+
+func knownConfigTypeID(name string) (string, bool) {
+	switch name {
+	case hostV1ConfigType:
+		return hostV1ConfigTypeID, true
+	case interceptV1ConfigType:
+		return interceptV1ConfigTypeID, true
+	default:
+		return "", false
+	}
+}
+
+func normalizeConfigTypeID(name, id string) string {
+	if knownID, ok := knownConfigTypeID(name); ok {
+		if id == "" || id == name {
+			return knownID
+		}
+	}
+	return id
 }

--- a/internal/ziti/config_types.go
+++ b/internal/ziti/config_types.go
@@ -1,0 +1,28 @@
+package ziti
+
+import (
+	_ "embed"
+	"encoding/json"
+)
+
+const (
+	hostV1ConfigType      = "host.v1"
+	interceptV1ConfigType = "intercept.v1"
+)
+
+//go:embed schemas/host.v1.json
+var hostV1SchemaRaw []byte
+
+//go:embed schemas/intercept.v1.json
+var interceptV1SchemaRaw []byte
+
+func configTypeSchema(name string) (json.RawMessage, bool) {
+	switch name {
+	case hostV1ConfigType:
+		return json.RawMessage(hostV1SchemaRaw), true
+	case interceptV1ConfigType:
+		return json.RawMessage(interceptV1SchemaRaw), true
+	default:
+		return nil, false
+	}
+}

--- a/internal/ziti/schemas/host.v1.json
+++ b/internal/ziti/schemas/host.v1.json
@@ -1,0 +1,476 @@
+{
+    "$id": "http://ziti-edge.netfoundry.io/schemas/host.v1.schema.json",
+    "additionalProperties": false,
+    "allOf": [
+        {
+            "else": {
+                "required": [
+                    "protocol"
+                ]
+            },
+            "if": {
+                "properties": {
+                    "forwardProtocol": {
+                        "const": true
+                    }
+                },
+                "required": [
+                    "forwardProtocol"
+                ]
+            },
+            "then": {
+                "required": [
+                    "allowedProtocols"
+                ]
+            }
+        },
+        {
+            "else": {
+                "required": [
+                    "address"
+                ]
+            },
+            "if": {
+                "properties": {
+                    "forwardAddress": {
+                        "const": true
+                    }
+                },
+                "required": [
+                    "forwardAddress"
+                ]
+            },
+            "then": {
+                "required": [
+                    "allowedAddresses"
+                ]
+            }
+        },
+        {
+            "else": {
+                "required": [
+                    "port"
+                ]
+            },
+            "if": {
+                "properties": {
+                    "forwardPort": {
+                        "const": true
+                    }
+                },
+                "required": [
+                    "forwardPort"
+                ]
+            },
+            "then": {
+                "required": [
+                    "allowedPortRanges"
+                ]
+            }
+        }
+    ],
+    "definitions": {
+        "action": {
+            "additionalProperties": false,
+            "properties": {
+                "action": {
+                    "pattern": "(mark (un)?healthy|increase cost [0-9]+|decrease cost [0-9]+|send event)",
+                    "type": "string"
+                },
+                "consecutiveEvents": {
+                    "maximum": 65535,
+                    "minimum": 0,
+                    "type": "integer"
+                },
+                "duration": {
+                    "$ref": "#/definitions/duration"
+                },
+                "trigger": {
+                    "enum": [
+                        "fail",
+                        "pass",
+                        "change"
+                    ],
+                    "type": "string"
+                }
+            },
+            "required": [
+                "trigger",
+                "action"
+            ],
+            "type": "object"
+        },
+        "actionList": {
+            "items": {
+                "$ref": "#/definitions/action"
+            },
+            "maxItems": 20,
+            "minItems": 1,
+            "type": "array"
+        },
+        "addressTranslation": {
+            "oneOf": [
+                {
+                    "$ref": "#/definitions/ipv4AddressTranslation"
+                },
+                {
+                    "$ref": "#/definitions/ipv6AddressTranslation"
+                }
+            ]
+        },
+        "dialAddress": {
+            "format": "idn-hostname",
+            "not": {
+                "pattern": "^$"
+            },
+            "type": "string"
+        },
+        "duration": {
+            "pattern": "[0-9]+(h|m|s|ms)",
+            "type": "string"
+        },
+        "httpCheck": {
+            "additionalProperties": false,
+            "properties": {
+                "actions": {
+                    "$ref": "#/definitions/actionList"
+                },
+                "body": {
+                    "type": "string"
+                },
+                "expectInBody": {
+                    "type": "string"
+                },
+                "expectStatus": {
+                    "maximum": 599,
+                    "minimum": 100,
+                    "type": "integer"
+                },
+                "interval": {
+                    "$ref": "#/definitions/duration"
+                },
+                "method": {
+                    "$ref": "#/definitions/method"
+                },
+                "timeout": {
+                    "$ref": "#/definitions/duration"
+                },
+                "url": {
+                    "type": "string"
+                }
+            },
+            "required": [
+                "interval",
+                "timeout",
+                "url"
+            ],
+            "type": "object"
+        },
+        "httpCheckList": {
+            "items": {
+                "$ref": "#/definitions/httpCheck"
+            },
+            "type": "array"
+        },
+        "inhabitedSet": {
+            "minItems": 1,
+            "type": "array",
+            "uniqueItems": true
+        },
+        "ipv4AddressTranslation": {
+            "additionalProperties": false,
+            "properties": {
+                "from": {
+                    "format": "ipv4",
+                    "type": "string"
+                },
+                "prefixLength": {
+                    "maximum": 32,
+                    "minimum": 0,
+                    "type": "integer"
+                },
+                "to": {
+                    "format": "ipv4",
+                    "type": "string"
+                }
+            },
+            "type": "object"
+        },
+        "ipv6AddressTranslation": {
+            "additionalProperties": false,
+            "properties": {
+                "from": {
+                    "format": "ipv6",
+                    "type": "string"
+                },
+                "prefixLength": {
+                    "maximum": 128,
+                    "minimum": 0,
+                    "type": "integer"
+                },
+                "to": {
+                    "format": "ipv6",
+                    "type": "string"
+                }
+            },
+            "type": "object"
+        },
+        "listenAddress": {
+            "description": "idn-hostname allows ipv4 and ipv6 addresses, as well as hostnames that might happen to contain '*' and/or '/'. so idn-hostname allows every supported intercept address, although ip addresses, wildcards and cidrs are only being validated as hostnames by this format. client applications will need to look for _valid_ ips, cidrs, and wildcards when parsing intercept addresses and treat them accordingly. anything else should be interpreted as a dns label. this means e.g. that '1.2.3.4/56' should be treated as a dns label, since it is not a valid cidr",
+            "format": "idn-hostname",
+            "not": {
+                "pattern": "^$"
+            },
+            "type": "string"
+        },
+        "method": {
+            "enum": [
+                "GET",
+                "POST",
+                "PUT",
+                "PATCH"
+            ],
+            "type": "string"
+        },
+        "portCheck": {
+            "additionalProperties": false,
+            "properties": {
+                "actions": {
+                    "$ref": "#/definitions/actionList"
+                },
+                "address": {
+                    "type": "string"
+                },
+                "interval": {
+                    "$ref": "#/definitions/duration"
+                },
+                "timeout": {
+                    "$ref": "#/definitions/duration"
+                }
+            },
+            "required": [
+                "interval",
+                "timeout",
+                "address"
+            ],
+            "type": "object"
+        },
+        "portCheckList": {
+            "items": {
+                "$ref": "#/definitions/portCheck"
+            },
+            "type": "array"
+        },
+        "portNumber": {
+            "maximum": 65535,
+            "minimum": 0,
+            "type": "integer"
+        },
+        "portRange": {
+            "additionalProperties": false,
+            "properties": {
+                "high": {
+                    "$ref": "#/definitions/portNumber"
+                },
+                "low": {
+                    "$ref": "#/definitions/portNumber"
+                }
+            },
+            "required": [
+                "low",
+                "high"
+            ],
+            "type": "object"
+        },
+        "protocolName": {
+            "enum": [
+                "tcp",
+                "udp"
+            ],
+            "type": "string"
+        },
+        "proxyConfiguration": {
+            "properties": {
+                "address": {
+                    "description": "The address of the proxy in host:port format",
+                    "type": "string"
+                },
+                "type": {
+                    "$ref": "#/definitions/proxyType",
+                    "description": "The type of the proxy being used"
+                }
+            },
+            "required": [
+                "type",
+                "address"
+            ],
+            "type": "object"
+        },
+        "proxyType": {
+            "description": "supported proxy types",
+            "enum": [
+                "http"
+            ],
+            "type": "string"
+        },
+        "timeoutSeconds": {
+            "maximum": 2147483647,
+            "minimum": 0,
+            "type": "integer"
+        }
+    },
+    "properties": {
+        "address": {
+            "$ref": "#/definitions/dialAddress",
+            "description": "Dial the specified ip address or hostname when a ziti client connects to the service."
+        },
+        "allowedAddresses": {
+            "allOf": [
+                {
+                    "$ref": "#/definitions/inhabitedSet"
+                },
+                {
+                    "items": {
+                        "$ref": "#/definitions/listenAddress"
+                    }
+                }
+            ],
+            "description": "Only allow addresses from this set to be dialed"
+        },
+        "allowedPortRanges": {
+            "allOf": [
+                {
+                    "$ref": "#/definitions/inhabitedSet"
+                },
+                {
+                    "items": {
+                        "$ref": "#/definitions/portRange"
+                    }
+                }
+            ],
+            "description": "Only allow ports from this set to be dialed"
+        },
+        "allowedProtocols": {
+            "allOf": [
+                {
+                    "$ref": "#/definitions/inhabitedSet"
+                },
+                {
+                    "items": {
+                        "$ref": "#/definitions/protocolName"
+                    }
+                }
+            ],
+            "description": "Only allow protocols from this set to be dialed"
+        },
+        "allowedSourceAddresses": {
+            "allOf": [
+                {
+                    "$ref": "#/definitions/inhabitedSet"
+                },
+                {
+                    "items": {
+                        "$ref": "#/definitions/listenAddress"
+                    }
+                }
+            ],
+            "description": "hosting tunnelers establish local routes for the specified source addresses so binding will succeed"
+        },
+        "forwardAddress": {
+            "description": "Dial the same ip address that was intercepted at the client tunneler. 'address' and 'forwardAddress' are mutually exclusive.",
+            "enum": [
+                true
+            ],
+            "type": "boolean"
+        },
+        "forwardAddressTranslations": {
+            "allOf": [
+                {
+                    "$ref": "#/definitions/inhabitedSet"
+                },
+                {
+                    "items": {
+                        "$ref": "#/definitions/addressTranslation"
+                    }
+                }
+            ],
+            "description": "Translate forwarded addresses according to this table"
+        },
+        "forwardPort": {
+            "description": "Dial the same port that was intercepted at the client tunneler. 'port' and 'forwardPort' are mutually exclusive.",
+            "enum": [
+                true
+            ],
+            "type": "boolean"
+        },
+        "forwardProtocol": {
+            "description": "Dial the same protocol that was intercepted at the client tunneler. 'protocol' and 'forwardProtocol' are mutually exclusive.",
+            "enum": [
+                true
+            ],
+            "type": "boolean"
+        },
+        "httpChecks": {
+            "$ref": "#/definitions/httpCheckList"
+        },
+        "listenOptions": {
+            "additionalProperties": false,
+            "properties": {
+                "bindUsingEdgeIdentity": {
+                    "description": "Associate the hosting terminator with the name of the hosting tunneler's identity. Setting this to 'true' is equivalent to setting 'identiy=$tunneler_id.name'",
+                    "type": "boolean"
+                },
+                "connectTimeout": {
+                    "$ref": "#/definitions/duration",
+                    "description": "Timeout when making outbound connections. Defaults to '5s'. If both connectTimoutSeconds and connectTimeout are specified, connectTimeout will be used."
+                },
+                "connectTimeoutSeconds": {
+                    "$ref": "#/definitions/timeoutSeconds",
+                    "deprecated": true,
+                    "description": "Timeout when making outbound connections. Defaults to 5. If both connectTimoutSeconds and connectTimeout are specified, connectTimeout will be used."
+                },
+                "cost": {
+                    "description": "defaults to 0",
+                    "maximum": 65535,
+                    "minimum": 0,
+                    "type": "integer"
+                },
+                "identity": {
+                    "description": "Associate the hosting terminator with the specified identity. '$tunneler_id.name' resolves to the name of the hosting tunneler's identity. '$tunneler_id.tag[tagName]' resolves to the value of the 'tagName' tag on the hosting tunneler's identity.",
+                    "type": "string"
+                },
+                "maxConnections": {
+                    "description": "defaults to 3",
+                    "minimum": 1,
+                    "type": "integer"
+                },
+                "precedence": {
+                    "description": "defaults to 'default'",
+                    "enum": [
+                        "default",
+                        "required",
+                        "failed"
+                    ],
+                    "type": "string"
+                }
+            },
+            "type": "object"
+        },
+        "port": {
+            "$ref": "#/definitions/portNumber",
+            "description": "Dial the specified port when a ziti client connects to the service."
+        },
+        "portChecks": {
+            "$ref": "#/definitions/portCheckList"
+        },
+        "protocol": {
+            "$ref": "#/definitions/protocolName",
+            "description": "Dial the specified protocol when a ziti client connects to the service."
+        },
+        "proxy": {
+            "$ref": "#/definitions/proxyConfiguration",
+            "description": "If defined, outgoing connections will be send through this proxy server"
+        }
+    },
+    "type": "object"
+}

--- a/internal/ziti/schemas/intercept.v1.json
+++ b/internal/ziti/schemas/intercept.v1.json
@@ -1,0 +1,158 @@
+{
+    "$id": "http://edge.openziti.org/schemas/intercept.v1.config.json",
+    "additionalProperties": false,
+    "definitions": {
+        "dialAddress": {
+            "format": "idn-hostname",
+            "not": {
+                "pattern": "^$"
+            },
+            "type": "string"
+        },
+        "inhabitedSet": {
+            "minItems": 1,
+            "type": "array",
+            "uniqueItems": true
+        },
+        "listenAddress": {
+            "description": "idn-hostname allows ipv4 and ipv6 addresses, as well as hostnames that might happen to contain '*' and/or '/'. so idn-hostname allows every supported intercept address, although ip addresses, wildcards and cidrs are only being validated as hostnames by this format. client applications will need to look for _valid_ ips, cidrs, and wildcards when parsing intercept addresses and treat them accordingly. anything else should be interpreted as a dns label. this means e.g. that '1.2.3.4/56' should be treated as a dns label, since it is not a valid cidr",
+            "format": "idn-hostname",
+            "not": {
+                "pattern": "^$"
+            },
+            "type": "string"
+        },
+        "portNumber": {
+            "maximum": 65535,
+            "minimum": 0,
+            "type": "integer"
+        },
+        "portRange": {
+            "additionalProperties": false,
+            "properties": {
+                "high": {
+                    "$ref": "#/definitions/portNumber"
+                },
+                "low": {
+                    "$ref": "#/definitions/portNumber"
+                }
+            },
+            "required": [
+                "low",
+                "high"
+            ],
+            "type": "object"
+        },
+        "protocolName": {
+            "enum": [
+                "tcp",
+                "udp"
+            ],
+            "type": "string"
+        },
+        "proxyConfiguration": {
+            "properties": {
+                "address": {
+                    "description": "The address of the proxy in host:port format",
+                    "type": "string"
+                },
+                "type": {
+                    "$ref": "#/definitions/proxyType",
+                    "description": "The type of the proxy being used"
+                }
+            },
+            "required": [
+                "type",
+                "address"
+            ],
+            "type": "object"
+        },
+        "proxyType": {
+            "description": "supported proxy types",
+            "enum": [
+                "http"
+            ],
+            "type": "string"
+        },
+        "timeoutSeconds": {
+            "maximum": 2147483647,
+            "minimum": 0,
+            "type": "integer"
+        }
+    },
+    "properties": {
+        "addresses": {
+            "allOf": [
+                {
+                    "$ref": "#/definitions/inhabitedSet"
+                },
+                {
+                    "items": {
+                        "$ref": "#/definitions/listenAddress"
+                    }
+                }
+            ]
+        },
+        "allowedSourceAddresses": {
+            "allOf": [
+                {
+                    "$ref": "#/definitions/inhabitedSet"
+                },
+                {
+                    "items": {
+                        "$ref": "#/definitions/listenAddress"
+                    }
+                }
+            ],
+            "description": "white list of source ips/cidrs that can be intercepted. all ips can be intercepted if this is not set."
+        },
+        "dialOptions": {
+            "additionalProperties": false,
+            "properties": {
+                "connectTimeoutSeconds": {
+                    "$ref": "#/definitions/timeoutSeconds",
+                    "description": "defaults to 5 seconds if no dialOptions are defined. defaults to 15 if dialOptions are defined but connectTimeoutSeconds is not specified."
+                },
+                "identity": {
+                    "description": "Dial a terminator with the specified identity. '$dst_protocol', '$dst_ip', '$dst_port are resolved to the corresponding value of the destination address.",
+                    "type": "string"
+                }
+            },
+            "type": "object"
+        },
+        "portRanges": {
+            "allOf": [
+                {
+                    "$ref": "#/definitions/inhabitedSet"
+                },
+                {
+                    "items": {
+                        "$ref": "#/definitions/portRange"
+                    }
+                }
+            ]
+        },
+        "protocols": {
+            "allOf": [
+                {
+                    "$ref": "#/definitions/inhabitedSet"
+                },
+                {
+                    "items": {
+                        "$ref": "#/definitions/protocolName"
+                    }
+                }
+            ]
+        },
+        "sourceIp": {
+            "description": "The source IP (and optional :port) to spoof when the connection is egressed from the hosting tunneler. '$tunneler_id.name' resolves to the name of the client tunneler's identity. '$tunneler_id.tag[tagName]' resolves to the value of the 'tagName' tag on the client tunneler's identity. '$src_ip' and '$src_port' resolve to the source IP / port of the originating client. '$dst_port' resolves to the port that the client is trying to connect.",
+            "type": "string"
+        }
+    },
+    "required": [
+        "protocols",
+        "addresses",
+        "portRanges"
+    ],
+    "type": "object"
+}


### PR DESCRIPTION
## Summary
- resolve config type IDs via controller lookup before creating configs
- seed host.v1 and intercept.v1 config types when missing using embedded schemas
- add config type lookups to client tests

## Testing
- go vet ./...
- go test ./...

Related: #138