### PR TITLE
feat(ziti): add debug service state

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -30,7 +30,7 @@ jobs:
 
       - name: Generate gRPC stubs
         run: |
-          buf generate buf.build/agynio/api \
+          buf generate "https://github.com/agynio/api.git#branch=noa/ziti-debug-state,subdir=proto" \
             --path agynio/api/ziti_management/v1
 
       - name: Go vet

--- a/Dockerfile
+++ b/Dockerfile
@@ -22,7 +22,7 @@ RUN --mount=type=cache,target=/go/pkg/mod \
     go mod download
 
 COPY buf.gen.yaml buf.yaml buf.lock ./
-RUN buf generate buf.build/agynio/api --path agynio/api/ziti_management/v1
+RUN buf generate "https://github.com/agynio/api.git#branch=noa/ziti-debug-state,subdir=proto" --path agynio/api/ziti_management/v1
 
 COPY . .
 

--- a/devspace.yaml
+++ b/devspace.yaml
@@ -52,7 +52,7 @@ functions:
                     sleep 1; elapsed=$((elapsed + 1))
                     [ "$elapsed" -ge 120 ] && { echo "ERROR: sync timeout" >&2; exit 1; }
                   done
-                  buf generate buf.build/agynio/api --path agynio/api/ziti_management/v1
+                  buf generate "https://github.com/agynio/api.git#branch=noa/ziti-debug-state,subdir=proto" --path agynio/api/ziti_management/v1
                   exec go run ./cmd/ziti-management
               volumeMounts:
                 - name: data
@@ -135,7 +135,7 @@ pipelines:
       exec_container \
         --label-selector "app.kubernetes.io/name=ziti-management-e2e" \
         -n ${ZITI_MANAGEMENT_NAMESPACE} \
-        -- bash -c 'cd /opt/app/data && buf generate buf.build/agynio/api --path agynio/api/ziti_management/v1 && go test -v -count=1 -tags e2e ./test/e2e/'
+        -- bash -c 'cd /opt/app/data && buf generate "https://github.com/agynio/api.git#branch=noa/ziti-debug-state,subdir=proto" --path agynio/api/ziti_management/v1 && go test -v -count=1 -tags e2e ./test/e2e/'
       EXIT_CODE=$?
       stop_dev e2e-runner
       purge_deployments e2e-runner

--- a/internal/server/converter.go
+++ b/internal/server/converter.go
@@ -183,3 +183,60 @@ func toProtoManagedIdentity(identity store.ManagedIdentity) (*zitimanagementv1.M
 	}
 	return protoIdentity, nil
 }
+
+func toProtoDebugServiceState(state *ziti.DebugServiceState) *zitimanagementv1.DebugServiceStateResponse {
+	return &zitimanagementv1.DebugServiceStateResponse{
+		ZitiServiceId:   state.ServiceID,
+		ZitiServiceName: state.ServiceName,
+		RoleAttributes:  append([]string(nil), state.RoleAttributes...),
+		Configs:         toProtoDebugConfigs(state.Configs),
+		ServicePolicies: toProtoDebugServicePolicies(state.ServicePolicies),
+		Terminators:     toProtoDebugTerminators(state.Terminators),
+	}
+}
+
+func toProtoDebugConfigs(configs []ziti.DebugConfig) []*zitimanagementv1.DebugConfig {
+	items := make([]*zitimanagementv1.DebugConfig, len(configs))
+	for i, config := range configs {
+		items[i] = &zitimanagementv1.DebugConfig{
+			Id:             config.ID,
+			Name:           config.Name,
+			ConfigTypeId:   config.ConfigTypeID,
+			ConfigTypeName: config.ConfigTypeName,
+			Json:           config.JSON,
+		}
+	}
+	return items
+}
+
+func toProtoDebugServicePolicies(policies []ziti.DebugServicePolicy) []*zitimanagementv1.DebugServicePolicy {
+	items := make([]*zitimanagementv1.DebugServicePolicy, len(policies))
+	for i, policy := range policies {
+		items[i] = &zitimanagementv1.DebugServicePolicy{
+			Id:            policy.ID,
+			Name:          policy.Name,
+			Type:          policy.Type,
+			IdentityRoles: append([]string(nil), policy.IdentityRoles...),
+			ServiceRoles:  append([]string(nil), policy.ServiceRoles...),
+		}
+	}
+	return items
+}
+
+func toProtoDebugTerminators(terminators []ziti.DebugTerminator) []*zitimanagementv1.DebugTerminator {
+	items := make([]*zitimanagementv1.DebugTerminator, len(terminators))
+	for i, terminator := range terminators {
+		items[i] = &zitimanagementv1.DebugTerminator{
+			Id:          terminator.ID,
+			Identity:    terminator.Identity,
+			RouterId:    terminator.RouterID,
+			RouterName:  terminator.RouterName,
+			Precedence:  terminator.Precedence,
+			Cost:        terminator.Cost,
+			DynamicCost: terminator.DynamicCost,
+			Binding:     terminator.Binding,
+			Address:     terminator.Address,
+		}
+	}
+	return items
+}

