### PR TITLE
fix(server): make DeleteAppIdentity idempotent

### DIFF
--- a/internal/server/delete_app_identity_test.go
+++ b/internal/server/delete_app_identity_test.go
@@ -1,0 +1,128 @@
+package server
+
+import (
+	"context"
+	"errors"
+	"testing"
+	"time"
+
+	zitimanagementv1 "github.com/agynio/ziti-management/.gen/go/agynio/api/ziti_management/v1"
+	"github.com/agynio/ziti-management/internal/store"
+	"github.com/google/uuid"
+)
+
+type deleteAppIdentityStore struct {
+	identity    store.ManagedIdentity
+	resolveErr  error
+	deleteErr   error
+	deleteCalls []string
+}
+
+func (s *deleteAppIdentityStore) InsertManagedIdentity(_ context.Context, _ store.ManagedIdentity) error {
+	return errors.New("unexpected insert managed identity")
+}
+
+func (s *deleteAppIdentityStore) DeleteManagedIdentity(_ context.Context, zitiIdentityID string) error {
+	s.deleteCalls = append(s.deleteCalls, zitiIdentityID)
+	if s.deleteErr != nil {
+		return s.deleteErr
+	}
+	return nil
+}
+
+func (s *deleteAppIdentityStore) DeleteManagedIdentityByIdentityID(_ context.Context, _ uuid.UUID) error {
+	return errors.New("unexpected delete managed identity by identity id")
+}
+
+func (s *deleteAppIdentityStore) ResolveIdentity(_ context.Context, _ string) (store.ManagedIdentity, error) {
+	return store.ManagedIdentity{}, errors.New("unexpected resolve identity")
+}
+
+func (s *deleteAppIdentityStore) ResolveIdentityByIdentityID(_ context.Context, _ uuid.UUID) (store.ManagedIdentity, error) {
+	if s.resolveErr != nil {
+		return store.ManagedIdentity{}, s.resolveErr
+	}
+	return s.identity, nil
+}
+
+func (s *deleteAppIdentityStore) ListManagedIdentities(_ context.Context, _ store.ListFilter, _ int32, _ *store.PageCursor) (store.ListResult, error) {
+	return store.ListResult{}, errors.New("unexpected list managed identities")
+}
+
+func (s *deleteAppIdentityStore) InsertServiceIdentity(_ context.Context, _ string, _ store.ServiceType, _ time.Time) error {
+	return errors.New("unexpected insert service identity")
+}
+
+func (s *deleteAppIdentityStore) ExtendServiceIdentityLease(_ context.Context, _ string, _ time.Time) error {
+	return errors.New("unexpected extend service identity")
+}
+
+func TestDeleteAppIdentityDeletesServiceWhenIdentityMissing(t *testing.T) {
+	ctx := context.Background()
+	appID := uuid.New()
+	storeClient := &deleteAppIdentityStore{resolveErr: store.ErrManagedIdentityNotFound}
+	zitiClient := &fakeZitiClient{}
+	server := New(storeClient, zitiClient, time.Minute, false)
+
+	serviceID := "service-123"
+	_, err := server.DeleteAppIdentity(ctx, &zitimanagementv1.DeleteAppIdentityRequest{
+		IdentityId:    appID.String(),
+		ZitiServiceId: serviceID,
+	})
+	if err != nil {
+		t.Fatalf("delete app identity: %v", err)
+	}
+	if len(zitiClient.deleteServiceIDs) != 1 {
+		t.Fatalf("expected 1 service delete call, got %d", len(zitiClient.deleteServiceIDs))
+	}
+	if zitiClient.deleteServiceIDs[0] != serviceID {
+		t.Fatalf("expected service delete %q, got %q", serviceID, zitiClient.deleteServiceIDs[0])
+	}
+	if len(zitiClient.deleteIdentityIDs) != 0 {
+		t.Fatalf("expected no identity deletes, got %d", len(zitiClient.deleteIdentityIDs))
+	}
+	if len(storeClient.deleteCalls) != 0 {
+		t.Fatalf("expected no managed identity deletes, got %d", len(storeClient.deleteCalls))
+	}
+}
+
+func TestDeleteAppIdentityUsesStoredServiceID(t *testing.T) {
+	ctx := context.Background()
+	appID := uuid.New()
+	serviceID := "service-456"
+	zitiID := "ziti-identity"
+	storeClient := &deleteAppIdentityStore{
+		identity: store.ManagedIdentity{
+			ZitiIdentityID: zitiID,
+			IdentityID:     appID,
+			ZitiServiceID:  &serviceID,
+		},
+	}
+	zitiClient := &fakeZitiClient{}
+	server := New(storeClient, zitiClient, time.Minute, false)
+
+	_, err := server.DeleteAppIdentity(ctx, &zitimanagementv1.DeleteAppIdentityRequest{
+		IdentityId: appID.String(),
+	})
+	if err != nil {
+		t.Fatalf("delete app identity: %v", err)
+	}
+	if len(storeClient.deleteCalls) != 1 {
+		t.Fatalf("expected 1 managed identity delete, got %d", len(storeClient.deleteCalls))
+	}
+	if storeClient.deleteCalls[0] != zitiID {
+		t.Fatalf("expected managed identity delete %q, got %q", zitiID, storeClient.deleteCalls[0])
+	}
+	if len(zitiClient.deleteIdentityIDs) != 1 {
+		t.Fatalf("expected 1 identity delete, got %d", len(zitiClient.deleteIdentityIDs))
+	}
+	if zitiClient.deleteIdentityIDs[0] != zitiID {
+		t.Fatalf("expected identity delete %q, got %q", zitiID, zitiClient.deleteIdentityIDs[0])
+	}
+	if len(zitiClient.deleteServiceIDs) != 1 {
+		t.Fatalf("expected 1 service delete call, got %d", len(zitiClient.deleteServiceIDs))
+	}
+	if zitiClient.deleteServiceIDs[0] != serviceID {
+		t.Fatalf("expected service delete %q, got %q", serviceID, zitiClient.deleteServiceIDs[0])
+	}
+}

