### PR TITLE
feat(ziti): add runners service identity

### DIFF
--- a/internal/server/converter.go
+++ b/internal/server/converter.go
@@ -51,6 +51,8 @@ func fromProtoServiceType(value zitimanagementv1.ServiceType) (store.ServiceType
 		return store.ServiceTypeLLMProxy, nil
 	case zitimanagementv1.ServiceType_SERVICE_TYPE_TRACING:
 		return store.ServiceTypeTracing, nil
+	case zitimanagementv1.ServiceType_SERVICE_TYPE_RUNNERS:
+		return store.ServiceTypeRunners, nil
 	case zitimanagementv1.ServiceType_SERVICE_TYPE_UNSPECIFIED:
 		return store.ServiceTypeUnspecified, fmt.Errorf("service type unspecified")
 	default:

--- a/internal/server/converter_test.go
+++ b/internal/server/converter_test.go
@@ -39,6 +39,11 @@ func TestFromProtoServiceType(t *testing.T) {
 			want:  store.ServiceTypeTracing,
 		},
 		{
+			name:  "runners",
+			input: zitimanagementv1.ServiceType_SERVICE_TYPE_RUNNERS,
+			want:  store.ServiceTypeRunners,
+		},
+		{
 			name:    "unspecified",
 			input:   zitimanagementv1.ServiceType_SERVICE_TYPE_UNSPECIFIED,
 			want:    store.ServiceTypeUnspecified,

--- a/internal/server/server.go
+++ b/internal/server/server.go
@@ -584,6 +584,8 @@ func serviceIdentityConfig(serviceType store.ServiceType) (string, []string, err
 		return fmt.Sprintf("svc-llm-proxy-%s", suffix), []string{"llm-proxy-hosts"}, nil
 	case store.ServiceTypeTracing:
 		return fmt.Sprintf("svc-tracing-%s", suffix), []string{"tracing-hosts"}, nil
+	case store.ServiceTypeRunners:
+		return fmt.Sprintf("svc-runners-%s", suffix), []string{"runners-service-hosts"}, nil
 	case store.ServiceTypeUnspecified:
 		return "", nil, fmt.Errorf("service type unspecified")
 	default:

--- a/internal/server/server_test.go
+++ b/internal/server/server_test.go
@@ -29,6 +29,12 @@ func TestServiceIdentityConfig(t *testing.T) {
 			wantRoles:  []string{"tracing-hosts"},
 		},
 		{
+			name:       "runners",
+			service:    store.ServiceTypeRunners,
+			wantPrefix: "svc-runners-",
+			wantRoles:  []string{"runners-service-hosts"},
+		},
+		{
 			name:    "unspecified",
 			service: store.ServiceTypeUnspecified,
 			wantErr: "service type unspecified",

--- a/internal/store/types.go
+++ b/internal/store/types.go
@@ -27,6 +27,7 @@ const (
 	ServiceTypeOrchestrator ServiceType = 2
 	ServiceTypeLLMProxy     ServiceType = 4
 	ServiceTypeTracing      ServiceType = 5
+	ServiceTypeRunners      ServiceType = 6
 )
 
 type ManagedIdentity struct {


### PR DESCRIPTION
## Summary
- add runners service type handling in RequestServiceIdentity
- issue runners service identities with runners-service-hosts role attribute
- cover new service type in converter + config tests

## Testing
- buf generate --template /workspace/ziti-management/buf.gen.yaml -o ../ziti-management --path proto/agynio/api/ziti_management/v1 (from /workspace/api)
- go test ./...

Refs agynio/runners#33