--- a/internal/server/identity_reenroll_test.go
+++ b/internal/server/identity_reenroll_test.go
@@ -112,6 +112,10 @@ func (f *fakeZitiClient) CreateServiceWithConfigs(_ context.Context, _ string, _
 	return "", errors.New("unexpected create service with configs")
 }
 
+func (f *fakeZitiClient) DebugServiceState(_ context.Context, _, _ string) (*ziti.DebugServiceState, error) {
+	return nil, errors.New("unexpected debug service state")
+}
+
 func (f *fakeZitiClient) CreateServicePolicy(_ context.Context, _ string, _ string, _ []string, _ []string) (string, error) {
 	return "", errors.New("unexpected create service policy")
 }

--- a/internal/server/server.go
+++ b/internal/server/server.go
@@ -37,6 +37,7 @@ type zitiClient interface {
 	CreateAndEnrollServiceIdentity(ctx context.Context, name string, roleAttributes []string) (string, []byte, error)
 	CreateService(ctx context.Context, name string, roleAttributes []string) (string, error)
 	CreateServiceWithConfigs(ctx context.Context, name string, roleAttributes []string, hostV1 *ziti.HostV1ConfigData, interceptV1 *ziti.InterceptV1ConfigData) (string, error)
+	DebugServiceState(ctx context.Context, serviceID, serviceName string) (*ziti.DebugServiceState, error)
 	CreateServicePolicy(ctx context.Context, name, policyType string, identityRoles, serviceRoles []string) (string, error)
 	CreateDeviceIdentity(ctx context.Context, userIdentityID uuid.UUID, name string) (string, string, error)
 	DeleteIdentity(ctx context.Context, zitiIdentityID string) error
@@ -418,6 +419,23 @@ func (s *Server) DeleteService(ctx context.Context, req *zitimanagementv1.Delete
 	}
 
 	return &zitimanagementv1.DeleteServiceResponse{}, nil
+}
+
+func (s *Server) DebugServiceState(ctx context.Context, req *zitimanagementv1.DebugServiceStateRequest) (*zitimanagementv1.DebugServiceStateResponse, error) {
+	serviceID := strings.TrimSpace(req.GetZitiServiceId())
+	serviceName := strings.TrimSpace(req.GetZitiServiceName())
+	if serviceID == "" && serviceName == "" {
+		return nil, status.Error(codes.InvalidArgument, "ziti_service_id or ziti_service_name is required")
+	}
+
+	state, err := s.ziti.DebugServiceState(ctx, serviceID, serviceName)
+	if err != nil {
+		if errors.Is(err, ziti.ErrServiceNotFound) {
+			return nil, status.Error(codes.NotFound, "ziti service not found")
+		}
+		return nil, status.Errorf(codes.Internal, "debug ziti service state: %v", err)
+	}
+	return toProtoDebugServiceState(state), nil
 }
 
 func (s *Server) CreateDeviceIdentity(ctx context.Context, req *zitimanagementv1.CreateDeviceIdentityRequest) (*zitimanagementv1.CreateDeviceIdentityResponse, error) {

--- a/internal/server/server.go
+++ b/internal/server/server.go
@@ -422,10 +422,9 @@ func (s *Server) DeleteService(ctx context.Context, req *zitimanagementv1.Delete
 }
 
 func (s *Server) DebugServiceState(ctx context.Context, req *zitimanagementv1.DebugServiceStateRequest) (*zitimanagementv1.DebugServiceStateResponse, error) {
-	serviceID := strings.TrimSpace(req.GetZitiServiceId())
-	serviceName := strings.TrimSpace(req.GetZitiServiceName())
-	if serviceID == "" && serviceName == "" {
-		return nil, status.Error(codes.InvalidArgument, "ziti_service_id or ziti_service_name is required")
+	serviceID, serviceName, err := debugServiceIdentifier(req)
+	if err != nil {
+		return nil, err
 	}
 
 	state, err := s.ziti.DebugServiceState(ctx, serviceID, serviceName)
@@ -436,6 +435,27 @@ func (s *Server) DebugServiceState(ctx context.Context, req *zitimanagementv1.De
 		return nil, status.Errorf(codes.Internal, "debug ziti service state: %v", err)
 	}
 	return toProtoDebugServiceState(state), nil
+}
+
+func debugServiceIdentifier(req *zitimanagementv1.DebugServiceStateRequest) (string, string, error) {
+	switch identifier := req.GetServiceIdentifier().(type) {
+	case *zitimanagementv1.DebugServiceStateRequest_ZitiServiceId:
+		serviceID := strings.TrimSpace(identifier.ZitiServiceId)
+		if serviceID == "" {
+			return "", "", status.Error(codes.InvalidArgument, "ziti_service_id is required")
+		}
+		return serviceID, "", nil
+	case *zitimanagementv1.DebugServiceStateRequest_ZitiServiceName:
+		serviceName := strings.TrimSpace(identifier.ZitiServiceName)
+		if serviceName == "" {
+			return "", "", status.Error(codes.InvalidArgument, "ziti_service_name is required")
+		}
+		return "", serviceName, nil
+	case nil:
+		return "", "", status.Error(codes.InvalidArgument, "ziti_service_id or ziti_service_name is required")
+	default:
+		return "", "", status.Error(codes.InvalidArgument, "unknown service identifier")
+	}
 }
 
 func (s *Server) CreateDeviceIdentity(ctx context.Context, req *zitimanagementv1.CreateDeviceIdentityRequest) (*zitimanagementv1.CreateDeviceIdentityResponse, error) {

--- a/internal/ziti/client.go
+++ b/internal/ziti/client.go
@@ -45,11 +45,17 @@ type identityService interface {
 type serviceService interface {
 	CreateService(params *service.CreateServiceParams, authInfo runtime.ClientAuthInfoWriter, opts ...service.ClientOption) (*service.CreateServiceCreated, error)
 	DeleteService(params *service.DeleteServiceParams, authInfo runtime.ClientAuthInfoWriter, opts ...service.ClientOption) (*service.DeleteServiceOK, error)
+	DetailService(params *service.DetailServiceParams, authInfo runtime.ClientAuthInfoWriter, opts ...service.ClientOption) (*service.DetailServiceOK, error)
+	ListServiceConfig(params *service.ListServiceConfigParams, authInfo runtime.ClientAuthInfoWriter, opts ...service.ClientOption) (*service.ListServiceConfigOK, error)
+	ListServiceServicePolicies(params *service.ListServiceServicePoliciesParams, authInfo runtime.ClientAuthInfoWriter, opts ...service.ClientOption) (*service.ListServiceServicePoliciesOK, error)
+	ListServiceTerminators(params *service.ListServiceTerminatorsParams, authInfo runtime.ClientAuthInfoWriter, opts ...service.ClientOption) (*service.ListServiceTerminatorsOK, error)
+	ListServices(params *service.ListServicesParams, authInfo runtime.ClientAuthInfoWriter, opts ...service.ClientOption) (*service.ListServicesOK, error)
 }
 
 type configService interface {
 	CreateConfig(params *config.CreateConfigParams, authInfo runtime.ClientAuthInfoWriter, opts ...config.ClientOption) (*config.CreateConfigCreated, error)
 	DeleteConfig(params *config.DeleteConfigParams, authInfo runtime.ClientAuthInfoWriter, opts ...config.ClientOption) (*config.DeleteConfigOK, error)
+	DetailConfig(params *config.DetailConfigParams, authInfo runtime.ClientAuthInfoWriter, opts ...config.ClientOption) (*config.DetailConfigOK, error)
 }
 
 type servicePolicyService interface {

--- a/internal/ziti/client_test.go
+++ b/internal/ziti/client_test.go
@@ -52,8 +52,13 @@ func (f *fakeIdentityService) ListIdentities(params *identity.ListIdentitiesPara
 }
 
 type fakeServiceService struct {
-	createServiceFunc func(params *service.CreateServiceParams) (*service.CreateServiceCreated, error)
-	deleteServiceFunc func(params *service.DeleteServiceParams) (*service.DeleteServiceOK, error)
+	createServiceFunc              func(params *service.CreateServiceParams) (*service.CreateServiceCreated, error)
+	deleteServiceFunc              func(params *service.DeleteServiceParams) (*service.DeleteServiceOK, error)
+	detailServiceFunc              func(params *service.DetailServiceParams) (*service.DetailServiceOK, error)
+	listServiceConfigFunc          func(params *service.ListServiceConfigParams) (*service.ListServiceConfigOK, error)
+	listServiceServicePoliciesFunc func(params *service.ListServiceServicePoliciesParams) (*service.ListServiceServicePoliciesOK, error)
+	listServiceTerminatorsFunc     func(params *service.ListServiceTerminatorsParams) (*service.ListServiceTerminatorsOK, error)
+	listServicesFunc               func(params *service.ListServicesParams) (*service.ListServicesOK, error)
 }
 
 func (f *fakeServiceService) CreateService(params *service.CreateServiceParams, _ runtime.ClientAuthInfoWriter, _ ...service.ClientOption) (*service.CreateServiceCreated, error) {
@@ -70,9 +75,45 @@ func (f *fakeServiceService) DeleteService(params *service.DeleteServiceParams, 
 	return f.deleteServiceFunc(params)
 }
 
+func (f *fakeServiceService) DetailService(params *service.DetailServiceParams, _ runtime.ClientAuthInfoWriter, _ ...service.ClientOption) (*service.DetailServiceOK, error) {
+	if f.detailServiceFunc == nil {
+		return nil, errors.New("detail service not stubbed")
+	}
+	return f.detailServiceFunc(params)
+}
+
+func (f *fakeServiceService) ListServiceConfig(params *service.ListServiceConfigParams, _ runtime.ClientAuthInfoWriter, _ ...service.ClientOption) (*service.ListServiceConfigOK, error) {
+	if f.listServiceConfigFunc == nil {
+		return nil, errors.New("list service config not stubbed")
+	}
+	return f.listServiceConfigFunc(params)
+}
+
+func (f *fakeServiceService) ListServiceServicePolicies(params *service.ListServiceServicePoliciesParams, _ runtime.ClientAuthInfoWriter, _ ...service.ClientOption) (*service.ListServiceServicePoliciesOK, error) {
+	if f.listServiceServicePoliciesFunc == nil {
+		return nil, errors.New("list service service policies not stubbed")
+	}
+	return f.listServiceServicePoliciesFunc(params)
+}
+
+func (f *fakeServiceService) ListServiceTerminators(params *service.ListServiceTerminatorsParams, _ runtime.ClientAuthInfoWriter, _ ...service.ClientOption) (*service.ListServiceTerminatorsOK, error) {
+	if f.listServiceTerminatorsFunc == nil {
+		return nil, errors.New("list service terminators not stubbed")
+	}
+	return f.listServiceTerminatorsFunc(params)
+}
+
+func (f *fakeServiceService) ListServices(params *service.ListServicesParams, _ runtime.ClientAuthInfoWriter, _ ...service.ClientOption) (*service.ListServicesOK, error) {
+	if f.listServicesFunc == nil {
+		return nil, errors.New("list services not stubbed")
+	}
+	return f.listServicesFunc(params)
+}
+
 type fakeConfigService struct {
 	createConfigFunc func(params *config.CreateConfigParams) (*config.CreateConfigCreated, error)
 	deleteConfigFunc func(params *config.DeleteConfigParams) (*config.DeleteConfigOK, error)
+	detailConfigFunc func(params *config.DetailConfigParams) (*config.DetailConfigOK, error)
 }
 
 func (f *fakeConfigService) CreateConfig(params *config.CreateConfigParams, _ runtime.ClientAuthInfoWriter, _ ...config.ClientOption) (*config.CreateConfigCreated, error) {
@@ -87,6 +128,13 @@ func (f *fakeConfigService) DeleteConfig(params *config.DeleteConfigParams, _ ru
 		return nil, errors.New("delete config not stubbed")
 	}
 	return f.deleteConfigFunc(params)
+}
+
+func (f *fakeConfigService) DetailConfig(params *config.DetailConfigParams, _ runtime.ClientAuthInfoWriter, _ ...config.ClientOption) (*config.DetailConfigOK, error) {
+	if f.detailConfigFunc == nil {
+		return nil, errors.New("detail config not stubbed")
+	}
+	return f.detailConfigFunc(params)
 }
 
 type fakeServicePolicyService struct {

--- a/internal/ziti/debug_state.go
+++ b/internal/ziti/debug_state.go
@@ -1,0 +1,344 @@
+package ziti
+
+import (
+	"context"
+	"encoding/json"
+	"errors"
+	"fmt"
+	"strconv"
+
+	"github.com/openziti/edge-api/rest_management_api_client/config"
+	"github.com/openziti/edge-api/rest_management_api_client/service"
+	"github.com/openziti/edge-api/rest_model"
+)
+
+const debugListLimit int64 = 100
+
+type DebugServiceState struct {
+	ServiceID       string
+	ServiceName     string
+	RoleAttributes  []string
+	Configs         []DebugConfig
+	ServicePolicies []DebugServicePolicy
+	Terminators     []DebugTerminator
+}
+
+type DebugConfig struct {
+	ID             string
+	Name           string
+	ConfigTypeID   string
+	ConfigTypeName string
+	JSON           string
+}
+
+type DebugServicePolicy struct {
+	ID            string
+	Name          string
+	Type          string
+	IdentityRoles []string
+	ServiceRoles  []string
+}
+
+type DebugTerminator struct {
+	ID          string
+	Identity    string
+	RouterID    string
+	RouterName  string
+	Precedence  string
+	Cost        int32
+	DynamicCost int32
+	Binding     string
+	Address     string
+}
+
+func (c *Client) DebugServiceState(ctx context.Context, serviceID, serviceName string) (*DebugServiceState, error) {
+	resolvedServiceID := serviceID
+	if resolvedServiceID == "" {
+		id, err := c.lookupServiceID(ctx, serviceName)
+		if err != nil {
+			return nil, err
+		}
+		resolvedServiceID = id
+	}
+
+	serviceDetail, err := c.detailService(ctx, resolvedServiceID)
+	if err != nil {
+		return nil, err
+	}
+	configs, err := c.debugServiceConfigs(ctx, resolvedServiceID)
+	if err != nil {
+		return nil, err
+	}
+	policies, err := c.debugServicePolicies(ctx, resolvedServiceID)
+	if err != nil {
+		return nil, err
+	}
+	terminators, err := c.debugServiceTerminators(ctx, resolvedServiceID)
+	if err != nil {
+		return nil, err
+	}
+
+	return &DebugServiceState{
+		ServiceID:       stringValue(serviceDetail.ID),
+		ServiceName:     stringValue(serviceDetail.Name),
+		RoleAttributes:  attributesToStrings(serviceDetail.RoleAttributes),
+		Configs:         configs,
+		ServicePolicies: policies,
+		Terminators:     terminators,
+	}, nil
+}
+
+func (c *Client) lookupServiceID(ctx context.Context, serviceName string) (string, error) {
+	if serviceName == "" {
+		return "", errors.New("service name is empty")
+	}
+	filter := fmt.Sprintf("name=%s", strconv.Quote(serviceName))
+	params := service.NewListServicesParamsWithContext(ctx)
+	params.Filter = &filter
+	params.Limit = int64Ptr(debugListLimit)
+
+	var listed *service.ListServicesOK
+	err := c.withReauth(func() error {
+		var callErr error
+		serviceClient := c.serviceClient()
+		listed, callErr = serviceClient.ListServices(params, nil)
+		return callErr
+	})
+	if err != nil {
+		return "", fmt.Errorf("list ziti services: %w", err)
+	}
+	if listed == nil || listed.Payload == nil {
+		return "", errors.New("list ziti services response missing payload")
+	}
+	if len(listed.Payload.Data) == 0 {
+		return "", ErrServiceNotFound
+	}
+	if len(listed.Payload.Data) > 1 {
+		return "", fmt.Errorf("multiple ziti services matched name %q", serviceName)
+	}
+	return requiredBaseID(listed.Payload.Data[0], "service")
+}
+
+func (c *Client) detailService(ctx context.Context, serviceID string) (*rest_model.ServiceDetail, error) {
+	params := service.NewDetailServiceParamsWithContext(ctx)
+	params.ID = serviceID
+	var detailed *service.DetailServiceOK
+	err := c.withReauth(func() error {
+		var callErr error
+		serviceClient := c.serviceClient()
+		detailed, callErr = serviceClient.DetailService(params, nil)
+		return callErr
+	})
+	if err != nil {
+		var notFound *service.DetailServiceNotFound
+		if errors.As(err, &notFound) {
+			return nil, ErrServiceNotFound
+		}
+		return nil, fmt.Errorf("detail ziti service: %w", err)
+	}
+	if detailed == nil || detailed.Payload == nil || detailed.Payload.Data == nil {
+		return nil, errors.New("detail ziti service response missing data")
+	}
+	return detailed.Payload.Data, nil
+}
+
+func (c *Client) debugServiceConfigs(ctx context.Context, serviceID string) ([]DebugConfig, error) {
+	params := service.NewListServiceConfigParamsWithContext(ctx)
+	params.ID = serviceID
+	params.Limit = int64Ptr(debugListLimit)
+	var listed *service.ListServiceConfigOK
+	err := c.withReauth(func() error {
+		var callErr error
+		serviceClient := c.serviceClient()
+		listed, callErr = serviceClient.ListServiceConfig(params, nil)
+		return callErr
+	})
+	if err != nil {
+		return nil, fmt.Errorf("list ziti service configs: %w", err)
+	}
+	if listed == nil || listed.Payload == nil {
+		return nil, errors.New("list ziti service configs response missing payload")
+	}
+	configs := make([]DebugConfig, 0, len(listed.Payload.Data))
+	for _, configDetail := range listed.Payload.Data {
+		configID, err := requiredConfigID(configDetail)
+		if err != nil {
+			return nil, err
+		}
+		configDetail, err := c.detailConfig(ctx, configID)
+		if err != nil {
+			return nil, err
+		}
+		configs = append(configs, configDetail)
+	}
+	return configs, nil
+}
+
+func (c *Client) detailConfig(ctx context.Context, configID string) (DebugConfig, error) {
+	params := config.NewDetailConfigParamsWithContext(ctx)
+	params.ID = configID
+	var detailed *config.DetailConfigOK
+	err := c.withReauth(func() error {
+		var callErr error
+		configClient := c.configClient()
+		detailed, callErr = configClient.DetailConfig(params, nil)
+		return callErr
+	})
+	if err != nil {
+		return DebugConfig{}, fmt.Errorf("detail ziti config: %w", err)
+	}
+	if detailed == nil || detailed.Payload == nil || detailed.Payload.Data == nil {
+		return DebugConfig{}, errors.New("detail ziti config response missing data")
+	}
+	configDetail := detailed.Payload.Data
+	jsonData, err := json.Marshal(configDetail.Data)
+	if err != nil {
+		return DebugConfig{}, fmt.Errorf("marshal ziti config data: %w", err)
+	}
+	configTypeName := ""
+	if configDetail.ConfigType != nil {
+		configTypeName = configDetail.ConfigType.Name
+	}
+	return DebugConfig{
+		ID:             stringValue(configDetail.ID),
+		Name:           stringValue(configDetail.Name),
+		ConfigTypeID:   stringValue(configDetail.ConfigTypeID),
+		ConfigTypeName: configTypeName,
+		JSON:           string(jsonData),
+	}, nil
+}
+
+func (c *Client) debugServicePolicies(ctx context.Context, serviceID string) ([]DebugServicePolicy, error) {
+	params := service.NewListServiceServicePoliciesParamsWithContext(ctx)
+	params.ID = serviceID
+	params.Limit = int64Ptr(debugListLimit)
+	var listed *service.ListServiceServicePoliciesOK
+	err := c.withReauth(func() error {
+		var callErr error
+		serviceClient := c.serviceClient()
+		listed, callErr = serviceClient.ListServiceServicePolicies(params, nil)
+		return callErr
+	})
+	if err != nil {
+		return nil, fmt.Errorf("list ziti service policies: %w", err)
+	}
+	if listed == nil || listed.Payload == nil {
+		return nil, errors.New("list ziti service policies response missing payload")
+	}
+	policies := make([]DebugServicePolicy, 0, len(listed.Payload.Data))
+	for _, policy := range listed.Payload.Data {
+		if policy == nil {
+			return nil, errors.New("list ziti service policies response missing policy")
+		}
+		policies = append(policies, DebugServicePolicy{
+			ID:            stringValue(policy.ID),
+			Name:          stringValue(policy.Name),
+			Type:          dialBindToString(policy.Type),
+			IdentityRoles: rolesToStrings(policy.IdentityRoles),
+			ServiceRoles:  rolesToStrings(policy.ServiceRoles),
+		})
+	}
+	return policies, nil
+}
+
+func (c *Client) debugServiceTerminators(ctx context.Context, serviceID string) ([]DebugTerminator, error) {
+	params := service.NewListServiceTerminatorsParamsWithContext(ctx)
+	params.ID = serviceID
+	params.Limit = int64Ptr(debugListLimit)
+	var listed *service.ListServiceTerminatorsOK
+	err := c.withReauth(func() error {
+		var callErr error
+		serviceClient := c.serviceClient()
+		listed, callErr = serviceClient.ListServiceTerminators(params, nil)
+		return callErr
+	})
+	if err != nil {
+		return nil, fmt.Errorf("list ziti service terminators: %w", err)
+	}
+	if listed == nil || listed.Payload == nil {
+		return nil, errors.New("list ziti service terminators response missing payload")
+	}
+	terminators := make([]DebugTerminator, 0, len(listed.Payload.Data))
+	for _, terminatorDetail := range listed.Payload.Data {
+		if terminatorDetail == nil {
+			return nil, errors.New("list ziti service terminators response missing terminator")
+		}
+		routerName := ""
+		if terminatorDetail.Router != nil {
+			routerName = terminatorDetail.Router.Name
+		}
+		terminators = append(terminators, DebugTerminator{
+			ID:          stringValue(terminatorDetail.ID),
+			Identity:    stringValue(terminatorDetail.Identity),
+			RouterID:    stringValue(terminatorDetail.RouterID),
+			RouterName:  routerName,
+			Precedence:  terminatorPrecedenceToString(terminatorDetail.Precedence),
+			Cost:        terminatorCostToInt32(terminatorDetail.Cost),
+			DynamicCost: terminatorCostToInt32(terminatorDetail.DynamicCost),
+			Binding:     stringValue(terminatorDetail.Binding),
+			Address:     stringValue(terminatorDetail.Address),
+		})
+	}
+	return terminators, nil
+}
+
+func requiredBaseID(entity *rest_model.ServiceDetail, resource string) (string, error) {
+	if entity == nil || entity.ID == nil || *entity.ID == "" {
+		return "", fmt.Errorf("%s missing id", resource)
+	}
+	return *entity.ID, nil
+}
+
+func requiredConfigID(config *rest_model.ConfigDetail) (string, error) {
+	if config == nil || config.ID == nil || *config.ID == "" {
+		return "", errors.New("service config missing config id")
+	}
+	return *config.ID, nil
+}
+
+func stringValue(value *string) string {
+	if value == nil {
+		return ""
+	}
+	return *value
+}
+
+func int64Ptr(value int64) *int64 {
+	return &value
+}
+
+func attributesToStrings(attributes *rest_model.Attributes) []string {
+	if attributes == nil {
+		return nil
+	}
+	values := make([]string, len(*attributes))
+	copy(values, *attributes)
+	return values
+}
+
+func rolesToStrings(roles rest_model.Roles) []string {
+	values := make([]string, len(roles))
+	copy(values, roles)
+	return values
+}
+
+func dialBindToString(value *rest_model.DialBind) string {
+	if value == nil {
+		return ""
+	}
+	return string(*value)
+}
+
+func terminatorPrecedenceToString(value *rest_model.TerminatorPrecedence) string {
+	if value == nil {
+		return ""
+	}
+	return string(*value)
+}
+
+func terminatorCostToInt32(value *rest_model.TerminatorCost) int32 {
+	if value == nil {
+		return 0
+	}
+	return int32(*value)
+}


### PR DESCRIPTION
## Summary
- Add `DebugServiceState` handling to inspect a Ziti service by ID or name.
- Return service roles, attached config JSON, service policies, and terminators for expose diagnostics.
- Map missing services to gRPC `NotFound`.

Closes #57
Supports agynio/expose#27 and agynio/api#142.

## Test & Lint Summary
- `nix shell nixpkgs#gcc --command sh -c 'go test ./... && go vet ./...'`: passed
- `git diff --check`: passed