### PR TITLE
Fix OpenZiti config type IDs

### DIFF
--- a/internal/ziti/client.go
+++ b/internal/ziti/client.go
@@ -400,7 +400,7 @@ func (c *Client) CreateServiceWithConfigs(ctx context.Context, name string, role
 			"address":  hostV1.Address,
 			"port":     hostV1.Port,
 		}
-		configID, err := c.createConfig(ctx, "host.v1", fmt.Sprintf("%s-host-v1", name), data)
+		configID, err := c.createConfig(ctx, hostV1ConfigTypeID, fmt.Sprintf("%s-host-v1", name), data)
 		if err != nil {
 			return "", err
 		}
@@ -419,7 +419,7 @@ func (c *Client) CreateServiceWithConfigs(ctx context.Context, name string, role
 			"addresses":  interceptV1.Addresses,
 			"portRanges": portRanges,
 		}
-		configID, err := c.createConfig(ctx, "intercept.v1", fmt.Sprintf("%s-intercept-v1", name), data)
+		configID, err := c.createConfig(ctx, interceptV1ConfigTypeID, fmt.Sprintf("%s-intercept-v1", name), data)
 		if err != nil {
 			return "", c.cleanupConfigs(ctx, configIDs, err)
 		}

--- a/internal/ziti/client_test.go
+++ b/internal/ziti/client_test.go
@@ -250,7 +250,7 @@ func TestCreateServiceWithConfigs(t *testing.T) {
 
 				switch callIndex {
 				case 0:
-					if *params.Config.ConfigTypeID != "host.v1" {
+					if *params.Config.ConfigTypeID != hostV1ConfigTypeID {
 						t.Fatalf("unexpected config type: %s", *params.Config.ConfigTypeID)
 					}
 					if *params.Config.Name != "svc-host-v1" {
@@ -265,7 +265,7 @@ func TestCreateServiceWithConfigs(t *testing.T) {
 						t.Fatalf("unexpected host config data: %#v", data)
 					}
 				case 1:
-					if *params.Config.ConfigTypeID != "intercept.v1" {
+					if *params.Config.ConfigTypeID != interceptV1ConfigTypeID {
 						t.Fatalf("unexpected config type: %s", *params.Config.ConfigTypeID)
 					}
 					if *params.Config.Name != "svc-intercept-v1" {

--- a/internal/ziti/config.go
+++ b/internal/ziti/config.go
@@ -1,5 +1,10 @@
 package ziti
 
+const (
+	hostV1ConfigTypeID      = "NH5p4FpGR"
+	interceptV1ConfigTypeID = "g7cIWbcGg"
+)
+
 type HostV1ConfigData struct {
 	Protocol string
 	Address  string


### PR DESCRIPTION
## Summary
- use config type entity IDs for host.v1 and intercept.v1 configs
- share config type IDs via package constants
- update CreateServiceWithConfigs tests to match IDs

## Testing
- go vet ./...
- go test ./...

Fixes #50