--- a/internal/server/delete_app_identity_test.go
+++ b/internal/server/delete_app_identity_test.go
@@ -9,6 +9,8 @@ import (
 	zitimanagementv1 "github.com/agynio/ziti-management/.gen/go/agynio/api/ziti_management/v1"
 	"github.com/agynio/ziti-management/internal/store"
 	"github.com/google/uuid"
+	"google.golang.org/grpc/codes"
+	"google.golang.org/grpc/status"
 )
 
 type deleteAppIdentityStore struct {
@@ -124,5 +126,23 @@ func TestDeleteAppIdentityUsesStoredServiceID(t *testing.T) {
 	}
 	if zitiClient.deleteServiceIDs[0] != serviceID {
 		t.Fatalf("expected service delete %q, got %q", serviceID, zitiClient.deleteServiceIDs[0])
+	}
+}
+
+func TestDeleteAppIdentityRequiresServiceIDWithoutMapping(t *testing.T) {
+	ctx := context.Background()
+	appID := uuid.New()
+	storeClient := &deleteAppIdentityStore{resolveErr: store.ErrManagedIdentityNotFound}
+	zitiClient := &fakeZitiClient{}
+	server := New(storeClient, zitiClient, time.Minute, false)
+
+	_, err := server.DeleteAppIdentity(ctx, &zitimanagementv1.DeleteAppIdentityRequest{
+		IdentityId: appID.String(),
+	})
+	if status.Code(err) != codes.InvalidArgument {
+		t.Fatalf("expected invalid argument error, got %v", err)
+	}
+	if len(zitiClient.deleteServiceIDs) != 0 {
+		t.Fatalf("expected no service delete calls, got %d", len(zitiClient.deleteServiceIDs))
 	}
 }

--- a/internal/server/identity_reenroll_test.go
+++ b/internal/server/identity_reenroll_test.go
@@ -69,6 +69,7 @@ type fakeZitiClient struct {
 	appCount          int
 	runnerCount       int
 	deleteIdentityIDs []string
+	deleteServiceIDs  []string
 	agentCalls        []agentCall
 	createAgentErr    error
 }
@@ -124,7 +125,8 @@ func (f *fakeZitiClient) DeleteIdentity(_ context.Context, zitiID string) error 
 	return nil
 }
 
-func (f *fakeZitiClient) DeleteService(_ context.Context, _ string) error {
+func (f *fakeZitiClient) DeleteService(_ context.Context, serviceID string) error {
+	f.deleteServiceIDs = append(f.deleteServiceIDs, serviceID)
 	return nil
 }
 

--- a/internal/server/server.go
+++ b/internal/server/server.go
@@ -272,29 +272,40 @@ func (s *Server) DeleteAppIdentity(ctx context.Context, req *zitimanagementv1.De
 		return nil, status.Errorf(codes.InvalidArgument, "identity_id: %v", err)
 	}
 
-	identity, err := s.store.ResolveIdentityByIdentityID(ctx, appID)
-	if err != nil {
-		return nil, toStatusError(err)
+	identity, resolveErr := s.store.ResolveIdentityByIdentityID(ctx, appID)
+	identityFound := resolveErr == nil
+	if resolveErr != nil && !errors.Is(resolveErr, store.ErrManagedIdentityNotFound) {
+		return nil, toStatusError(resolveErr)
 	}
 
-	if err := s.store.DeleteManagedIdentity(ctx, identity.ZitiIdentityID); err != nil {
-		return nil, toStatusError(err)
-	}
+	if identityFound {
+		if err := s.store.DeleteManagedIdentity(ctx, identity.ZitiIdentityID); err != nil {
+			if errors.Is(err, store.ErrManagedIdentityNotFound) {
+				log.Printf("managed identity %s already deleted", identity.ZitiIdentityID)
+			} else {
+				return nil, toStatusError(err)
+			}
+		}
 
-	if err := s.ziti.DeleteIdentity(ctx, identity.ZitiIdentityID); err != nil {
-		if errors.Is(err, ziti.ErrIdentityNotFound) {
-			log.Printf("ziti identity %s already deleted", identity.ZitiIdentityID)
-		} else {
-			return nil, status.Errorf(codes.Internal, "delete ziti identity: %v", err)
+		if err := s.ziti.DeleteIdentity(ctx, identity.ZitiIdentityID); err != nil {
+			if errors.Is(err, ziti.ErrIdentityNotFound) {
+				log.Printf("ziti identity %s already deleted", identity.ZitiIdentityID)
+			} else {
+				return nil, status.Errorf(codes.Internal, "delete ziti identity: %v", err)
+			}
 		}
 	}
 
 	zitiServiceID := req.GetZitiServiceId()
-	if zitiServiceID == "" && identity.ZitiServiceID != nil {
+	if zitiServiceID == "" && identityFound && identity.ZitiServiceID != nil {
 		zitiServiceID = *identity.ZitiServiceID
 	}
 	if zitiServiceID == "" {
-		return nil, status.Errorf(codes.Internal, "managed identity %s missing ziti service id", identity.ZitiIdentityID)
+		if identityFound {
+			return nil, status.Errorf(codes.Internal, "managed identity %s missing ziti service id", identity.ZitiIdentityID)
+		}
+		log.Printf("app identity %s missing ziti service id", appID)
+		return &zitimanagementv1.DeleteAppIdentityResponse{}, nil
 	}
 	if err := s.ziti.DeleteService(ctx, zitiServiceID); err != nil {
 		if errors.Is(err, ziti.ErrServiceNotFound) {

--- a/internal/server/server.go
+++ b/internal/server/server.go
@@ -304,8 +304,7 @@ func (s *Server) DeleteAppIdentity(ctx context.Context, req *zitimanagementv1.De
 		if identityFound {
 			return nil, status.Errorf(codes.Internal, "managed identity %s missing ziti service id", identity.ZitiIdentityID)
 		}
-		log.Printf("app identity %s missing ziti service id", appID)
-		return &zitimanagementv1.DeleteAppIdentityResponse{}, nil
+		return nil, status.Error(codes.InvalidArgument, "ziti_service_id is required when managed identity is missing")
 	}
 	if err := s.ziti.DeleteService(ctx, zitiServiceID); err != nil {
 		if errors.Is(err, ziti.ErrServiceNotFound) {


### PR DESCRIPTION
## Summary
- allow DeleteAppIdentity to proceed without a managed identity record
- delete app services using request or stored service IDs
- add DeleteAppIdentity coverage for missing identity/service IDs

## Testing
- buf generate buf.build/agynio/api --path agynio/api/ziti_management/v1
- go vet ./...
- go test ./...

#52