### PR TITLE
feat(ziti): implement service reconcile APIs

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -38,3 +38,31 @@ jobs:
 
       - name: Go test
         run: go test ./...
+
+  publish-pr-image:
+    if: github.event_name == 'pull_request'
+    runs-on: ubuntu-latest
+    needs: build
+    permissions:
+      contents: read
+      packages: write
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v4
+
+      - name: Set up Docker Buildx
+        uses: docker/setup-buildx-action@v3
+
+      - name: Log in to GHCR
+        uses: docker/login-action@v3
+        with:
+          registry: ghcr.io
+          username: ${{ github.actor }}
+          password: ${{ secrets.GITHUB_TOKEN }}
+
+      - name: Build and publish PR image
+        uses: docker/build-push-action@v6
+        with:
+          context: .
+          push: true
+          tags: ghcr.io/agynio/ziti-management:pr-${{ github.event.pull_request.number }}-${{ github.event.pull_request.head.sha }}

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -30,8 +30,8 @@ jobs:
 
       - name: Generate gRPC stubs
         run: |
-          buf generate buf.build/agynio/api \
-            --path agynio/api/ziti_management/v1
+          buf generate https://github.com/agynio/api.git#branch=noa/issue-60-api \
+            --path proto/agynio/api/ziti_management/v1/ziti_management.proto
 
       - name: Go vet
         run: go vet ./...

--- a/Dockerfile
+++ b/Dockerfile
@@ -14,6 +14,8 @@ FROM --platform=$BUILDPLATFORM golang:${GO_VERSION}-alpine AS build
 
 WORKDIR /src
 
+RUN apk add --no-cache git
+
 COPY --from=buf /usr/local/bin/buf /usr/local/bin/buf
 
 COPY go.mod go.sum ./

--- a/Dockerfile
+++ b/Dockerfile
@@ -22,7 +22,8 @@ RUN --mount=type=cache,target=/go/pkg/mod \
     go mod download
 
 COPY buf.gen.yaml buf.yaml buf.lock ./
-RUN buf generate buf.build/agynio/api --path agynio/api/ziti_management/v1
+RUN buf generate https://github.com/agynio/api.git#branch=noa/issue-60-api \
+    --path proto/agynio/api/ziti_management/v1/ziti_management.proto
 
 COPY . .
 

--- a/internal/server/converter.go
+++ b/internal/server/converter.go
@@ -75,6 +75,19 @@ func fromProtoServicePolicyType(value zitimanagementv1.ServicePolicyType) (strin
 	}
 }
 
+func toProtoServicePolicyType(value string) (zitimanagementv1.ServicePolicyType, error) {
+	switch value {
+	case "Bind":
+		return zitimanagementv1.ServicePolicyType_SERVICE_POLICY_TYPE_BIND, nil
+	case "Dial":
+		return zitimanagementv1.ServicePolicyType_SERVICE_POLICY_TYPE_DIAL, nil
+	case "":
+		return zitimanagementv1.ServicePolicyType_SERVICE_POLICY_TYPE_UNSPECIFIED, fmt.Errorf("service policy type unspecified")
+	default:
+		return zitimanagementv1.ServicePolicyType_SERVICE_POLICY_TYPE_UNSPECIFIED, fmt.Errorf("unknown service policy type %s", value)
+	}
+}
+
 func fromProtoHostV1Config(value *zitimanagementv1.HostV1Config) (*ziti.HostV1ConfigData, error) {
 	if value == nil {
 		return nil, nil
@@ -210,6 +223,69 @@ func fromProtoOptionalPortRanges(portRanges []*zitimanagementv1.PortRange, field
 		convertedRanges[i] = ziti.PortRangeData{Low: low, High: high}
 	}
 	return convertedRanges, nil
+}
+
+func toProtoService(value ziti.Service) *zitimanagementv1.Service {
+	return &zitimanagementv1.Service{
+		ZitiServiceId:     value.ID,
+		Name:              value.Name,
+		RoleAttributes:    value.RoleAttributes,
+		HostV1Config:      toProtoHostV1Config(value.HostV1Config),
+		InterceptV1Config: toProtoInterceptV1Config(value.InterceptV1Config),
+	}
+}
+
+func toProtoServicePolicy(value ziti.ServicePolicy) (*zitimanagementv1.ServicePolicy, error) {
+	policyType, err := toProtoServicePolicyType(value.Type)
+	if err != nil {
+		return nil, err
+	}
+	return &zitimanagementv1.ServicePolicy{
+		ZitiServicePolicyId: value.ID,
+		Name:                value.Name,
+		Type:                policyType,
+		IdentityRoles:       value.IdentityRoles,
+		ServiceRoles:        value.ServiceRoles,
+	}, nil
+}
+
+func toProtoHostV1Config(value *ziti.HostV1ConfigData) *zitimanagementv1.HostV1Config {
+	if value == nil {
+		return nil
+	}
+	return &zitimanagementv1.HostV1Config{
+		Protocol:          value.Protocol,
+		Address:           value.Address,
+		Port:              value.Port,
+		ForwardProtocol:   value.ForwardProtocol,
+		ForwardAddress:    value.ForwardAddress,
+		ForwardPort:       value.ForwardPort,
+		AllowedProtocols:  value.AllowedProtocols,
+		AllowedAddresses:  value.AllowedAddresses,
+		AllowedPortRanges: toProtoPortRanges(value.AllowedPortRanges),
+	}
+}
+
+func toProtoInterceptV1Config(value *ziti.InterceptV1ConfigData) *zitimanagementv1.InterceptV1Config {
+	if value == nil {
+		return nil
+	}
+	return &zitimanagementv1.InterceptV1Config{
+		Protocols:  value.Protocols,
+		Addresses:  value.Addresses,
+		PortRanges: toProtoPortRanges(value.PortRanges),
+	}
+}
+
+func toProtoPortRanges(portRanges []ziti.PortRangeData) []*zitimanagementv1.PortRange {
+	if len(portRanges) == 0 {
+		return nil
+	}
+	values := make([]*zitimanagementv1.PortRange, 0, len(portRanges))
+	for _, portRange := range portRanges {
+		values = append(values, &zitimanagementv1.PortRange{Low: portRange.Low, High: portRange.High})
+	}
+	return values
 }
 
 func toProtoIdentityType(value store.IdentityType) (identityv1.IdentityType, error) {

--- a/internal/server/converter.go
+++ b/internal/server/converter.go
@@ -344,14 +344,14 @@ func toProtoOpenZitiServicePolicy(policy ziti.OpenZitiServicePolicy) *zitimanage
 	return &zitimanagementv1.OpenZitiServicePolicy{
 		ZitiServicePolicyId: policy.ID,
 		Name:                policy.Name,
-		Type:                toProtoServicePolicyType(policy.Type),
+		Type:                toProtoOpenZitiServicePolicyType(policy.Type),
 		IdentityRoles:       policy.IdentityRoles,
 		ServiceRoles:        policy.ServiceRoles,
 		Tags:                policy.Tags,
 	}
 }
 
-func toProtoServicePolicyType(value string) zitimanagementv1.ServicePolicyType {
+func toProtoOpenZitiServicePolicyType(value string) zitimanagementv1.ServicePolicyType {
 	switch value {
 	case "Bind":
 		return zitimanagementv1.ServicePolicyType_SERVICE_POLICY_TYPE_BIND

--- a/internal/server/identity_reenroll_test.go
+++ b/internal/server/identity_reenroll_test.go
@@ -202,10 +202,6 @@ func (f *fakeZitiClient) ListServicePoliciesByTag(_ context.Context, _ map[strin
 	return ziti.ListResult[ziti.OpenZitiServicePolicy]{}, errors.New("unexpected list service policies by tag")
 }
 
-func (f *fakeZitiClient) UpdateService(_ context.Context, _ string, _ *ziti.HostV1ConfigData, _ *ziti.InterceptV1ConfigData, _ map[string]string, _ bool) (ziti.OpenZitiService, error) {
-	return ziti.OpenZitiService{}, errors.New("unexpected update service")
-}
-
 func TestCreateAppIdentityAllowsReenroll(t *testing.T) {
 	ctx := context.Background()
 	appID := uuid.New()

--- a/internal/server/identity_reenroll_test.go
+++ b/internal/server/identity_reenroll_test.go
@@ -448,3 +448,39 @@ func TestPatchIdentityRoleAttributesMapsNotFound(t *testing.T) {
 		t.Fatalf("expected not found, got %v", err)
 	}
 }
+
+func (f *fakeZitiClient) CreateServiceReturning(_ context.Context, name string, _ []string, _ *ziti.HostV1ConfigData, _ *ziti.InterceptV1ConfigData, _ bool) (ziti.Service, error) {
+	return ziti.Service{ID: "service-id", Name: name}, nil
+}
+
+func (f *fakeZitiClient) GetService(_ context.Context, id string) (ziti.Service, error) {
+	return ziti.Service{ID: id, Name: "service"}, nil
+}
+
+func (f *fakeZitiClient) GetServiceByName(_ context.Context, name string) (ziti.Service, error) {
+	return ziti.Service{ID: "service-id", Name: name}, nil
+}
+
+func (f *fakeZitiClient) ListServices(context.Context, ziti.ServiceListFilter) (ziti.ServiceListResult, error) {
+	return ziti.ServiceListResult{}, nil
+}
+
+func (f *fakeZitiClient) UpdateService(_ context.Context, id string, name string, roleAttributes []string, hostV1 *ziti.HostV1ConfigData, interceptV1 *ziti.InterceptV1ConfigData) (ziti.Service, error) {
+	return ziti.Service{ID: id, Name: name, RoleAttributes: roleAttributes, HostV1Config: hostV1, InterceptV1Config: interceptV1}, nil
+}
+
+func (f *fakeZitiClient) CreateServicePolicyReturning(_ context.Context, name string, policyType string, identityRoles []string, serviceRoles []string, _ bool) (ziti.ServicePolicy, error) {
+	return ziti.ServicePolicy{ID: "policy-id", Name: name, Type: policyType, IdentityRoles: identityRoles, ServiceRoles: serviceRoles}, nil
+}
+
+func (f *fakeZitiClient) GetServicePolicy(_ context.Context, id string) (ziti.ServicePolicy, error) {
+	return ziti.ServicePolicy{ID: id, Name: "policy", Type: "Dial"}, nil
+}
+
+func (f *fakeZitiClient) GetServicePolicyByName(_ context.Context, name string) (ziti.ServicePolicy, error) {
+	return ziti.ServicePolicy{ID: "policy-id", Name: name, Type: "Dial"}, nil
+}
+
+func (f *fakeZitiClient) ListServicePolicies(context.Context, ziti.ServicePolicyListFilter) (ziti.ServicePolicyListResult, error) {
+	return ziti.ServicePolicyListResult{}, nil
+}

--- a/internal/server/server.go
+++ b/internal/server/server.go
@@ -42,8 +42,17 @@ type zitiClient interface {
 	CreateService(ctx context.Context, name string, roleAttributes []string) (string, error)
 	CreateServiceWithConfigs(ctx context.Context, name string, roleAttributes []string, hostV1 *ziti.HostV1ConfigData, interceptV1 *ziti.InterceptV1ConfigData) (string, error)
 	CreateServiceWithConfigsAndTags(ctx context.Context, name string, roleAttributes []string, hostV1 *ziti.HostV1ConfigData, interceptV1 *ziti.InterceptV1ConfigData, tags map[string]string) (string, error)
+	CreateServiceReturning(ctx context.Context, name string, roleAttributes []string, hostV1 *ziti.HostV1ConfigData, interceptV1 *ziti.InterceptV1ConfigData, returnExisting bool) (ziti.Service, error)
+	GetService(ctx context.Context, id string) (ziti.Service, error)
+	GetServiceByName(ctx context.Context, name string) (ziti.Service, error)
+	ListServices(ctx context.Context, filter ziti.ServiceListFilter) (ziti.ServiceListResult, error)
+	UpdateService(ctx context.Context, id string, name string, roleAttributes []string, hostV1 *ziti.HostV1ConfigData, interceptV1 *ziti.InterceptV1ConfigData) (ziti.Service, error)
 	CreateServicePolicy(ctx context.Context, name, policyType string, identityRoles, serviceRoles []string) (string, error)
 	CreateServicePolicyWithTags(ctx context.Context, name, policyType string, identityRoles, serviceRoles []string, tags map[string]string) (string, error)
+	CreateServicePolicyReturning(ctx context.Context, name, policyType string, identityRoles, serviceRoles []string, returnExisting bool) (ziti.ServicePolicy, error)
+	GetServicePolicy(ctx context.Context, id string) (ziti.ServicePolicy, error)
+	GetServicePolicyByName(ctx context.Context, name string) (ziti.ServicePolicy, error)
+	ListServicePolicies(ctx context.Context, filter ziti.ServicePolicyListFilter) (ziti.ServicePolicyListResult, error)
 	CreateDeviceIdentity(ctx context.Context, userIdentityID uuid.UUID, name string) (string, string, error)
 	CreateDeviceIdentityWithOptions(ctx context.Context, userIdentityID uuid.UUID, name string, additionalRoleAttributes []string, tags map[string]string) (string, string, error)
 	CreateTunnelIdentity(ctx context.Context, networkID, tunnelCredentialID string, tags map[string]string) (string, ziti.EnrollmentJWT, error)
@@ -170,19 +179,14 @@ func (s *Server) CreateService(ctx context.Context, req *zitimanagementv1.Create
 		return nil, status.Errorf(codes.InvalidArgument, "intercept_v1_config: %v", err)
 	}
 
-	var serviceID string
-	if hostV1Config != nil || interceptV1Config != nil || len(req.GetTags()) > 0 {
-		serviceID, err = s.ziti.CreateServiceWithConfigsAndTags(ctx, name, roleAttributes, hostV1Config, interceptV1Config, req.GetTags())
-	} else {
-		serviceID, err = s.ziti.CreateService(ctx, name, roleAttributes)
-	}
+	service, err := s.ziti.CreateServiceReturning(ctx, name, roleAttributes, hostV1Config, interceptV1Config, req.GetReturnExisting())
 	if err != nil {
 		return nil, status.Errorf(codes.Internal, "create ziti service: %v", err)
 	}
 
 	return &zitimanagementv1.CreateServiceResponse{
-		ZitiServiceId:   serviceID,
-		ZitiServiceName: name,
+		ZitiServiceId:   service.ID,
+		ZitiServiceName: service.Name,
 	}, nil
 }
 
@@ -392,12 +396,12 @@ func (s *Server) CreateServicePolicy(ctx context.Context, req *zitimanagementv1.
 		return nil, status.Error(codes.InvalidArgument, "service_roles is required")
 	}
 
-	policyID, err := s.ziti.CreateServicePolicyWithTags(ctx, name, policyType, identityRoles, serviceRoles, req.GetTags())
+	policy, err := s.ziti.CreateServicePolicyReturning(ctx, name, policyType, identityRoles, serviceRoles, req.GetReturnExisting())
 	if err != nil {
 		return nil, status.Errorf(codes.Internal, "create ziti service policy: %v", err)
 	}
 
-	return &zitimanagementv1.CreateServicePolicyResponse{ZitiServicePolicyId: policyID}, nil
+	return &zitimanagementv1.CreateServicePolicyResponse{ZitiServicePolicyId: policy.ID}, nil
 }
 
 func (s *Server) DeleteServicePolicy(ctx context.Context, req *zitimanagementv1.DeleteServicePolicyRequest) (*zitimanagementv1.DeleteServicePolicyResponse, error) {

--- a/internal/server/server.go
+++ b/internal/server/server.go
@@ -64,7 +64,6 @@ type zitiClient interface {
 	ListServicesByTag(ctx context.Context, tags map[string]string, pageSize int32, pageToken string) (ziti.ListResult[ziti.OpenZitiService], error)
 	ListIdentitiesByTag(ctx context.Context, tags map[string]string, pageSize int32, pageToken string) (ziti.ListResult[ziti.OpenZitiIdentity], error)
 	ListServicePoliciesByTag(ctx context.Context, tags map[string]string, pageSize int32, pageToken string) (ziti.ListResult[ziti.OpenZitiServicePolicy], error)
-	UpdateService(ctx context.Context, serviceID string, hostV1 *ziti.HostV1ConfigData, interceptV1 *ziti.InterceptV1ConfigData, tags map[string]string, updateTags bool) (ziti.OpenZitiService, error)
 }
 
 type Server struct {
@@ -569,32 +568,6 @@ func (s *Server) ListServicePoliciesByTag(ctx context.Context, req *zitimanageme
 		resp.ServicePolicies[i] = toProtoOpenZitiServicePolicy(item)
 	}
 	return resp, nil
-}
-
-func (s *Server) UpdateService(ctx context.Context, req *zitimanagementv1.UpdateServiceRequest) (*zitimanagementv1.UpdateServiceResponse, error) {
-	serviceID := req.GetZitiServiceId()
-	if serviceID == "" {
-		return nil, status.Error(codes.InvalidArgument, "ziti_service_id is required")
-	}
-	hostV1Config, err := fromProtoHostV1Config(req.GetHostV1Config())
-	if err != nil {
-		return nil, status.Errorf(codes.InvalidArgument, "host_v1_config: %v", err)
-	}
-	interceptV1Config, err := fromProtoInterceptV1Config(req.GetInterceptV1Config())
-	if err != nil {
-		return nil, status.Errorf(codes.InvalidArgument, "intercept_v1_config: %v", err)
-	}
-	tags := req.GetTags()
-	updateTags := len(tags) > 0
-	if req.GetTagsUpdate() != nil {
-		tags = req.GetTagsUpdate().GetTags()
-		updateTags = true
-	}
-	updated, err := s.ziti.UpdateService(ctx, serviceID, hostV1Config, interceptV1Config, tags, updateTags)
-	if err != nil {
-		return nil, status.Errorf(codes.Internal, "update ziti service: %v", err)
-	}
-	return &zitimanagementv1.UpdateServiceResponse{Service: toProtoOpenZitiService(updated)}, nil
 }
 
 func (s *Server) ListManagedIdentities(ctx context.Context, req *zitimanagementv1.ListManagedIdentitiesRequest) (*zitimanagementv1.ListManagedIdentitiesResponse, error) {

--- a/internal/server/services.go
+++ b/internal/server/services.go
@@ -1,0 +1,184 @@
+package server
+
+import (
+	"context"
+	"errors"
+	"strings"
+
+	zitimanagementv1 "github.com/agynio/ziti-management/.gen/go/agynio/api/ziti_management/v1"
+	"github.com/agynio/ziti-management/internal/ziti"
+	"google.golang.org/grpc/codes"
+	"google.golang.org/grpc/status"
+)
+
+func (s *Server) GetService(ctx context.Context, req *zitimanagementv1.GetServiceRequest) (*zitimanagementv1.GetServiceResponse, error) {
+	service, err := s.getService(ctx, req)
+	if err != nil {
+		return nil, err
+	}
+	return &zitimanagementv1.GetServiceResponse{Service: toProtoService(service)}, nil
+}
+
+func (s *Server) ListServices(ctx context.Context, req *zitimanagementv1.ListServicesRequest) (*zitimanagementv1.ListServicesResponse, error) {
+	name := strings.TrimSpace(req.GetName())
+	namePrefix := strings.TrimSpace(req.GetNamePrefix())
+	if name != "" && namePrefix != "" {
+		return nil, status.Error(codes.InvalidArgument, "only one of name or name_prefix may be set")
+	}
+	result, err := s.ziti.ListServices(ctx, ziti.ServiceListFilter{
+		Name:           name,
+		NamePrefix:     namePrefix,
+		RoleAttributes: cleanStringList(req.GetRoleAttributes()),
+		PageSize:       req.GetPageSize(),
+		PageToken:      req.GetPageToken(),
+	})
+	if err != nil {
+		return nil, status.Errorf(codes.Internal, "list ziti services: %v", err)
+	}
+	services := make([]*zitimanagementv1.Service, 0, len(result.Services))
+	for _, service := range result.Services {
+		services = append(services, toProtoService(service))
+	}
+	return &zitimanagementv1.ListServicesResponse{Services: services, NextPageToken: result.NextPageToken}, nil
+}
+
+func (s *Server) UpdateService(ctx context.Context, req *zitimanagementv1.UpdateServiceRequest) (*zitimanagementv1.UpdateServiceResponse, error) {
+	serviceID := strings.TrimSpace(req.GetZitiServiceId())
+	if serviceID == "" {
+		return nil, status.Error(codes.InvalidArgument, "ziti_service_id is required")
+	}
+	name := strings.TrimSpace(req.GetName())
+	if name == "" {
+		return nil, status.Error(codes.InvalidArgument, "name is required")
+	}
+	roleAttributes := cleanStringList(req.GetRoleAttributes())
+	if len(roleAttributes) == 0 {
+		return nil, status.Error(codes.InvalidArgument, "role_attributes is required")
+	}
+	hostV1Config, err := fromProtoHostV1Config(req.GetHostV1Config())
+	if err != nil {
+		return nil, status.Errorf(codes.InvalidArgument, "host_v1_config: %v", err)
+	}
+	interceptV1Config, err := fromProtoInterceptV1Config(req.GetInterceptV1Config())
+	if err != nil {
+		return nil, status.Errorf(codes.InvalidArgument, "intercept_v1_config: %v", err)
+	}
+	service, err := s.ziti.UpdateService(ctx, serviceID, name, roleAttributes, hostV1Config, interceptV1Config)
+	if err != nil {
+		if errors.Is(err, ziti.ErrServiceNotFound) {
+			return nil, status.Error(codes.NotFound, "ziti service not found")
+		}
+		return nil, status.Errorf(codes.Internal, "update ziti service: %v", err)
+	}
+	return &zitimanagementv1.UpdateServiceResponse{Service: toProtoService(service)}, nil
+}
+
+func (s *Server) GetServicePolicy(ctx context.Context, req *zitimanagementv1.GetServicePolicyRequest) (*zitimanagementv1.GetServicePolicyResponse, error) {
+	policy, err := s.getServicePolicy(ctx, req)
+	if err != nil {
+		return nil, err
+	}
+	protoPolicy, err := toProtoServicePolicy(policy)
+	if err != nil {
+		return nil, status.Errorf(codes.Internal, "convert ziti service policy: %v", err)
+	}
+	return &zitimanagementv1.GetServicePolicyResponse{ServicePolicy: protoPolicy}, nil
+}
+
+func (s *Server) ListServicePolicies(ctx context.Context, req *zitimanagementv1.ListServicePoliciesRequest) (*zitimanagementv1.ListServicePoliciesResponse, error) {
+	name := strings.TrimSpace(req.GetName())
+	namePrefix := strings.TrimSpace(req.GetNamePrefix())
+	if name != "" && namePrefix != "" {
+		return nil, status.Error(codes.InvalidArgument, "only one of name or name_prefix may be set")
+	}
+	var policyType string
+	var err error
+	if req.GetType() != zitimanagementv1.ServicePolicyType_SERVICE_POLICY_TYPE_UNSPECIFIED {
+		policyType, err = fromProtoServicePolicyType(req.GetType())
+		if err != nil {
+			return nil, status.Errorf(codes.InvalidArgument, "type: %v", err)
+		}
+	}
+	result, err := s.ziti.ListServicePolicies(ctx, ziti.ServicePolicyListFilter{
+		Name:          name,
+		NamePrefix:    namePrefix,
+		Type:          policyType,
+		IdentityRoles: cleanStringList(req.GetIdentityRoles()),
+		ServiceRoles:  cleanStringList(req.GetServiceRoles()),
+		PageSize:      req.GetPageSize(),
+		PageToken:     req.GetPageToken(),
+	})
+	if err != nil {
+		return nil, status.Errorf(codes.Internal, "list ziti service policies: %v", err)
+	}
+	policies := make([]*zitimanagementv1.ServicePolicy, 0, len(result.ServicePolicies))
+	for _, policy := range result.ServicePolicies {
+		protoPolicy, err := toProtoServicePolicy(policy)
+		if err != nil {
+			return nil, status.Errorf(codes.Internal, "convert ziti service policy: %v", err)
+		}
+		policies = append(policies, protoPolicy)
+	}
+	return &zitimanagementv1.ListServicePoliciesResponse{ServicePolicies: policies, NextPageToken: result.NextPageToken}, nil
+}
+
+func (s *Server) getService(ctx context.Context, req *zitimanagementv1.GetServiceRequest) (ziti.Service, error) {
+	serviceID := strings.TrimSpace(req.GetZitiServiceId())
+	name := strings.TrimSpace(req.GetName())
+	if serviceID == "" && name == "" {
+		return ziti.Service{}, status.Error(codes.InvalidArgument, "ziti_service_id or name is required")
+	}
+	if serviceID != "" && name != "" {
+		return ziti.Service{}, status.Error(codes.InvalidArgument, "only one of ziti_service_id or name may be set")
+	}
+	var service ziti.Service
+	var err error
+	if serviceID != "" {
+		service, err = s.ziti.GetService(ctx, serviceID)
+	} else {
+		service, err = s.ziti.GetServiceByName(ctx, name)
+	}
+	if err != nil {
+		if errors.Is(err, ziti.ErrServiceNotFound) {
+			return ziti.Service{}, status.Error(codes.NotFound, "ziti service not found")
+		}
+		return ziti.Service{}, status.Errorf(codes.Internal, "get ziti service: %v", err)
+	}
+	return service, nil
+}
+
+func (s *Server) getServicePolicy(ctx context.Context, req *zitimanagementv1.GetServicePolicyRequest) (ziti.ServicePolicy, error) {
+	policyID := strings.TrimSpace(req.GetZitiServicePolicyId())
+	name := strings.TrimSpace(req.GetName())
+	if policyID == "" && name == "" {
+		return ziti.ServicePolicy{}, status.Error(codes.InvalidArgument, "ziti_service_policy_id or name is required")
+	}
+	if policyID != "" && name != "" {
+		return ziti.ServicePolicy{}, status.Error(codes.InvalidArgument, "only one of ziti_service_policy_id or name may be set")
+	}
+	var policy ziti.ServicePolicy
+	var err error
+	if policyID != "" {
+		policy, err = s.ziti.GetServicePolicy(ctx, policyID)
+	} else {
+		policy, err = s.ziti.GetServicePolicyByName(ctx, name)
+	}
+	if err != nil {
+		if errors.Is(err, ziti.ErrServicePolicyNotFound) {
+			return ziti.ServicePolicy{}, status.Error(codes.NotFound, "ziti service policy not found")
+		}
+		return ziti.ServicePolicy{}, status.Errorf(codes.Internal, "get ziti service policy: %v", err)
+	}
+	return policy, nil
+}
+
+func cleanStringList(values []string) []string {
+	cleaned := make([]string, 0, len(values))
+	for _, value := range values {
+		trimmed := strings.TrimSpace(value)
+		if trimmed != "" {
+			cleaned = append(cleaned, trimmed)
+		}
+	}
+	return cleaned
+}

--- a/internal/server/services.go
+++ b/internal/server/services.go
@@ -70,7 +70,10 @@ func (s *Server) UpdateService(ctx context.Context, req *zitimanagementv1.Update
 		}
 		return nil, status.Errorf(codes.Internal, "update ziti service: %v", err)
 	}
-	return &zitimanagementv1.UpdateServiceResponse{Service: toProtoService(service)}, nil
+	return &zitimanagementv1.UpdateServiceResponse{
+		Service:           &zitimanagementv1.OpenZitiService{ZitiServiceId: service.ID, Name: service.Name, RoleAttributes: service.RoleAttributes},
+		ReconciledService: toProtoService(service),
+	}, nil
 }
 
 func (s *Server) GetServicePolicy(ctx context.Context, req *zitimanagementv1.GetServicePolicyRequest) (*zitimanagementv1.GetServicePolicyResponse, error) {

--- a/internal/ziti/client.go
+++ b/internal/ziti/client.go
@@ -5,6 +5,7 @@ import (
 	"crypto"
 	"crypto/tls"
 	"crypto/x509"
+	"encoding/base64"
 	"encoding/json"
 	"errors"
 	"fmt"
@@ -48,6 +49,9 @@ type identityService interface {
 
 type serviceService interface {
 	CreateService(params *service.CreateServiceParams, authInfo runtime.ClientAuthInfoWriter, opts ...service.ClientOption) (*service.CreateServiceCreated, error)
+	DetailService(params *service.DetailServiceParams, authInfo runtime.ClientAuthInfoWriter, opts ...service.ClientOption) (*service.DetailServiceOK, error)
+	ListServices(params *service.ListServicesParams, authInfo runtime.ClientAuthInfoWriter, opts ...service.ClientOption) (*service.ListServicesOK, error)
+	UpdateService(params *service.UpdateServiceParams, authInfo runtime.ClientAuthInfoWriter, opts ...service.ClientOption) (*service.UpdateServiceOK, error)
 	DeleteService(params *service.DeleteServiceParams, authInfo runtime.ClientAuthInfoWriter, opts ...service.ClientOption) (*service.DeleteServiceOK, error)
 	DetailService(params *service.DetailServiceParams, authInfo runtime.ClientAuthInfoWriter, opts ...service.ClientOption) (*service.DetailServiceOK, error)
 	ListServiceConfig(params *service.ListServiceConfigParams, authInfo runtime.ClientAuthInfoWriter, opts ...service.ClientOption) (*service.ListServiceConfigOK, error)
@@ -63,6 +67,8 @@ type configService interface {
 
 type servicePolicyService interface {
 	CreateServicePolicy(params *service_policy.CreateServicePolicyParams, authInfo runtime.ClientAuthInfoWriter, opts ...service_policy.ClientOption) (*service_policy.CreateServicePolicyCreated, error)
+	DetailServicePolicy(params *service_policy.DetailServicePolicyParams, authInfo runtime.ClientAuthInfoWriter, opts ...service_policy.ClientOption) (*service_policy.DetailServicePolicyOK, error)
+	ListServicePolicies(params *service_policy.ListServicePoliciesParams, authInfo runtime.ClientAuthInfoWriter, opts ...service_policy.ClientOption) (*service_policy.ListServicePoliciesOK, error)
 	DeleteServicePolicy(params *service_policy.DeleteServicePolicyParams, authInfo runtime.ClientAuthInfoWriter, opts ...service_policy.ClientOption) (*service_policy.DeleteServicePolicyOK, error)
 	ListServicePolicies(params *service_policy.ListServicePoliciesParams, authInfo runtime.ClientAuthInfoWriter, opts ...service_policy.ClientOption) (*service_policy.ListServicePoliciesOK, error)
 }
@@ -1249,4 +1255,455 @@ func (c *Client) DeleteIdentity(ctx context.Context, zitiIdentityID string) erro
 		return ErrIdentityNotFound
 	}
 	return fmt.Errorf("delete ziti identity: %w", err)
+}
+
+const defaultListLimit int64 = 100
+
+func (c *Client) GetService(ctx context.Context, id string) (Service, error) {
+	params := service.NewDetailServiceParamsWithContext(ctx)
+	params.ID = id
+	var detail *rest_model.ServiceDetail
+	err := c.withReauth(func() error {
+		serviceClient := c.serviceClient()
+		resp, callErr := serviceClient.DetailService(params, nil)
+		if callErr != nil {
+			return callErr
+		}
+		if resp != nil && resp.Payload != nil {
+			detail = resp.Payload.Data
+		}
+		return nil
+	})
+	if err != nil {
+		var notFound *service.DetailServiceNotFound
+		if errors.As(err, &notFound) {
+			return Service{}, ErrServiceNotFound
+		}
+		return Service{}, fmt.Errorf("get ziti service: %w", err)
+	}
+	if detail == nil {
+		return Service{}, fmt.Errorf("get ziti service: missing response data")
+	}
+	return serviceFromDetail(detail), nil
+}
+
+func (c *Client) GetServiceByName(ctx context.Context, name string) (Service, error) {
+	result, err := c.ListServices(ctx, ServiceListFilter{Name: name, PageSize: 2})
+	if err != nil {
+		return Service{}, err
+	}
+	if len(result.Services) == 0 {
+		return Service{}, ErrServiceNotFound
+	}
+	return result.Services[0], nil
+}
+
+func (c *Client) ListServices(ctx context.Context, filter ServiceListFilter) (ServiceListResult, error) {
+	limit := listLimit(filter.PageSize)
+	offset, err := decodePageToken(filter.PageToken)
+	if err != nil {
+		return ServiceListResult{}, err
+	}
+	queryFilter := serviceFilter(filter)
+	params := service.NewListServicesParamsWithContext(ctx)
+	params.Limit = &limit
+	params.Offset = &offset
+	if queryFilter != "" {
+		params.Filter = &queryFilter
+	}
+	var envelope *rest_model.ListServicesEnvelope
+	err = c.withReauth(func() error {
+		serviceClient := c.serviceClient()
+		resp, callErr := serviceClient.ListServices(params, nil)
+		if callErr != nil {
+			return callErr
+		}
+		if resp != nil {
+			envelope = resp.Payload
+		}
+		return nil
+	})
+	if err != nil {
+		return ServiceListResult{}, fmt.Errorf("list ziti services: %w", err)
+	}
+	if envelope == nil {
+		return ServiceListResult{}, fmt.Errorf("list ziti services: missing response data")
+	}
+	items := make([]Service, 0, len(envelope.Data))
+	for _, detail := range envelope.Data {
+		items = append(items, serviceFromDetail(detail))
+	}
+	return ServiceListResult{Services: items, NextPageToken: nextPageToken(envelope.Meta)}, nil
+}
+
+func (c *Client) CreateServiceReturning(ctx context.Context, name string, roleAttributes []string, hostV1 *HostV1ConfigData, interceptV1 *InterceptV1ConfigData, returnExisting bool) (Service, error) {
+	serviceID, err := c.CreateServiceWithConfigs(ctx, name, roleAttributes, hostV1, interceptV1)
+	if err == nil {
+		return c.GetService(ctx, serviceID)
+	}
+	if !returnExisting || !isConflictError(err) {
+		return Service{}, err
+	}
+	return c.GetServiceByName(ctx, name)
+}
+
+func (c *Client) UpdateService(ctx context.Context, id string, name string, roleAttributes []string, hostV1 *HostV1ConfigData, interceptV1 *InterceptV1ConfigData) (Service, error) {
+	configIDs := make([]string, 0, 2)
+	if hostV1 != nil {
+		configID, err := c.createConfig(ctx, hostV1ConfigTypeID, fmt.Sprintf("%s-host-v1", name), hostV1ConfigData(hostV1))
+		if err != nil {
+			return Service{}, err
+		}
+		configIDs = append(configIDs, configID)
+	}
+	if interceptV1 != nil {
+		configID, err := c.createConfig(ctx, interceptV1ConfigTypeID, fmt.Sprintf("%s-intercept-v1", name), interceptV1ConfigData(interceptV1))
+		if err != nil {
+			return Service{}, c.cleanupConfigs(ctx, configIDs, err)
+		}
+		configIDs = append(configIDs, configID)
+	}
+	params := service.NewUpdateServiceParamsWithContext(ctx)
+	params.ID = id
+	params.Service = &rest_model.ServiceUpdate{Name: &name, RoleAttributes: roleAttributes, Configs: configIDs}
+	err := c.withReauth(func() error {
+		serviceClient := c.serviceClient()
+		_, callErr := serviceClient.UpdateService(params, nil)
+		return callErr
+	})
+	if err != nil {
+		var notFound *service.UpdateServiceNotFound
+		if errors.As(err, &notFound) {
+			return Service{}, c.cleanupConfigs(ctx, configIDs, ErrServiceNotFound)
+		}
+		return Service{}, c.cleanupConfigs(ctx, configIDs, fmt.Errorf("update ziti service: %w", err))
+	}
+	return c.GetService(ctx, id)
+}
+
+func (c *Client) GetServicePolicy(ctx context.Context, id string) (ServicePolicy, error) {
+	params := service_policy.NewDetailServicePolicyParamsWithContext(ctx)
+	params.ID = id
+	var detail *rest_model.ServicePolicyDetail
+	err := c.withReauth(func() error {
+		servicePolicyClient := c.servicePolicyClient()
+		resp, callErr := servicePolicyClient.DetailServicePolicy(params, nil)
+		if callErr != nil {
+			return callErr
+		}
+		if resp != nil && resp.Payload != nil {
+			detail = resp.Payload.Data
+		}
+		return nil
+	})
+	if err != nil {
+		var notFound *service_policy.DetailServicePolicyNotFound
+		if errors.As(err, &notFound) {
+			return ServicePolicy{}, ErrServicePolicyNotFound
+		}
+		return ServicePolicy{}, fmt.Errorf("get ziti service policy: %w", err)
+	}
+	if detail == nil {
+		return ServicePolicy{}, fmt.Errorf("get ziti service policy: missing response data")
+	}
+	return servicePolicyFromDetail(detail), nil
+}
+
+func (c *Client) GetServicePolicyByName(ctx context.Context, name string) (ServicePolicy, error) {
+	result, err := c.ListServicePolicies(ctx, ServicePolicyListFilter{Name: name, PageSize: 2})
+	if err != nil {
+		return ServicePolicy{}, err
+	}
+	if len(result.ServicePolicies) == 0 {
+		return ServicePolicy{}, ErrServicePolicyNotFound
+	}
+	return result.ServicePolicies[0], nil
+}
+
+func (c *Client) ListServicePolicies(ctx context.Context, filter ServicePolicyListFilter) (ServicePolicyListResult, error) {
+	limit := listLimit(filter.PageSize)
+	offset, err := decodePageToken(filter.PageToken)
+	if err != nil {
+		return ServicePolicyListResult{}, err
+	}
+	queryFilter := servicePolicyFilter(filter)
+	params := service_policy.NewListServicePoliciesParamsWithContext(ctx)
+	params.Limit = &limit
+	params.Offset = &offset
+	if queryFilter != "" {
+		params.Filter = &queryFilter
+	}
+	var envelope *rest_model.ListServicePoliciesEnvelope
+	err = c.withReauth(func() error {
+		servicePolicyClient := c.servicePolicyClient()
+		resp, callErr := servicePolicyClient.ListServicePolicies(params, nil)
+		if callErr != nil {
+			return callErr
+		}
+		if resp != nil {
+			envelope = resp.Payload
+		}
+		return nil
+	})
+	if err != nil {
+		return ServicePolicyListResult{}, fmt.Errorf("list ziti service policies: %w", err)
+	}
+	if envelope == nil {
+		return ServicePolicyListResult{}, fmt.Errorf("list ziti service policies: missing response data")
+	}
+	items := make([]ServicePolicy, 0, len(envelope.Data))
+	for _, detail := range envelope.Data {
+		items = append(items, servicePolicyFromDetail(detail))
+	}
+	return ServicePolicyListResult{ServicePolicies: items, NextPageToken: nextPageToken(envelope.Meta)}, nil
+}
+
+func (c *Client) CreateServicePolicyReturning(ctx context.Context, name, policyType string, identityRoles, serviceRoles []string, returnExisting bool) (ServicePolicy, error) {
+	policyID, err := c.CreateServicePolicy(ctx, name, policyType, identityRoles, serviceRoles)
+	if err == nil {
+		return c.GetServicePolicy(ctx, policyID)
+	}
+	if !returnExisting || !isConflictError(err) {
+		return ServicePolicy{}, err
+	}
+	return c.GetServicePolicyByName(ctx, name)
+}
+
+func hostV1ConfigData(hostV1 *HostV1ConfigData) map[string]any {
+	data := map[string]any{
+		"protocol":        hostV1.Protocol,
+		"address":         hostV1.Address,
+		"port":            hostV1.Port,
+		"forwardProtocol": hostV1.ForwardProtocol,
+		"forwardAddress":  hostV1.ForwardAddress,
+		"forwardPort":     hostV1.ForwardPort,
+	}
+	if len(hostV1.AllowedProtocols) > 0 {
+		data["allowedProtocols"] = hostV1.AllowedProtocols
+	}
+	if len(hostV1.AllowedAddresses) > 0 {
+		data["allowedAddresses"] = hostV1.AllowedAddresses
+	}
+	if len(hostV1.AllowedPortRanges) > 0 {
+		data["allowedPortRanges"] = portRangeConfigData(hostV1.AllowedPortRanges)
+	}
+	return data
+}
+
+func interceptV1ConfigData(interceptV1 *InterceptV1ConfigData) map[string]any {
+	return map[string]any{
+		"protocols":  interceptV1.Protocols,
+		"addresses":  interceptV1.Addresses,
+		"portRanges": portRangeConfigData(interceptV1.PortRanges),
+	}
+}
+
+func serviceFromDetail(detail *rest_model.ServiceDetail) Service {
+	return Service{
+		ID:                stringValue(detail.ID),
+		Name:              stringValue(detail.Name),
+		RoleAttributes:    attributesToStrings(detail.RoleAttributes),
+		HostV1Config:      hostV1FromConfig(detail.Config["host.v1"]),
+		InterceptV1Config: interceptV1FromConfig(detail.Config["intercept.v1"]),
+	}
+}
+
+func servicePolicyFromDetail(detail *rest_model.ServicePolicyDetail) ServicePolicy {
+	return ServicePolicy{
+		ID:            stringValue(detail.ID),
+		Name:          stringValue(detail.Name),
+		Type:          stringValue((*string)(detail.Type)),
+		IdentityRoles: rolesToStrings(detail.IdentityRoles),
+		ServiceRoles:  rolesToStrings(detail.ServiceRoles),
+	}
+}
+
+func serviceFilter(filter ServiceListFilter) string {
+	parts := make([]string, 0)
+	if filter.Name != "" {
+		parts = append(parts, fmt.Sprintf(`name = "%s"`, escapeFilterValue(filter.Name)))
+	}
+	if filter.NamePrefix != "" {
+		parts = append(parts, fmt.Sprintf(`name contains "%s"`, escapeFilterValue(filter.NamePrefix)))
+	}
+	for _, role := range filter.RoleAttributes {
+		parts = append(parts, fmt.Sprintf(`roleAttributes contains "%s"`, escapeFilterValue(role)))
+	}
+	return strings.Join(parts, " and ")
+}
+
+func servicePolicyFilter(filter ServicePolicyListFilter) string {
+	parts := make([]string, 0)
+	if filter.Name != "" {
+		parts = append(parts, fmt.Sprintf(`name = "%s"`, escapeFilterValue(filter.Name)))
+	}
+	if filter.NamePrefix != "" {
+		parts = append(parts, fmt.Sprintf(`name contains "%s"`, escapeFilterValue(filter.NamePrefix)))
+	}
+	if filter.Type != "" {
+		parts = append(parts, fmt.Sprintf(`type = "%s"`, escapeFilterValue(filter.Type)))
+	}
+	for _, role := range filter.IdentityRoles {
+		parts = append(parts, fmt.Sprintf(`identityRoles contains "%s"`, escapeFilterValue(role)))
+	}
+	for _, role := range filter.ServiceRoles {
+		parts = append(parts, fmt.Sprintf(`serviceRoles contains "%s"`, escapeFilterValue(role)))
+	}
+	return strings.Join(parts, " and ")
+}
+
+func escapeFilterValue(value string) string {
+	return strings.ReplaceAll(value, `"`, `\"`)
+}
+
+func listLimit(pageSize int32) int64 {
+	if pageSize <= 0 {
+		return defaultListLimit
+	}
+	return int64(pageSize)
+}
+
+func decodePageToken(token string) (int64, error) {
+	if token == "" {
+		return 0, nil
+	}
+	raw, err := base64.RawURLEncoding.DecodeString(token)
+	if err != nil {
+		return 0, fmt.Errorf("invalid page token")
+	}
+	offset, err := strconv.ParseInt(string(raw), 10, 64)
+	if err != nil || offset < 0 {
+		return 0, fmt.Errorf("invalid page token")
+	}
+	return offset, nil
+}
+
+func nextPageToken(meta *rest_model.Meta) string {
+	if meta == nil || meta.Pagination == nil || meta.Pagination.Offset == nil || meta.Pagination.Limit == nil || meta.Pagination.TotalCount == nil {
+		return ""
+	}
+	nextOffset := *meta.Pagination.Offset + *meta.Pagination.Limit
+	if nextOffset >= *meta.Pagination.TotalCount {
+		return ""
+	}
+	return base64.RawURLEncoding.EncodeToString([]byte(strconv.FormatInt(nextOffset, 10)))
+}
+
+func stringValue(value *string) string {
+	if value == nil {
+		return ""
+	}
+	return *value
+}
+
+func attributesToStrings(values *rest_model.Attributes) []string {
+	if values == nil {
+		return nil
+	}
+	return append([]string(nil), ([]string)(*values)...)
+}
+
+func rolesToStrings(values rest_model.Roles) []string {
+	return append([]string(nil), ([]string)(values)...)
+}
+
+func hostV1FromConfig(config map[string]any) *HostV1ConfigData {
+	if config == nil {
+		return nil
+	}
+	return &HostV1ConfigData{
+		Protocol:          stringFromMap(config, "protocol"),
+		Address:           stringFromMap(config, "address"),
+		Port:              int32FromMap(config, "port"),
+		ForwardProtocol:   boolFromMap(config, "forwardProtocol"),
+		ForwardAddress:    boolFromMap(config, "forwardAddress"),
+		ForwardPort:       boolFromMap(config, "forwardPort"),
+		AllowedProtocols:  stringsFromMap(config, "allowedProtocols"),
+		AllowedAddresses:  stringsFromMap(config, "allowedAddresses"),
+		AllowedPortRanges: portRangesFromMap(config, "allowedPortRanges"),
+	}
+}
+
+func interceptV1FromConfig(config map[string]any) *InterceptV1ConfigData {
+	if config == nil {
+		return nil
+	}
+	return &InterceptV1ConfigData{
+		Protocols:  stringsFromMap(config, "protocols"),
+		Addresses:  stringsFromMap(config, "addresses"),
+		PortRanges: portRangesFromMap(config, "portRanges"),
+	}
+}
+
+func stringFromMap(values map[string]any, key string) string {
+	value, ok := values[key].(string)
+	if !ok {
+		return ""
+	}
+	return value
+}
+
+func boolFromMap(values map[string]any, key string) bool {
+	value, ok := values[key].(bool)
+	return ok && value
+}
+
+func int32FromMap(values map[string]any, key string) int32 {
+	switch value := values[key].(type) {
+	case int32:
+		return value
+	case int:
+		return int32(value)
+	case int64:
+		return int32(value)
+	case float64:
+		return int32(value)
+	case json.Number:
+		parsed, err := strconv.ParseInt(value.String(), 10, 32)
+		if err != nil {
+			return 0
+		}
+		return int32(parsed)
+	default:
+		return 0
+	}
+}
+
+func stringsFromMap(values map[string]any, key string) []string {
+	raw, ok := values[key].([]any)
+	if !ok {
+		if strings, ok := values[key].([]string); ok {
+			return append([]string(nil), strings...)
+		}
+		return nil
+	}
+	strings := make([]string, 0, len(raw))
+	for _, item := range raw {
+		value, ok := item.(string)
+		if ok {
+			strings = append(strings, value)
+		}
+	}
+	return strings
+}
+
+func portRangesFromMap(values map[string]any, key string) []PortRangeData {
+	raw, ok := values[key].([]any)
+	if !ok {
+		return nil
+	}
+	portRanges := make([]PortRangeData, 0, len(raw))
+	for _, item := range raw {
+		value, ok := item.(map[string]any)
+		if !ok {
+			continue
+		}
+		portRanges = append(portRanges, PortRangeData{Low: int32FromMap(value, "low"), High: int32FromMap(value, "high")})
+	}
+	return portRanges
+}
+
+func isConflictError(err error) bool {
+	var checker statusCodeChecker
+	return errors.As(err, &checker) && checker.IsCode(409)
 }

--- a/internal/ziti/client.go
+++ b/internal/ziti/client.go
@@ -59,6 +59,7 @@ type serviceService interface {
 
 type configService interface {
 	CreateConfig(params *config.CreateConfigParams, authInfo runtime.ClientAuthInfoWriter, opts ...config.ClientOption) (*config.CreateConfigCreated, error)
+	ListConfigs(params *config.ListConfigsParams, authInfo runtime.ClientAuthInfoWriter, opts ...config.ClientOption) (*config.ListConfigsOK, error)
 	DeleteConfig(params *config.DeleteConfigParams, authInfo runtime.ClientAuthInfoWriter, opts ...config.ClientOption) (*config.DeleteConfigOK, error)
 	PatchConfig(params *config.PatchConfigParams, authInfo runtime.ClientAuthInfoWriter, opts ...config.ClientOption) (*config.PatchConfigOK, error)
 }
@@ -1007,24 +1008,10 @@ func (c *Client) upsertServiceConfig(ctx context.Context, serviceID, configTypeI
 		return "", err
 	}
 	if configDetail == nil {
-		return c.createConfig(ctx, configTypeID, name, data, tags)
+		configID, _, err := c.upsertConfigByName(ctx, configTypeID, name, data, tags, updateTags)
+		return configID, err
 	}
-	patch := &rest_model.ConfigPatch{Data: data, Name: name}
-	if updateTags {
-		patch.Tags = tagsFromMap(tags)
-	}
-	params := config.NewPatchConfigParamsWithContext(ctx)
-	params.ID = *configDetail.ID
-	params.Config = patch
-	err = c.withReauth(func() error {
-		configClient := c.configClient()
-		_, callErr := configClient.PatchConfig(params, nil)
-		return callErr
-	})
-	if err != nil {
-		return "", fmt.Errorf("patch ziti config: %w", err)
-	}
-	return *configDetail.ID, nil
+	return c.patchConfig(ctx, configDetail, name, data, tags, updateTags)
 }
 
 func (c *Client) findServiceConfigByType(ctx context.Context, serviceID, configTypeID string) (*rest_model.ConfigDetail, error) {
@@ -1346,19 +1333,26 @@ func (c *Client) CreateServiceReturning(ctx context.Context, name string, roleAt
 
 func (c *Client) UpdateService(ctx context.Context, id string, name string, roleAttributes []string, hostV1 *HostV1ConfigData, interceptV1 *InterceptV1ConfigData) (Service, error) {
 	configIDs := make([]string, 0, 2)
+	createdConfigIDs := make([]string, 0, 2)
 	if hostV1 != nil {
-		configID, err := c.createConfig(ctx, hostV1ConfigTypeID, fmt.Sprintf("%s-host-v1", name), hostV1ConfigData(hostV1), nil)
+		configID, created, err := c.upsertConfigByName(ctx, hostV1ConfigTypeID, fmt.Sprintf("%s-host-v1", name), hostV1ConfigData(hostV1), nil, false)
 		if err != nil {
 			return Service{}, err
 		}
 		configIDs = append(configIDs, configID)
+		if created {
+			createdConfigIDs = append(createdConfigIDs, configID)
+		}
 	}
 	if interceptV1 != nil {
-		configID, err := c.createConfig(ctx, interceptV1ConfigTypeID, fmt.Sprintf("%s-intercept-v1", name), interceptV1ConfigData(interceptV1), nil)
+		configID, created, err := c.upsertConfigByName(ctx, interceptV1ConfigTypeID, fmt.Sprintf("%s-intercept-v1", name), interceptV1ConfigData(interceptV1), nil, false)
 		if err != nil {
-			return Service{}, c.cleanupConfigs(ctx, configIDs, err)
+			return Service{}, c.cleanupConfigs(ctx, createdConfigIDs, err)
 		}
 		configIDs = append(configIDs, configID)
+		if created {
+			createdConfigIDs = append(createdConfigIDs, configID)
+		}
 	}
 	params := service.NewUpdateServiceParamsWithContext(ctx)
 	params.ID = id
@@ -1371,9 +1365,9 @@ func (c *Client) UpdateService(ctx context.Context, id string, name string, role
 	if err != nil {
 		var notFound *service.UpdateServiceNotFound
 		if errors.As(err, &notFound) {
-			return Service{}, c.cleanupConfigs(ctx, configIDs, ErrServiceNotFound)
+			return Service{}, c.cleanupConfigs(ctx, createdConfigIDs, ErrServiceNotFound)
 		}
-		return Service{}, c.cleanupConfigs(ctx, configIDs, fmt.Errorf("update ziti service: %w", err))
+		return Service{}, c.cleanupConfigs(ctx, createdConfigIDs, fmt.Errorf("update ziti service: %w", err))
 	}
 	return c.GetService(ctx, id)
 }
@@ -1703,4 +1697,66 @@ func portRangesFromMap(values map[string]any, key string) []PortRangeData {
 func isConflictError(err error) bool {
 	var checker statusCodeChecker
 	return errors.As(err, &checker) && checker.IsCode(409)
+}
+
+func (c *Client) upsertConfigByName(ctx context.Context, configTypeID, name string, data map[string]any, tags map[string]string, updateTags bool) (string, bool, error) {
+	configDetail, err := c.findConfigByName(ctx, name)
+	if err != nil {
+		return "", false, err
+	}
+	if configDetail == nil {
+		configID, err := c.createConfig(ctx, configTypeID, name, data, tags)
+		return configID, true, err
+	}
+	if configDetail.ConfigTypeID == nil || *configDetail.ConfigTypeID != configTypeID {
+		return "", false, fmt.Errorf("config %s has unexpected config type", name)
+	}
+	configID, err := c.patchConfig(ctx, configDetail, name, data, tags, updateTags)
+	return configID, false, err
+}
+
+func (c *Client) patchConfig(ctx context.Context, configDetail *rest_model.ConfigDetail, name string, data map[string]any, tags map[string]string, updateTags bool) (string, error) {
+	patch := &rest_model.ConfigPatch{Data: data, Name: name}
+	if updateTags {
+		patch.Tags = tagsFromMap(tags)
+	}
+	params := config.NewPatchConfigParamsWithContext(ctx)
+	params.ID = *configDetail.ID
+	params.Config = patch
+	err := c.withReauth(func() error {
+		configClient := c.configClient()
+		_, callErr := configClient.PatchConfig(params, nil)
+		return callErr
+	})
+	if err != nil {
+		return "", fmt.Errorf("patch ziti config: %w", err)
+	}
+	return *configDetail.ID, nil
+}
+
+func (c *Client) findConfigByName(ctx context.Context, name string) (*rest_model.ConfigDetail, error) {
+	limit := int64(2)
+	offset := int64(0)
+	filter := fmt.Sprintf(`name = "%s"`, escapeFilterValue(name))
+	params := config.NewListConfigsParamsWithContext(ctx)
+	params.Limit = &limit
+	params.Offset = &offset
+	params.Filter = &filter
+	var listed *config.ListConfigsOK
+	err := c.withReauth(func() error {
+		configClient := c.configClient()
+		var callErr error
+		listed, callErr = configClient.ListConfigs(params, nil)
+		return callErr
+	})
+	if err != nil {
+		return nil, fmt.Errorf("list ziti configs: %w", err)
+	}
+	if listed.Payload == nil {
+		return nil, errors.New("list ziti configs response missing payload")
+	}
+	if len(listed.Payload.Data) == 0 {
+		return nil, nil
+	}
+	return listed.Payload.Data[0], nil
 }

--- a/internal/ziti/client.go
+++ b/internal/ziti/client.go
@@ -1359,6 +1359,9 @@ func (c *Client) ListServices(ctx context.Context, filter ServiceListFilter) (Se
 	if queryFilter != "" {
 		params.Filter = &queryFilter
 	}
+	if len(filter.RoleAttributes) > 0 {
+		params.RoleFilter = filter.RoleAttributes
+	}
 	var envelope *rest_model.ListServicesEnvelope
 	err = c.withReauth(func() error {
 		serviceClient := c.serviceClient()
@@ -1580,9 +1583,6 @@ func serviceFilter(filter ServiceListFilter) string {
 	}
 	if filter.NamePrefix != "" {
 		parts = append(parts, fmt.Sprintf(`name contains "%s"`, escapeFilterValue(filter.NamePrefix)))
-	}
-	for _, role := range filter.RoleAttributes {
-		parts = append(parts, fmt.Sprintf(`roleAttributes contains "%s"`, escapeFilterValue(role)))
 	}
 	return strings.Join(parts, " and ")
 }

--- a/internal/ziti/client.go
+++ b/internal/ziti/client.go
@@ -336,6 +336,22 @@ func tagFilter(tags map[string]string) string {
 	return strings.Join(filters, " and ")
 }
 
+func roleFilters(attributes []string) []string {
+	filters := make([]string, 0, len(attributes))
+	for _, attribute := range attributes {
+		trimmed := strings.TrimSpace(attribute)
+		if trimmed == "" {
+			continue
+		}
+		if strings.HasPrefix(trimmed, "#") || strings.HasPrefix(trimmed, "@") {
+			filters = append(filters, trimmed)
+			continue
+		}
+		filters = append(filters, "#"+trimmed)
+	}
+	return filters
+}
+
 func listPagination(pageSize int32, pageToken string) (int64, int64, error) {
 	limit := int64(pageSize)
 	if limit <= 0 {
@@ -458,7 +474,6 @@ func (c *Client) CreateAgentIdentityWithOptions(ctx context.Context, agentID, wo
 		IsAdmin:        &isAdmin,
 		RoleAttributes: &roleAttrs,
 		ExternalID:     &externalID,
-		Enrollment:     &rest_model.IdentityCreateEnrollment{Ott: true},
 		Tags:           tagsFromMap(tags),
 	}
 
@@ -467,7 +482,7 @@ func (c *Client) CreateAgentIdentityWithOptions(ctx context.Context, agentID, wo
 		return "", "", err
 	}
 
-	jwt, err := c.fetchEnrollmentJWT(ctx, zitiID)
+	jwt, err := c.createEnrollmentJWT(ctx, zitiID)
 	if err != nil {
 		return "", "", err
 	}
@@ -1361,7 +1376,7 @@ func (c *Client) ListServices(ctx context.Context, filter ServiceListFilter) (Se
 		params.Filter = &queryFilter
 	}
 	if len(filter.RoleAttributes) > 0 {
-		params.RoleFilter = filter.RoleAttributes
+		params.RoleFilter = roleFilters(filter.RoleAttributes)
 	}
 	var envelope *rest_model.ListServicesEnvelope
 	err = c.withReauth(func() error {

--- a/internal/ziti/client.go
+++ b/internal/ziti/client.go
@@ -51,6 +51,7 @@ type identityService interface {
 
 type enrollmentService interface {
 	CreateEnrollment(params *enrollment.CreateEnrollmentParams, authInfo runtime.ClientAuthInfoWriter, opts ...enrollment.ClientOption) (*enrollment.CreateEnrollmentCreated, error)
+	DeleteEnrollment(params *enrollment.DeleteEnrollmentParams, authInfo runtime.ClientAuthInfoWriter, opts ...enrollment.ClientOption) (*enrollment.DeleteEnrollmentOK, error)
 	DetailEnrollment(params *enrollment.DetailEnrollmentParams, authInfo runtime.ClientAuthInfoWriter, opts ...enrollment.ClientOption) (*enrollment.DetailEnrollmentOK, error)
 }
 
@@ -482,11 +483,57 @@ func (c *Client) CreateAgentIdentityWithOptions(ctx context.Context, agentID, wo
 		return "", "", err
 	}
 
-	jwt, err := c.createEnrollmentJWT(ctx, zitiID)
+	jwt, err := c.refreshEnrollmentJWT(ctx, zitiID)
 	if err != nil {
 		return "", "", err
 	}
 	return zitiID, jwt.Token, nil
+}
+
+func (c *Client) refreshEnrollmentJWT(ctx context.Context, zitiIdentityID string) (EnrollmentJWT, error) {
+	if err := c.deleteIdentityEnrollments(ctx, zitiIdentityID); err != nil {
+		return EnrollmentJWT{}, err
+	}
+	return c.createEnrollmentJWT(ctx, zitiIdentityID)
+}
+
+func (c *Client) deleteIdentityEnrollments(ctx context.Context, zitiIdentityID string) error {
+	detail, err := c.detailIdentity(ctx, zitiIdentityID)
+	if err != nil {
+		return err
+	}
+	if detail.Enrollment == nil {
+		return nil
+	}
+	if detail.Enrollment.Ott != nil {
+		if err := c.deleteEnrollment(ctx, rest_model.EnrollmentCreateMethodOtt, detail.Enrollment.Ott.ID); err != nil {
+			return err
+		}
+	}
+	if detail.Enrollment.Ottca != nil {
+		if err := c.deleteEnrollment(ctx, rest_model.EnrollmentCreateMethodOttca, detail.Enrollment.Ottca.ID); err != nil {
+			return err
+		}
+	}
+	if detail.Enrollment.Updb != nil {
+		if err := c.deleteEnrollment(ctx, rest_model.EnrollmentCreateMethodUpdb, detail.Enrollment.Updb.ID); err != nil {
+			return err
+		}
+	}
+	return nil
+}
+
+func (c *Client) deleteEnrollment(ctx context.Context, method string, enrollmentID string) error {
+	if enrollmentID == "" {
+		return fmt.Errorf("identity %s enrollment missing id", method)
+	}
+	params := enrollment.NewDeleteEnrollmentParamsWithContext(ctx)
+	params.ID = enrollmentID
+	return c.withReauth(func() error {
+		enrollmentClient := c.enrollmentClient()
+		_, err := enrollmentClient.DeleteEnrollment(params, nil)
+		return err
+	})
 }
 
 func (c *Client) createEnrollmentJWT(ctx context.Context, zitiIdentityID string) (EnrollmentJWT, error) {
@@ -528,6 +575,16 @@ func (c *Client) createEnrollmentJWT(ctx context.Context, zitiIdentityID string)
 	data := detail.Payload.Data
 	if data.JWT == "" {
 		return EnrollmentJWT{}, errors.New("detail ziti enrollment response missing enrollment jwt")
+	}
+	claims, _, err := parseEnrollmentToken(data.JWT)
+	if err != nil {
+		return EnrollmentJWT{}, fmt.Errorf("parse enrollment token: %w", err)
+	}
+	if claims.EnrollmentMethod != method {
+		return EnrollmentJWT{}, fmt.Errorf("enrollment jwt method %q does not match enrollment method %q", claims.EnrollmentMethod, method)
+	}
+	if claims.ID == "" {
+		return EnrollmentJWT{}, errors.New("enrollment jwt missing token id")
 	}
 	if data.ExpiresAt != nil {
 		expiresAt = time.Time(*data.ExpiresAt)

--- a/internal/ziti/client.go
+++ b/internal/ziti/client.go
@@ -49,8 +49,6 @@ type identityService interface {
 
 type serviceService interface {
 	CreateService(params *service.CreateServiceParams, authInfo runtime.ClientAuthInfoWriter, opts ...service.ClientOption) (*service.CreateServiceCreated, error)
-	DetailService(params *service.DetailServiceParams, authInfo runtime.ClientAuthInfoWriter, opts ...service.ClientOption) (*service.DetailServiceOK, error)
-	ListServices(params *service.ListServicesParams, authInfo runtime.ClientAuthInfoWriter, opts ...service.ClientOption) (*service.ListServicesOK, error)
 	UpdateService(params *service.UpdateServiceParams, authInfo runtime.ClientAuthInfoWriter, opts ...service.ClientOption) (*service.UpdateServiceOK, error)
 	DeleteService(params *service.DeleteServiceParams, authInfo runtime.ClientAuthInfoWriter, opts ...service.ClientOption) (*service.DeleteServiceOK, error)
 	DetailService(params *service.DetailServiceParams, authInfo runtime.ClientAuthInfoWriter, opts ...service.ClientOption) (*service.DetailServiceOK, error)
@@ -68,7 +66,6 @@ type configService interface {
 type servicePolicyService interface {
 	CreateServicePolicy(params *service_policy.CreateServicePolicyParams, authInfo runtime.ClientAuthInfoWriter, opts ...service_policy.ClientOption) (*service_policy.CreateServicePolicyCreated, error)
 	DetailServicePolicy(params *service_policy.DetailServicePolicyParams, authInfo runtime.ClientAuthInfoWriter, opts ...service_policy.ClientOption) (*service_policy.DetailServicePolicyOK, error)
-	ListServicePolicies(params *service_policy.ListServicePoliciesParams, authInfo runtime.ClientAuthInfoWriter, opts ...service_policy.ClientOption) (*service_policy.ListServicePoliciesOK, error)
 	DeleteServicePolicy(params *service_policy.DeleteServicePolicyParams, authInfo runtime.ClientAuthInfoWriter, opts ...service_policy.ClientOption) (*service_policy.DeleteServicePolicyOK, error)
 	ListServicePolicies(params *service_policy.ListServicePoliciesParams, authInfo runtime.ClientAuthInfoWriter, opts ...service_policy.ClientOption) (*service_policy.ListServicePoliciesOK, error)
 }
@@ -338,7 +335,7 @@ func listPagination(pageSize int32, pageToken string) (int64, int64, error) {
 	return limit, offset, nil
 }
 
-func nextPageToken(meta *rest_model.Meta) string {
+func tagNextPageToken(meta *rest_model.Meta) string {
 	if meta == nil || meta.Pagination == nil || meta.Pagination.Offset == nil || meta.Pagination.Limit == nil || meta.Pagination.TotalCount == nil {
 		return ""
 	}
@@ -851,7 +848,7 @@ func (c *Client) ListIdentitiesByTag(ctx context.Context, tags map[string]string
 	for _, identityDetail := range listed.Payload.Data {
 		items = append(items, toOpenZitiIdentity(identityDetail))
 	}
-	return ListResult[OpenZitiIdentity]{Items: items, NextPageToken: nextPageToken(listed.Payload.Meta)}, nil
+	return ListResult[OpenZitiIdentity]{Items: items, NextPageToken: tagNextPageToken(listed.Payload.Meta)}, nil
 }
 
 func (c *Client) ListServicesByTag(ctx context.Context, tags map[string]string, pageSize int32, pageToken string) (ListResult[OpenZitiService], error) {
@@ -883,7 +880,7 @@ func (c *Client) ListServicesByTag(ctx context.Context, tags map[string]string, 
 	for _, serviceDetail := range listed.Payload.Data {
 		items = append(items, toOpenZitiService(serviceDetail))
 	}
-	return ListResult[OpenZitiService]{Items: items, NextPageToken: nextPageToken(listed.Payload.Meta)}, nil
+	return ListResult[OpenZitiService]{Items: items, NextPageToken: tagNextPageToken(listed.Payload.Meta)}, nil
 }
 
 func (c *Client) ListServicePoliciesByTag(ctx context.Context, tags map[string]string, pageSize int32, pageToken string) (ListResult[OpenZitiServicePolicy], error) {
@@ -915,10 +912,10 @@ func (c *Client) ListServicePoliciesByTag(ctx context.Context, tags map[string]s
 	for _, policyDetail := range listed.Payload.Data {
 		items = append(items, toOpenZitiServicePolicy(policyDetail))
 	}
-	return ListResult[OpenZitiServicePolicy]{Items: items, NextPageToken: nextPageToken(listed.Payload.Meta)}, nil
+	return ListResult[OpenZitiServicePolicy]{Items: items, NextPageToken: tagNextPageToken(listed.Payload.Meta)}, nil
 }
 
-func (c *Client) UpdateService(ctx context.Context, serviceID string, hostV1 *HostV1ConfigData, interceptV1 *InterceptV1ConfigData, tags map[string]string, updateTags bool) (OpenZitiService, error) {
+func (c *Client) updateServiceConfigsAndTags(ctx context.Context, serviceID string, hostV1 *HostV1ConfigData, interceptV1 *InterceptV1ConfigData, tags map[string]string, updateTags bool) (OpenZitiService, error) {
 	detail, err := c.detailService(ctx, serviceID)
 	if err != nil {
 		return OpenZitiService{}, err
@@ -1350,14 +1347,14 @@ func (c *Client) CreateServiceReturning(ctx context.Context, name string, roleAt
 func (c *Client) UpdateService(ctx context.Context, id string, name string, roleAttributes []string, hostV1 *HostV1ConfigData, interceptV1 *InterceptV1ConfigData) (Service, error) {
 	configIDs := make([]string, 0, 2)
 	if hostV1 != nil {
-		configID, err := c.createConfig(ctx, hostV1ConfigTypeID, fmt.Sprintf("%s-host-v1", name), hostV1ConfigData(hostV1))
+		configID, err := c.createConfig(ctx, hostV1ConfigTypeID, fmt.Sprintf("%s-host-v1", name), hostV1ConfigData(hostV1), nil)
 		if err != nil {
 			return Service{}, err
 		}
 		configIDs = append(configIDs, configID)
 	}
 	if interceptV1 != nil {
-		configID, err := c.createConfig(ctx, interceptV1ConfigTypeID, fmt.Sprintf("%s-intercept-v1", name), interceptV1ConfigData(interceptV1))
+		configID, err := c.createConfig(ctx, interceptV1ConfigTypeID, fmt.Sprintf("%s-intercept-v1", name), interceptV1ConfigData(interceptV1), nil)
 		if err != nil {
 			return Service{}, c.cleanupConfigs(ctx, configIDs, err)
 		}

--- a/internal/ziti/client.go
+++ b/internal/ziti/client.go
@@ -17,10 +17,8 @@ import (
 
 	"github.com/agynio/ziti-management/internal/id"
 	"github.com/go-openapi/runtime"
-	"github.com/go-openapi/strfmt"
 	"github.com/google/uuid"
 	"github.com/openziti/edge-api/rest_management_api_client/config"
-	"github.com/openziti/edge-api/rest_management_api_client/enrollment"
 	"github.com/openziti/edge-api/rest_management_api_client/identity"
 	"github.com/openziti/edge-api/rest_management_api_client/service"
 	"github.com/openziti/edge-api/rest_management_api_client/service_policy"
@@ -47,11 +45,6 @@ type identityService interface {
 	DetailIdentity(params *identity.DetailIdentityParams, authInfo runtime.ClientAuthInfoWriter, opts ...identity.ClientOption) (*identity.DetailIdentityOK, error)
 	ListIdentities(params *identity.ListIdentitiesParams, authInfo runtime.ClientAuthInfoWriter, opts ...identity.ClientOption) (*identity.ListIdentitiesOK, error)
 	PatchIdentity(params *identity.PatchIdentityParams, authInfo runtime.ClientAuthInfoWriter, opts ...identity.ClientOption) (*identity.PatchIdentityOK, error)
-}
-
-type enrollmentService interface {
-	CreateEnrollment(params *enrollment.CreateEnrollmentParams, authInfo runtime.ClientAuthInfoWriter, opts ...enrollment.ClientOption) (*enrollment.CreateEnrollmentCreated, error)
-	DetailEnrollment(params *enrollment.DetailEnrollmentParams, authInfo runtime.ClientAuthInfoWriter, opts ...enrollment.ClientOption) (*enrollment.DetailEnrollmentOK, error)
 }
 
 type serviceService interface {
@@ -81,7 +74,6 @@ type servicePolicyService interface {
 type Client struct {
 	mu               sync.Mutex
 	identity         identityService
-	enrollment       enrollmentService
 	service          serviceService
 	config           configService
 	servicePolicy    servicePolicyService
@@ -107,7 +99,6 @@ func NewClient(controllerURL, certFile, keyFile, caFile string) (*Client, error)
 	}
 	return &Client{
 		identity:      client.Identity,
-		enrollment:    client.Enrollment,
 		service:       client.Service,
 		config:        client.Config,
 		servicePolicy: client.ServicePolicy,
@@ -167,12 +158,6 @@ func (c *Client) identityClient() identityService {
 	return c.identity
 }
 
-func (c *Client) enrollmentClient() enrollmentService {
-	c.mu.Lock()
-	defer c.mu.Unlock()
-	return c.enrollment
-}
-
 func (c *Client) serviceClient() serviceService {
 	c.mu.Lock()
 	defer c.mu.Unlock()
@@ -208,7 +193,6 @@ func (c *Client) reauthenticate() error {
 		return fmt.Errorf("create edge management client: %w", err)
 	}
 	c.identity = client.Identity
-	c.enrollment = client.Enrollment
 	c.service = client.Service
 	c.config = client.Config
 	c.servicePolicy = client.ServicePolicy
@@ -458,6 +442,7 @@ func (c *Client) CreateAgentIdentityWithOptions(ctx context.Context, agentID, wo
 		IsAdmin:        &isAdmin,
 		RoleAttributes: &roleAttrs,
 		ExternalID:     &externalID,
+		Enrollment:     &rest_model.IdentityCreateEnrollment{Ott: true},
 		Tags:           tagsFromMap(tags),
 	}
 
@@ -466,57 +451,11 @@ func (c *Client) CreateAgentIdentityWithOptions(ctx context.Context, agentID, wo
 		return "", "", err
 	}
 
-	jwt, err := c.createEnrollmentJWT(ctx, zitiID)
+	jwt, err := c.fetchEnrollmentJWT(ctx, zitiID)
 	if err != nil {
 		return "", "", err
 	}
 	return zitiID, jwt.Token, nil
-}
-
-func (c *Client) createEnrollmentJWT(ctx context.Context, zitiIdentityID string) (EnrollmentJWT, error) {
-	method := rest_model.EnrollmentCreateMethodOtt
-	expiresAt := time.Now().Add(time.Hour).UTC()
-	expires := strfmt.DateTime(expiresAt)
-	params := enrollment.NewCreateEnrollmentParamsWithContext(ctx)
-	params.Enrollment = &rest_model.EnrollmentCreate{IdentityID: &zitiIdentityID, Method: &method, ExpiresAt: &expires}
-	var created *enrollment.CreateEnrollmentCreated
-	err := c.withReauth(func() error {
-		var callErr error
-		enrollmentClient := c.enrollmentClient()
-		created, callErr = enrollmentClient.CreateEnrollment(params, nil)
-		return callErr
-	})
-	if err != nil {
-		return EnrollmentJWT{}, fmt.Errorf("create ziti enrollment: %w", err)
-	}
-	enrollmentID, err := extractCreateID("enrollment", created.Payload)
-	if err != nil {
-		return EnrollmentJWT{}, err
-	}
-
-	detailParams := enrollment.NewDetailEnrollmentParamsWithContext(ctx)
-	detailParams.ID = enrollmentID
-	var detail *enrollment.DetailEnrollmentOK
-	err = c.withReauth(func() error {
-		var callErr error
-		enrollmentClient := c.enrollmentClient()
-		detail, callErr = enrollmentClient.DetailEnrollment(detailParams, nil)
-		return callErr
-	})
-	if err != nil {
-		return EnrollmentJWT{}, fmt.Errorf("detail ziti enrollment: %w", err)
-	}
-	if detail.Payload == nil || detail.Payload.Data == nil {
-		return EnrollmentJWT{}, errors.New("detail ziti enrollment response missing data")
-	}
-	data := detail.Payload.Data
-	if data.JWT == "" {
-		return EnrollmentJWT{}, errors.New("detail ziti enrollment response missing enrollment jwt")
-	}
-	if data.ExpiresAt != nil {
-		expiresAt = time.Time(*data.ExpiresAt)
-	}
-	return EnrollmentJWT{Token: data.JWT, ExpiresAt: expiresAt}, nil
 }
 
 func (c *Client) CreateDeviceIdentity(ctx context.Context, userIdentityID uuid.UUID, name string) (string, string, error) {

--- a/internal/ziti/client.go
+++ b/internal/ziti/client.go
@@ -9,6 +9,7 @@ import (
 	"encoding/json"
 	"errors"
 	"fmt"
+	"log"
 	"os"
 	"strconv"
 	"strings"
@@ -385,7 +386,9 @@ func (c *Client) deleteIdentityByExternalID(ctx context.Context, externalID stri
 	if err != nil {
 		return err
 	}
+	log.Printf("ziti identity cleanup by external id external_id=%s matches=%d", externalID, len(identityIDs))
 	for _, identityID := range identityIDs {
+		log.Printf("ziti identity cleanup deleting external_id=%s ziti_identity_id=%s", externalID, identityID)
 		if err := c.DeleteIdentity(ctx, identityID); err != nil && !errors.Is(err, ErrIdentityNotFound) {
 			return err
 		}
@@ -482,11 +485,16 @@ func (c *Client) CreateAgentIdentityWithOptions(ctx context.Context, agentID, wo
 	if err != nil {
 		return "", "", err
 	}
+	log.Printf("ziti agent identity created agent_id=%s workload_id=%s external_id=%s ziti_identity_id=%s", agentID.String(), workloadID.String(), externalID, zitiID)
 
 	jwt, err := c.refreshEnrollmentJWT(ctx, zitiID)
 	if err != nil {
 		return "", "", err
 	}
+	if _, err := c.detailIdentity(ctx, zitiID); err != nil {
+		return "", "", fmt.Errorf("verify ziti agent identity after enrollment creation: %w", err)
+	}
+	log.Printf("ziti agent identity enrollment ready agent_id=%s workload_id=%s ziti_identity_id=%s enrollment_token_id=%s expires_at=%s", agentID.String(), workloadID.String(), zitiID, jwt.TokenID, jwt.ExpiresAt.Format(time.RFC3339))
 	return zitiID, jwt.Token, nil
 }
 
@@ -503,19 +511,23 @@ func (c *Client) deleteIdentityEnrollments(ctx context.Context, zitiIdentityID s
 		return err
 	}
 	if detail.Enrollment == nil {
+		log.Printf("ziti identity enrollment cleanup skipped ziti_identity_id=%s reason=no_enrollment", zitiIdentityID)
 		return nil
 	}
 	if detail.Enrollment.Ott != nil {
+		log.Printf("ziti identity enrollment cleanup deleting ziti_identity_id=%s method=%s enrollment_id=%s token=%s", zitiIdentityID, rest_model.EnrollmentCreateMethodOtt, detail.Enrollment.Ott.ID, detail.Enrollment.Ott.Token)
 		if err := c.deleteEnrollment(ctx, rest_model.EnrollmentCreateMethodOtt, detail.Enrollment.Ott.ID); err != nil {
 			return err
 		}
 	}
 	if detail.Enrollment.Ottca != nil {
+		log.Printf("ziti identity enrollment cleanup deleting ziti_identity_id=%s method=%s enrollment_id=%s token=%s", zitiIdentityID, rest_model.EnrollmentCreateMethodOttca, detail.Enrollment.Ottca.ID, detail.Enrollment.Ottca.Token)
 		if err := c.deleteEnrollment(ctx, rest_model.EnrollmentCreateMethodOttca, detail.Enrollment.Ottca.ID); err != nil {
 			return err
 		}
 	}
 	if detail.Enrollment.Updb != nil {
+		log.Printf("ziti identity enrollment cleanup deleting ziti_identity_id=%s method=%s enrollment_id=%s token=%s", zitiIdentityID, rest_model.EnrollmentCreateMethodUpdb, detail.Enrollment.Updb.ID, detail.Enrollment.Updb.Token)
 		if err := c.deleteEnrollment(ctx, rest_model.EnrollmentCreateMethodUpdb, detail.Enrollment.Updb.ID); err != nil {
 			return err
 		}
@@ -589,7 +601,15 @@ func (c *Client) createEnrollmentJWT(ctx context.Context, zitiIdentityID string)
 	if data.ExpiresAt != nil {
 		expiresAt = time.Time(*data.ExpiresAt)
 	}
-	return EnrollmentJWT{Token: data.JWT, ExpiresAt: expiresAt}, nil
+	log.Printf("ziti enrollment created ziti_identity_id=%s enrollment_id=%s token=%s token_id=%s method=%s expires_at=%s", zitiIdentityID, enrollmentID, enrollmentDetailToken(data), claims.ID, claims.EnrollmentMethod, expiresAt.Format(time.RFC3339))
+	return EnrollmentJWT{Token: data.JWT, TokenID: claims.ID, ExpiresAt: expiresAt}, nil
+}
+
+func enrollmentDetailToken(detail *rest_model.EnrollmentDetail) string {
+	if detail == nil || detail.Token == nil {
+		return ""
+	}
+	return *detail.Token
 }
 
 func (c *Client) CreateDeviceIdentity(ctx context.Context, userIdentityID uuid.UUID, name string) (string, string, error) {

--- a/internal/ziti/client.go
+++ b/internal/ziti/client.go
@@ -433,6 +433,9 @@ func (c *Client) CreateAgentIdentityWithOptions(ctx context.Context, agentID, wo
 		fmt.Sprintf("workload-%s", workloadID.String()),
 	}, additionalRoleAttributes)
 	externalID := workloadID.String()
+	if err := c.deleteIdentityByExternalID(ctx, externalID); err != nil {
+		return "", "", fmt.Errorf("delete existing ziti identity: %w", err)
+	}
 	identityCreate := &rest_model.IdentityCreate{
 		Name:           &name,
 		Type:           &identityType,

--- a/internal/ziti/client.go
+++ b/internal/ziti/client.go
@@ -17,8 +17,10 @@ import (
 
 	"github.com/agynio/ziti-management/internal/id"
 	"github.com/go-openapi/runtime"
+	"github.com/go-openapi/strfmt"
 	"github.com/google/uuid"
 	"github.com/openziti/edge-api/rest_management_api_client/config"
+	"github.com/openziti/edge-api/rest_management_api_client/enrollment"
 	"github.com/openziti/edge-api/rest_management_api_client/identity"
 	"github.com/openziti/edge-api/rest_management_api_client/service"
 	"github.com/openziti/edge-api/rest_management_api_client/service_policy"
@@ -45,6 +47,11 @@ type identityService interface {
 	DetailIdentity(params *identity.DetailIdentityParams, authInfo runtime.ClientAuthInfoWriter, opts ...identity.ClientOption) (*identity.DetailIdentityOK, error)
 	ListIdentities(params *identity.ListIdentitiesParams, authInfo runtime.ClientAuthInfoWriter, opts ...identity.ClientOption) (*identity.ListIdentitiesOK, error)
 	PatchIdentity(params *identity.PatchIdentityParams, authInfo runtime.ClientAuthInfoWriter, opts ...identity.ClientOption) (*identity.PatchIdentityOK, error)
+}
+
+type enrollmentService interface {
+	CreateEnrollment(params *enrollment.CreateEnrollmentParams, authInfo runtime.ClientAuthInfoWriter, opts ...enrollment.ClientOption) (*enrollment.CreateEnrollmentCreated, error)
+	DetailEnrollment(params *enrollment.DetailEnrollmentParams, authInfo runtime.ClientAuthInfoWriter, opts ...enrollment.ClientOption) (*enrollment.DetailEnrollmentOK, error)
 }
 
 type serviceService interface {
@@ -74,6 +81,7 @@ type servicePolicyService interface {
 type Client struct {
 	mu               sync.Mutex
 	identity         identityService
+	enrollment       enrollmentService
 	service          serviceService
 	config           configService
 	servicePolicy    servicePolicyService
@@ -99,6 +107,7 @@ func NewClient(controllerURL, certFile, keyFile, caFile string) (*Client, error)
 	}
 	return &Client{
 		identity:      client.Identity,
+		enrollment:    client.Enrollment,
 		service:       client.Service,
 		config:        client.Config,
 		servicePolicy: client.ServicePolicy,
@@ -158,6 +167,12 @@ func (c *Client) identityClient() identityService {
 	return c.identity
 }
 
+func (c *Client) enrollmentClient() enrollmentService {
+	c.mu.Lock()
+	defer c.mu.Unlock()
+	return c.enrollment
+}
+
 func (c *Client) serviceClient() serviceService {
 	c.mu.Lock()
 	defer c.mu.Unlock()
@@ -193,6 +208,7 @@ func (c *Client) reauthenticate() error {
 		return fmt.Errorf("create edge management client: %w", err)
 	}
 	c.identity = client.Identity
+	c.enrollment = client.Enrollment
 	c.service = client.Service
 	c.config = client.Config
 	c.servicePolicy = client.ServicePolicy
@@ -442,7 +458,6 @@ func (c *Client) CreateAgentIdentityWithOptions(ctx context.Context, agentID, wo
 		IsAdmin:        &isAdmin,
 		RoleAttributes: &roleAttrs,
 		ExternalID:     &externalID,
-		Enrollment:     &rest_model.IdentityCreateEnrollment{Ott: true},
 		Tags:           tagsFromMap(tags),
 	}
 
@@ -451,11 +466,57 @@ func (c *Client) CreateAgentIdentityWithOptions(ctx context.Context, agentID, wo
 		return "", "", err
 	}
 
-	jwt, err := c.fetchEnrollmentJWT(ctx, zitiID)
+	jwt, err := c.createEnrollmentJWT(ctx, zitiID)
 	if err != nil {
 		return "", "", err
 	}
 	return zitiID, jwt.Token, nil
+}
+
+func (c *Client) createEnrollmentJWT(ctx context.Context, zitiIdentityID string) (EnrollmentJWT, error) {
+	method := rest_model.EnrollmentCreateMethodOtt
+	expiresAt := time.Now().Add(time.Hour).UTC()
+	expires := strfmt.DateTime(expiresAt)
+	params := enrollment.NewCreateEnrollmentParamsWithContext(ctx)
+	params.Enrollment = &rest_model.EnrollmentCreate{IdentityID: &zitiIdentityID, Method: &method, ExpiresAt: &expires}
+	var created *enrollment.CreateEnrollmentCreated
+	err := c.withReauth(func() error {
+		var callErr error
+		enrollmentClient := c.enrollmentClient()
+		created, callErr = enrollmentClient.CreateEnrollment(params, nil)
+		return callErr
+	})
+	if err != nil {
+		return EnrollmentJWT{}, fmt.Errorf("create ziti enrollment: %w", err)
+	}
+	enrollmentID, err := extractCreateID("enrollment", created.Payload)
+	if err != nil {
+		return EnrollmentJWT{}, err
+	}
+
+	detailParams := enrollment.NewDetailEnrollmentParamsWithContext(ctx)
+	detailParams.ID = enrollmentID
+	var detail *enrollment.DetailEnrollmentOK
+	err = c.withReauth(func() error {
+		var callErr error
+		enrollmentClient := c.enrollmentClient()
+		detail, callErr = enrollmentClient.DetailEnrollment(detailParams, nil)
+		return callErr
+	})
+	if err != nil {
+		return EnrollmentJWT{}, fmt.Errorf("detail ziti enrollment: %w", err)
+	}
+	if detail.Payload == nil || detail.Payload.Data == nil {
+		return EnrollmentJWT{}, errors.New("detail ziti enrollment response missing data")
+	}
+	data := detail.Payload.Data
+	if data.JWT == "" {
+		return EnrollmentJWT{}, errors.New("detail ziti enrollment response missing enrollment jwt")
+	}
+	if data.ExpiresAt != nil {
+		expiresAt = time.Time(*data.ExpiresAt)
+	}
+	return EnrollmentJWT{Token: data.JWT, ExpiresAt: expiresAt}, nil
 }
 
 func (c *Client) CreateDeviceIdentity(ctx context.Context, userIdentityID uuid.UUID, name string) (string, string, error) {

--- a/internal/ziti/client.go
+++ b/internal/ziti/client.go
@@ -458,6 +458,7 @@ func (c *Client) CreateAgentIdentityWithOptions(ctx context.Context, agentID, wo
 		IsAdmin:        &isAdmin,
 		RoleAttributes: &roleAttrs,
 		ExternalID:     &externalID,
+		Enrollment:     &rest_model.IdentityCreateEnrollment{Ott: true},
 		Tags:           tagsFromMap(tags),
 	}
 
@@ -466,7 +467,7 @@ func (c *Client) CreateAgentIdentityWithOptions(ctx context.Context, agentID, wo
 		return "", "", err
 	}
 
-	jwt, err := c.createEnrollmentJWT(ctx, zitiID)
+	jwt, err := c.fetchEnrollmentJWT(ctx, zitiID)
 	if err != nil {
 		return "", "", err
 	}

--- a/internal/ziti/client_test.go
+++ b/internal/ziti/client_test.go
@@ -14,6 +14,7 @@ import (
 	"github.com/golang-jwt/jwt/v5"
 	"github.com/google/uuid"
 	"github.com/openziti/edge-api/rest_management_api_client/config"
+	"github.com/openziti/edge-api/rest_management_api_client/enrollment"
 	"github.com/openziti/edge-api/rest_management_api_client/identity"
 	"github.com/openziti/edge-api/rest_management_api_client/service"
 	"github.com/openziti/edge-api/rest_management_api_client/service_policy"
@@ -26,6 +27,11 @@ type fakeIdentityService struct {
 	deleteIdentityFunc func(params *identity.DeleteIdentityParams) (*identity.DeleteIdentityOK, error)
 	detailIdentityFunc func(params *identity.DetailIdentityParams) (*identity.DetailIdentityOK, error)
 	listIdentitiesFunc func(params *identity.ListIdentitiesParams) (*identity.ListIdentitiesOK, error)
+}
+
+type fakeEnrollmentService struct {
+	createEnrollmentFunc func(params *enrollment.CreateEnrollmentParams) (*enrollment.CreateEnrollmentCreated, error)
+	detailEnrollmentFunc func(params *enrollment.DetailEnrollmentParams) (*enrollment.DetailEnrollmentOK, error)
 }
 
 func (f *fakeIdentityService) CreateIdentity(params *identity.CreateIdentityParams, _ runtime.ClientAuthInfoWriter, _ ...identity.ClientOption) (*identity.CreateIdentityCreated, error) {
@@ -54,6 +60,20 @@ func (f *fakeIdentityService) ListIdentities(params *identity.ListIdentitiesPara
 		return nil, errors.New("list identities not stubbed")
 	}
 	return f.listIdentitiesFunc(params)
+}
+
+func (f *fakeEnrollmentService) CreateEnrollment(params *enrollment.CreateEnrollmentParams, _ runtime.ClientAuthInfoWriter, _ ...enrollment.ClientOption) (*enrollment.CreateEnrollmentCreated, error) {
+	if f.createEnrollmentFunc == nil {
+		return nil, errors.New("create enrollment not stubbed")
+	}
+	return f.createEnrollmentFunc(params)
+}
+
+func (f *fakeEnrollmentService) DetailEnrollment(params *enrollment.DetailEnrollmentParams, _ runtime.ClientAuthInfoWriter, _ ...enrollment.ClientOption) (*enrollment.DetailEnrollmentOK, error) {
+	if f.detailEnrollmentFunc == nil {
+		return nil, errors.New("detail enrollment not stubbed")
+	}
+	return f.detailEnrollmentFunc(params)
 }
 
 type fakeServiceService struct {
@@ -190,6 +210,7 @@ func TestCreateAgentIdentityCreatesIdentity(t *testing.T) {
 	agentID := uuid.New()
 	workloadID := uuid.New()
 	createdID := "created-id"
+	enrollmentID := "enrollment-id"
 	jwt := "jwt-token"
 
 	fake := &fakeIdentityService{
@@ -202,15 +223,23 @@ func TestCreateAgentIdentityCreatesIdentity(t *testing.T) {
 			assertCreateAgentRoleAttributes(t, params, agentID, workloadID)
 			return createIdentityResponse(createdID), nil
 		},
-		detailIdentityFunc: func(params *identity.DetailIdentityParams) (*identity.DetailIdentityOK, error) {
-			if params == nil || params.ID != createdID {
-				t.Fatalf("expected detail identity id %q, got %#v", createdID, params)
+	}
+	fakeEnrollment := &fakeEnrollmentService{
+		createEnrollmentFunc: func(params *enrollment.CreateEnrollmentParams) (*enrollment.CreateEnrollmentCreated, error) {
+			if params == nil || params.Enrollment == nil || params.Enrollment.IdentityID == nil || *params.Enrollment.IdentityID != createdID {
+				t.Fatalf("expected create enrollment identity id %q, got %#v", createdID, params)
 			}
-			return detailIdentityResponse(jwt), nil
+			return createEnrollmentResponse(enrollmentID), nil
+		},
+		detailEnrollmentFunc: func(params *enrollment.DetailEnrollmentParams) (*enrollment.DetailEnrollmentOK, error) {
+			if params == nil || params.ID != enrollmentID {
+				t.Fatalf("expected detail enrollment id %q, got %#v", enrollmentID, params)
+			}
+			return detailEnrollmentResponse(jwt), nil
 		},
 	}
 
-	client := &Client{identity: fake}
+	client := &Client{identity: fake, enrollment: fakeEnrollment}
 	zitiID, token, err := client.CreateAgentIdentity(ctx, agentID, workloadID)
 	if err != nil {
 		t.Fatalf("create agent identity: %v", err)
@@ -237,12 +266,20 @@ func TestCreateAgentIdentityWithOptionsAddsRolesAndTags(t *testing.T) {
 			assertTags(t, params.Identity.Tags, map[string]string{"network": "net-1"})
 			return createIdentityResponse("identity-id"), nil
 		},
-		detailIdentityFunc: func(params *identity.DetailIdentityParams) (*identity.DetailIdentityOK, error) {
-			return detailIdentityResponse("jwt-token"), nil
+	}
+	fakeEnrollment := &fakeEnrollmentService{
+		createEnrollmentFunc: func(params *enrollment.CreateEnrollmentParams) (*enrollment.CreateEnrollmentCreated, error) {
+			if params == nil || params.Enrollment == nil || params.Enrollment.IdentityID == nil || *params.Enrollment.IdentityID != "identity-id" {
+				t.Fatalf("expected enrollment for identity-id, got %#v", params)
+			}
+			return createEnrollmentResponse("enrollment-id"), nil
+		},
+		detailEnrollmentFunc: func(params *enrollment.DetailEnrollmentParams) (*enrollment.DetailEnrollmentOK, error) {
+			return detailEnrollmentResponse("jwt-token"), nil
 		},
 	}
 
-	client := &Client{identity: fake}
+	client := &Client{identity: fake, enrollment: fakeEnrollment}
 	_, _, err := client.CreateAgentIdentityWithOptions(ctx, agentID, workloadID, []string{"group-one"}, map[string]string{"network": "net-1"})
 	if err != nil {
 		t.Fatalf("create agent identity: %v", err)
@@ -538,7 +575,7 @@ func TestCreateAgentIdentityCreateFailure(t *testing.T) {
 	agentID := uuid.New()
 	workloadID := uuid.New()
 	createErr := errors.New("create failed")
-	var detailCalled bool
+	var enrollmentCalled bool
 
 	fake := &fakeIdentityService{
 		listIdentitiesFunc: func(params *identity.ListIdentitiesParams) (*identity.ListIdentitiesOK, error) {
@@ -550,13 +587,15 @@ func TestCreateAgentIdentityCreateFailure(t *testing.T) {
 			assertCreateAgentRoleAttributes(t, params, agentID, workloadID)
 			return nil, createErr
 		},
-		detailIdentityFunc: func(params *identity.DetailIdentityParams) (*identity.DetailIdentityOK, error) {
-			detailCalled = true
-			return nil, errors.New("detail identity should not be called")
+	}
+	fakeEnrollment := &fakeEnrollmentService{
+		createEnrollmentFunc: func(params *enrollment.CreateEnrollmentParams) (*enrollment.CreateEnrollmentCreated, error) {
+			enrollmentCalled = true
+			return nil, errors.New("create enrollment should not be called")
 		},
 	}
 
-	client := &Client{identity: fake}
+	client := &Client{identity: fake, enrollment: fakeEnrollment}
 	_, _, err := client.CreateAgentIdentity(ctx, agentID, workloadID)
 	if err == nil {
 		t.Fatalf("expected create error")
@@ -564,8 +603,8 @@ func TestCreateAgentIdentityCreateFailure(t *testing.T) {
 	if !errors.Is(err, createErr) {
 		t.Fatalf("expected error %q, got %v", createErr, err)
 	}
-	if detailCalled {
-		t.Fatalf("expected detail not called")
+	if enrollmentCalled {
+		t.Fatalf("expected enrollment not called")
 	}
 }
 
@@ -1016,6 +1055,15 @@ func assertSameStrings(t *testing.T, actual, expected []string) {
 
 func createIdentityResponse(identityID string) *identity.CreateIdentityCreated {
 	return &identity.CreateIdentityCreated{Payload: &rest_model.CreateEnvelope{Data: &rest_model.CreateLocation{ID: identityID}}}
+}
+
+func createEnrollmentResponse(enrollmentID string) *enrollment.CreateEnrollmentCreated {
+	return &enrollment.CreateEnrollmentCreated{Payload: &rest_model.CreateEnvelope{Data: &rest_model.CreateLocation{ID: enrollmentID}}}
+}
+
+func detailEnrollmentResponse(jwt string) *enrollment.DetailEnrollmentOK {
+	expiresAt := strfmt.DateTime(time.Now().Add(time.Hour).UTC())
+	return &enrollment.DetailEnrollmentOK{Payload: &rest_model.DetailEnrollmentEnvelope{Data: &rest_model.EnrollmentDetail{JWT: jwt, ExpiresAt: &expiresAt}}}
 }
 
 func detailIdentityResponse(jwt string) *identity.DetailIdentityOK {

--- a/internal/ziti/client_test.go
+++ b/internal/ziti/client_test.go
@@ -14,6 +14,7 @@ import (
 	"github.com/golang-jwt/jwt/v5"
 	"github.com/google/uuid"
 	"github.com/openziti/edge-api/rest_management_api_client/config"
+	"github.com/openziti/edge-api/rest_management_api_client/enrollment"
 	"github.com/openziti/edge-api/rest_management_api_client/identity"
 	"github.com/openziti/edge-api/rest_management_api_client/service"
 	"github.com/openziti/edge-api/rest_management_api_client/service_policy"
@@ -26,7 +27,11 @@ type fakeIdentityService struct {
 	deleteIdentityFunc func(params *identity.DeleteIdentityParams) (*identity.DeleteIdentityOK, error)
 	detailIdentityFunc func(params *identity.DetailIdentityParams) (*identity.DetailIdentityOK, error)
 	listIdentitiesFunc func(params *identity.ListIdentitiesParams) (*identity.ListIdentitiesOK, error)
-	patchIdentityFunc  func(params *identity.PatchIdentityParams) (*identity.PatchIdentityOK, error)
+}
+
+type fakeEnrollmentService struct {
+	createEnrollmentFunc func(params *enrollment.CreateEnrollmentParams) (*enrollment.CreateEnrollmentCreated, error)
+	detailEnrollmentFunc func(params *enrollment.DetailEnrollmentParams) (*enrollment.DetailEnrollmentOK, error)
 }
 
 func (f *fakeIdentityService) CreateIdentity(params *identity.CreateIdentityParams, _ runtime.ClientAuthInfoWriter, _ ...identity.ClientOption) (*identity.CreateIdentityCreated, error) {
@@ -57,11 +62,18 @@ func (f *fakeIdentityService) ListIdentities(params *identity.ListIdentitiesPara
 	return f.listIdentitiesFunc(params)
 }
 
-func (f *fakeIdentityService) PatchIdentity(params *identity.PatchIdentityParams, _ runtime.ClientAuthInfoWriter, _ ...identity.ClientOption) (*identity.PatchIdentityOK, error) {
-	if f.patchIdentityFunc == nil {
-		return nil, errors.New("patch identity not stubbed")
+func (f *fakeEnrollmentService) CreateEnrollment(params *enrollment.CreateEnrollmentParams, _ runtime.ClientAuthInfoWriter, _ ...enrollment.ClientOption) (*enrollment.CreateEnrollmentCreated, error) {
+	if f.createEnrollmentFunc == nil {
+		return nil, errors.New("create enrollment not stubbed")
 	}
-	return f.patchIdentityFunc(params)
+	return f.createEnrollmentFunc(params)
+}
+
+func (f *fakeEnrollmentService) DetailEnrollment(params *enrollment.DetailEnrollmentParams, _ runtime.ClientAuthInfoWriter, _ ...enrollment.ClientOption) (*enrollment.DetailEnrollmentOK, error) {
+	if f.detailEnrollmentFunc == nil {
+		return nil, errors.New("detail enrollment not stubbed")
+	}
+	return f.detailEnrollmentFunc(params)
 }
 
 type fakeServiceService struct {
@@ -198,6 +210,7 @@ func TestCreateAgentIdentityCreatesIdentity(t *testing.T) {
 	agentID := uuid.New()
 	workloadID := uuid.New()
 	createdID := "created-id"
+	enrollmentID := "enrollment-id"
 	jwt := "jwt-token"
 
 	fake := &fakeIdentityService{
@@ -210,15 +223,23 @@ func TestCreateAgentIdentityCreatesIdentity(t *testing.T) {
 			assertCreateAgentRoleAttributes(t, params, agentID, workloadID)
 			return createIdentityResponse(createdID), nil
 		},
-		detailIdentityFunc: func(params *identity.DetailIdentityParams) (*identity.DetailIdentityOK, error) {
-			if params == nil || params.ID != createdID {
-				t.Fatalf("expected detail identity id %q, got %#v", createdID, params)
+	}
+	fakeEnrollment := &fakeEnrollmentService{
+		createEnrollmentFunc: func(params *enrollment.CreateEnrollmentParams) (*enrollment.CreateEnrollmentCreated, error) {
+			if params == nil || params.Enrollment == nil || params.Enrollment.IdentityID == nil || *params.Enrollment.IdentityID != createdID {
+				t.Fatalf("expected create enrollment identity id %q, got %#v", createdID, params)
 			}
-			return detailIdentityResponse(jwt), nil
+			return createEnrollmentResponse(enrollmentID), nil
+		},
+		detailEnrollmentFunc: func(params *enrollment.DetailEnrollmentParams) (*enrollment.DetailEnrollmentOK, error) {
+			if params == nil || params.ID != enrollmentID {
+				t.Fatalf("expected detail enrollment id %q, got %#v", enrollmentID, params)
+			}
+			return detailEnrollmentResponse(jwt), nil
 		},
 	}
 
-	client := &Client{identity: fake}
+	client := &Client{identity: fake, enrollment: fakeEnrollment}
 	zitiID, token, err := client.CreateAgentIdentity(ctx, agentID, workloadID)
 	if err != nil {
 		t.Fatalf("create agent identity: %v", err)
@@ -245,12 +266,20 @@ func TestCreateAgentIdentityWithOptionsAddsRolesAndTags(t *testing.T) {
 			assertTags(t, params.Identity.Tags, map[string]string{"network": "net-1"})
 			return createIdentityResponse("identity-id"), nil
 		},
-		detailIdentityFunc: func(params *identity.DetailIdentityParams) (*identity.DetailIdentityOK, error) {
-			return detailIdentityResponse("jwt-token"), nil
+	}
+	fakeEnrollment := &fakeEnrollmentService{
+		createEnrollmentFunc: func(params *enrollment.CreateEnrollmentParams) (*enrollment.CreateEnrollmentCreated, error) {
+			if params == nil || params.Enrollment == nil || params.Enrollment.IdentityID == nil || *params.Enrollment.IdentityID != "identity-id" {
+				t.Fatalf("expected enrollment for identity-id, got %#v", params)
+			}
+			return createEnrollmentResponse("enrollment-id"), nil
+		},
+		detailEnrollmentFunc: func(params *enrollment.DetailEnrollmentParams) (*enrollment.DetailEnrollmentOK, error) {
+			return detailEnrollmentResponse("jwt-token"), nil
 		},
 	}
 
-	client := &Client{identity: fake}
+	client := &Client{identity: fake, enrollment: fakeEnrollment}
 	_, _, err := client.CreateAgentIdentityWithOptions(ctx, agentID, workloadID, []string{"group-one"}, map[string]string{"network": "net-1"})
 	if err != nil {
 		t.Fatalf("create agent identity: %v", err)
@@ -317,153 +346,19 @@ func TestCreateTunnelIdentityUsesJWTExpirationWhenControllerExpiryMissing(t *tes
 	}
 }
 
-func TestPatchIdentityRoleAttributesAddsAttrs(t *testing.T) {
-	ctx := context.Background()
-	fake := &fakeIdentityService{
-		detailIdentityFunc: detailIdentityWithRoleAttributes(rest_model.Attributes{"agents", "agent-one"}),
-		patchIdentityFunc: func(params *identity.PatchIdentityParams) (*identity.PatchIdentityOK, error) {
-			assertPatchIdentityRoleAttributes(t, params, "identity-id", []string{"agents", "agent-one", "group-one", "group-two"})
-			return &identity.PatchIdentityOK{}, nil
-		},
-	}
-
-	client := &Client{identity: fake}
-	if err := client.PatchIdentityRoleAttributes(ctx, "identity-id", []string{"group-one", "group-two"}, nil); err != nil {
-		t.Fatalf("patch identity role attributes: %v", err)
-	}
-}
-
-func TestPatchIdentityRoleAttributesRemovesAttrs(t *testing.T) {
-	ctx := context.Background()
-	fake := &fakeIdentityService{
-		detailIdentityFunc: detailIdentityWithRoleAttributes(rest_model.Attributes{"agents", "group-one", "agent-one", "group-two"}),
-		patchIdentityFunc: func(params *identity.PatchIdentityParams) (*identity.PatchIdentityOK, error) {
-			assertPatchIdentityRoleAttributes(t, params, "identity-id", []string{"agents", "agent-one"})
-			return &identity.PatchIdentityOK{}, nil
-		},
-	}
-
-	client := &Client{identity: fake}
-	if err := client.PatchIdentityRoleAttributes(ctx, "identity-id", nil, []string{"group-one", "group-two"}); err != nil {
-		t.Fatalf("patch identity role attributes: %v", err)
-	}
-}
-
-func TestPatchIdentityRoleAttributesAddsAndRemovesDeterministically(t *testing.T) {
-	ctx := context.Background()
-	fake := &fakeIdentityService{
-		detailIdentityFunc: detailIdentityWithRoleAttributes(rest_model.Attributes{"agents", "group-old", "agent-one", "group-same"}),
-		patchIdentityFunc: func(params *identity.PatchIdentityParams) (*identity.PatchIdentityOK, error) {
-			assertPatchIdentityRoleAttributes(t, params, "identity-id", []string{"agents", "agent-one", "group-new"})
-			return &identity.PatchIdentityOK{}, nil
-		},
-	}
-
-	client := &Client{identity: fake}
-	err := client.PatchIdentityRoleAttributes(ctx, "identity-id", []string{"group-new", "group-same"}, []string{"group-old", "group-same"})
-	if err != nil {
-		t.Fatalf("patch identity role attributes: %v", err)
-	}
-}
-
-func TestPatchIdentityRoleAttributesIsIdempotent(t *testing.T) {
-	ctx := context.Background()
-	currentAttrs := rest_model.Attributes{"agents", "group-one", "agent-one"}
-	fake := &fakeIdentityService{
-		detailIdentityFunc: detailIdentityWithRoleAttributes(currentAttrs),
-		patchIdentityFunc: func(params *identity.PatchIdentityParams) (*identity.PatchIdentityOK, error) {
-			assertPatchIdentityRoleAttributes(t, params, "identity-id", []string{"agents", "group-one", "agent-one"})
-			return &identity.PatchIdentityOK{}, nil
-		},
-	}
-
-	client := &Client{identity: fake}
-	err := client.PatchIdentityRoleAttributes(ctx, "identity-id", []string{"group-one", "group-one"}, []string{"missing", "missing"})
-	if err != nil {
-		t.Fatalf("patch identity role attributes: %v", err)
-	}
-}
-
-func TestPatchIdentityRoleAttributesPreservesUnrelatedAttrs(t *testing.T) {
-	ctx := context.Background()
-	currentAttrs := rest_model.Attributes{"agents", "agent-one", "workload-one", "devices", "user-one", "apps", "app-one", "custom"}
-	fake := &fakeIdentityService{
-		detailIdentityFunc: detailIdentityWithRoleAttributes(currentAttrs),
-		patchIdentityFunc: func(params *identity.PatchIdentityParams) (*identity.PatchIdentityOK, error) {
-			assertPatchIdentityRoleAttributes(t, params, "identity-id", []string{"agents", "agent-one", "workload-one", "devices", "user-one", "apps", "app-one", "custom", "group-one"})
-			return &identity.PatchIdentityOK{}, nil
-		},
-	}
-
-	client := &Client{identity: fake}
-	if err := client.PatchIdentityRoleAttributes(ctx, "identity-id", []string{"group-one"}, []string{"missing"}); err != nil {
-		t.Fatalf("patch identity role attributes: %v", err)
-	}
-}
-
-func TestPatchIdentityRoleAttributesMapsDetailNotFound(t *testing.T) {
+func TestPatchIdentityRoleAttributesUnsupported(t *testing.T) {
 	ctx := context.Background()
 	fake := &fakeIdentityService{
 		detailIdentityFunc: func(params *identity.DetailIdentityParams) (*identity.DetailIdentityOK, error) {
-			return nil, &identity.DetailIdentityNotFound{}
+			t.Fatalf("detail identity should not be called for unsupported delta patch")
+			return nil, nil
 		},
 	}
 
 	client := &Client{identity: fake}
-	err := client.PatchIdentityRoleAttributes(ctx, "identity-id", []string{"group-one"}, nil)
-	if !errors.Is(err, ErrIdentityNotFound) {
-		t.Fatalf("expected identity not found, got %v", err)
-	}
-}
-
-func TestPatchIdentityRoleAttributesMapsPatchNotFound(t *testing.T) {
-	ctx := context.Background()
-	fake := &fakeIdentityService{
-		detailIdentityFunc: detailIdentityWithRoleAttributes(rest_model.Attributes{"agents"}),
-		patchIdentityFunc: func(params *identity.PatchIdentityParams) (*identity.PatchIdentityOK, error) {
-			return nil, &identity.PatchIdentityNotFound{}
-		},
-	}
-
-	client := &Client{identity: fake}
-	err := client.PatchIdentityRoleAttributes(ctx, "identity-id", []string{"group-one"}, nil)
-	if !errors.Is(err, ErrIdentityNotFound) {
-		t.Fatalf("expected identity not found, got %v", err)
-	}
-}
-
-func TestPatchIdentityRoleAttributesWrapsControllerError(t *testing.T) {
-	ctx := context.Background()
-	controllerErr := errors.New("controller unavailable")
-	fake := &fakeIdentityService{
-		detailIdentityFunc: detailIdentityWithRoleAttributes(rest_model.Attributes{"agents"}),
-		patchIdentityFunc: func(params *identity.PatchIdentityParams) (*identity.PatchIdentityOK, error) {
-			return nil, controllerErr
-		},
-	}
-
-	client := &Client{identity: fake}
-	err := client.PatchIdentityRoleAttributes(ctx, "identity-id", []string{"group-one"}, nil)
-	if !errors.Is(err, controllerErr) {
-		t.Fatalf("expected controller error, got %v", err)
-	}
-}
-
-func detailIdentityWithRoleAttributes(roleAttributes rest_model.Attributes) func(*identity.DetailIdentityParams) (*identity.DetailIdentityOK, error) {
-	return func(params *identity.DetailIdentityParams) (*identity.DetailIdentityOK, error) {
-		return &identity.DetailIdentityOK{Payload: &rest_model.DetailIdentityEnvelope{Data: &rest_model.IdentityDetail{
-			RoleAttributes: &roleAttributes,
-		}}}, nil
-	}
-}
-
-func assertPatchIdentityRoleAttributes(t *testing.T, params *identity.PatchIdentityParams, identityID string, expected []string) {
-	t.Helper()
-	if params == nil || params.ID != identityID || params.Identity == nil || params.Identity.RoleAttributes == nil {
-		t.Fatalf("unexpected patch params: %#v", params)
-	}
-	if !reflect.DeepEqual([]string(*params.Identity.RoleAttributes), expected) {
-		t.Fatalf("unexpected role attributes: %#v", *params.Identity.RoleAttributes)
+	err := client.PatchIdentityRoleAttributes(ctx, "identity-id", []string{"group-new"}, []string{"group-old"})
+	if !errors.Is(err, ErrRoleAttributePatchUnsupported) {
+		t.Fatalf("expected unsupported error, got %v", err)
 	}
 }
 
@@ -680,7 +575,7 @@ func TestCreateAgentIdentityCreateFailure(t *testing.T) {
 	agentID := uuid.New()
 	workloadID := uuid.New()
 	createErr := errors.New("create failed")
-	var detailCalled bool
+	var enrollmentCalled bool
 
 	fake := &fakeIdentityService{
 		listIdentitiesFunc: func(params *identity.ListIdentitiesParams) (*identity.ListIdentitiesOK, error) {
@@ -692,13 +587,15 @@ func TestCreateAgentIdentityCreateFailure(t *testing.T) {
 			assertCreateAgentRoleAttributes(t, params, agentID, workloadID)
 			return nil, createErr
 		},
-		detailIdentityFunc: func(params *identity.DetailIdentityParams) (*identity.DetailIdentityOK, error) {
-			detailCalled = true
-			return nil, errors.New("detail identity should not be called")
+	}
+	fakeEnrollment := &fakeEnrollmentService{
+		createEnrollmentFunc: func(params *enrollment.CreateEnrollmentParams) (*enrollment.CreateEnrollmentCreated, error) {
+			enrollmentCalled = true
+			return nil, errors.New("create enrollment should not be called")
 		},
 	}
 
-	client := &Client{identity: fake}
+	client := &Client{identity: fake, enrollment: fakeEnrollment}
 	_, _, err := client.CreateAgentIdentity(ctx, agentID, workloadID)
 	if err == nil {
 		t.Fatalf("expected create error")
@@ -706,8 +603,8 @@ func TestCreateAgentIdentityCreateFailure(t *testing.T) {
 	if !errors.Is(err, createErr) {
 		t.Fatalf("expected error %q, got %v", createErr, err)
 	}
-	if detailCalled {
-		t.Fatalf("expected detail not called")
+	if enrollmentCalled {
+		t.Fatalf("expected enrollment not called")
 	}
 }
 
@@ -1158,6 +1055,15 @@ func assertSameStrings(t *testing.T, actual, expected []string) {
 
 func createIdentityResponse(identityID string) *identity.CreateIdentityCreated {
 	return &identity.CreateIdentityCreated{Payload: &rest_model.CreateEnvelope{Data: &rest_model.CreateLocation{ID: identityID}}}
+}
+
+func createEnrollmentResponse(enrollmentID string) *enrollment.CreateEnrollmentCreated {
+	return &enrollment.CreateEnrollmentCreated{Payload: &rest_model.CreateEnvelope{Data: &rest_model.CreateLocation{ID: enrollmentID}}}
+}
+
+func detailEnrollmentResponse(jwt string) *enrollment.DetailEnrollmentOK {
+	expiresAt := strfmt.DateTime(time.Now().Add(time.Hour).UTC())
+	return &enrollment.DetailEnrollmentOK{Payload: &rest_model.DetailEnrollmentEnvelope{Data: &rest_model.EnrollmentDetail{JWT: jwt, ExpiresAt: &expiresAt}}}
 }
 
 func detailIdentityResponse(jwt string) *identity.DetailIdentityOK {

--- a/internal/ziti/client_test.go
+++ b/internal/ziti/client_test.go
@@ -235,6 +235,7 @@ func TestCreateAgentIdentityCreatesIdentity(t *testing.T) {
 		return &sdkziti.EnrollmentClaims{EnrollmentMethod: rest_model.EnrollmentCreateMethodOtt, RegisteredClaims: jwtlibClaims("jwt-token-id")}, nil, nil
 	})
 
+	detailCalls := 0
 	fake := &fakeIdentityService{
 		listIdentitiesFunc: func(params *identity.ListIdentitiesParams) (*identity.ListIdentitiesOK, error) {
 			assertListExternalID(t, params, workloadID)
@@ -249,7 +250,14 @@ func TestCreateAgentIdentityCreatesIdentity(t *testing.T) {
 			return createIdentityResponse(createdID), nil
 		},
 		detailIdentityFunc: func(params *identity.DetailIdentityParams) (*identity.DetailIdentityOK, error) {
-			return detailIdentityResponseWithEnrollmentIDs("stale-enrollment-id"), nil
+			if params == nil || params.ID != createdID {
+				t.Fatalf("expected detail identity id %q, got %#v", createdID, params)
+			}
+			detailCalls++
+			if detailCalls == 1 {
+				return detailIdentityResponseWithEnrollmentIDs("stale-enrollment-id"), nil
+			}
+			return detailIdentityResponseNoEnrollments(), nil
 		},
 	}
 	fakeEnrollment := &fakeEnrollmentService{

--- a/internal/ziti/client_test.go
+++ b/internal/ziti/client_test.go
@@ -31,6 +31,7 @@ type fakeIdentityService struct {
 
 type fakeEnrollmentService struct {
 	createEnrollmentFunc func(params *enrollment.CreateEnrollmentParams) (*enrollment.CreateEnrollmentCreated, error)
+	deleteEnrollmentFunc func(params *enrollment.DeleteEnrollmentParams) (*enrollment.DeleteEnrollmentOK, error)
 	detailEnrollmentFunc func(params *enrollment.DetailEnrollmentParams) (*enrollment.DetailEnrollmentOK, error)
 }
 
@@ -67,6 +68,13 @@ func (f *fakeEnrollmentService) CreateEnrollment(params *enrollment.CreateEnroll
 		return nil, errors.New("create enrollment not stubbed")
 	}
 	return f.createEnrollmentFunc(params)
+}
+
+func (f *fakeEnrollmentService) DeleteEnrollment(params *enrollment.DeleteEnrollmentParams, _ runtime.ClientAuthInfoWriter, _ ...enrollment.ClientOption) (*enrollment.DeleteEnrollmentOK, error) {
+	if f.deleteEnrollmentFunc == nil {
+		return nil, errors.New("delete enrollment not stubbed")
+	}
+	return f.deleteEnrollmentFunc(params)
 }
 
 func (f *fakeEnrollmentService) DetailEnrollment(params *enrollment.DetailEnrollmentParams, _ runtime.ClientAuthInfoWriter, _ ...enrollment.ClientOption) (*enrollment.DetailEnrollmentOK, error) {
@@ -211,7 +219,13 @@ func TestCreateAgentIdentityCreatesIdentity(t *testing.T) {
 	workloadID := uuid.New()
 	createdID := "created-id"
 	enrollmentID := "enrollment-id"
-	jwt := "jwt-token"
+	enrollmentJWT := "jwt-token"
+	stubEnrollmentParser(t, func(token string) (*sdkziti.EnrollmentClaims, *jwt.Token, error) {
+		if token != enrollmentJWT {
+			t.Fatalf("unexpected token: %s", token)
+		}
+		return &sdkziti.EnrollmentClaims{EnrollmentMethod: rest_model.EnrollmentCreateMethodOtt, RegisteredClaims: jwtlibClaims("jwt-token-id")}, nil, nil
+	})
 
 	fake := &fakeIdentityService{
 		listIdentitiesFunc: func(params *identity.ListIdentitiesParams) (*identity.ListIdentitiesOK, error) {
@@ -226,8 +240,17 @@ func TestCreateAgentIdentityCreatesIdentity(t *testing.T) {
 			}
 			return createIdentityResponse(createdID), nil
 		},
+		detailIdentityFunc: func(params *identity.DetailIdentityParams) (*identity.DetailIdentityOK, error) {
+			return detailIdentityResponseWithEnrollmentIDs("stale-enrollment-id"), nil
+		},
 	}
 	fakeEnrollment := &fakeEnrollmentService{
+		deleteEnrollmentFunc: func(params *enrollment.DeleteEnrollmentParams) (*enrollment.DeleteEnrollmentOK, error) {
+			if params == nil || params.ID != "stale-enrollment-id" {
+				t.Fatalf("expected stale enrollment delete, got %#v", params)
+			}
+			return &enrollment.DeleteEnrollmentOK{}, nil
+		},
 		createEnrollmentFunc: func(params *enrollment.CreateEnrollmentParams) (*enrollment.CreateEnrollmentCreated, error) {
 			if params == nil || params.Enrollment == nil || params.Enrollment.IdentityID == nil || *params.Enrollment.IdentityID != createdID {
 				t.Fatalf("expected create enrollment identity id %q, got %#v", createdID, params)
@@ -238,7 +261,7 @@ func TestCreateAgentIdentityCreatesIdentity(t *testing.T) {
 			if params == nil || params.ID != enrollmentID {
 				t.Fatalf("expected detail enrollment id %q, got %#v", enrollmentID, params)
 			}
-			return detailEnrollmentResponse(jwt), nil
+			return detailEnrollmentResponse(enrollmentJWT), nil
 		},
 	}
 
@@ -250,8 +273,8 @@ func TestCreateAgentIdentityCreatesIdentity(t *testing.T) {
 	if zitiID != createdID {
 		t.Fatalf("expected identity id %q, got %q", createdID, zitiID)
 	}
-	if token != jwt {
-		t.Fatalf("expected jwt %q, got %q", jwt, token)
+	if token != enrollmentJWT {
+		t.Fatalf("expected jwt %q, got %q", enrollmentJWT, token)
 	}
 }
 
@@ -259,6 +282,12 @@ func TestCreateAgentIdentityWithOptionsAddsRolesAndTags(t *testing.T) {
 	ctx := context.Background()
 	agentID := uuid.New()
 	workloadID := uuid.New()
+	stubEnrollmentParser(t, func(token string) (*sdkziti.EnrollmentClaims, *jwt.Token, error) {
+		if token != "jwt-token" {
+			t.Fatalf("unexpected token: %s", token)
+		}
+		return &sdkziti.EnrollmentClaims{EnrollmentMethod: rest_model.EnrollmentCreateMethodOtt, RegisteredClaims: jwtlibClaims("jwt-token-id")}, nil, nil
+	})
 	fake := &fakeIdentityService{
 		listIdentitiesFunc: func(params *identity.ListIdentitiesParams) (*identity.ListIdentitiesOK, error) {
 			assertListExternalID(t, params, workloadID)
@@ -272,8 +301,15 @@ func TestCreateAgentIdentityWithOptionsAddsRolesAndTags(t *testing.T) {
 			assertTags(t, params.Identity.Tags, map[string]string{"network": "net-1"})
 			return createIdentityResponse("identity-id"), nil
 		},
+		detailIdentityFunc: func(params *identity.DetailIdentityParams) (*identity.DetailIdentityOK, error) {
+			return detailIdentityResponseNoEnrollments(), nil
+		},
 	}
 	fakeEnrollment := &fakeEnrollmentService{
+		deleteEnrollmentFunc: func(params *enrollment.DeleteEnrollmentParams) (*enrollment.DeleteEnrollmentOK, error) {
+			t.Fatalf("delete enrollment should not be called without existing enrollments")
+			return nil, nil
+		},
 		createEnrollmentFunc: func(params *enrollment.CreateEnrollmentParams) (*enrollment.CreateEnrollmentCreated, error) {
 			if params == nil || params.Enrollment == nil || params.Enrollment.IdentityID == nil || *params.Enrollment.IdentityID != "identity-id" {
 				t.Fatalf("expected enrollment for identity-id, got %#v", params)
@@ -289,6 +325,42 @@ func TestCreateAgentIdentityWithOptionsAddsRolesAndTags(t *testing.T) {
 	_, _, err := client.CreateAgentIdentityWithOptions(ctx, agentID, workloadID, []string{"group-one"}, map[string]string{"network": "net-1"})
 	if err != nil {
 		t.Fatalf("create agent identity: %v", err)
+	}
+}
+
+func TestCreateAgentIdentityRejectsEnrollmentJWTWithoutTokenID(t *testing.T) {
+	ctx := context.Background()
+	stubEnrollmentParser(t, func(token string) (*sdkziti.EnrollmentClaims, *jwt.Token, error) {
+		return &sdkziti.EnrollmentClaims{EnrollmentMethod: rest_model.EnrollmentCreateMethodOtt}, nil, nil
+	})
+	fakeIdentity := &fakeIdentityService{
+		listIdentitiesFunc: func(params *identity.ListIdentitiesParams) (*identity.ListIdentitiesOK, error) {
+			return listIdentitiesResponse(nil, 100, 0, 0), nil
+		},
+		createIdentityFunc: func(params *identity.CreateIdentityParams) (*identity.CreateIdentityCreated, error) {
+			return createIdentityResponse("identity-id"), nil
+		},
+		detailIdentityFunc: func(params *identity.DetailIdentityParams) (*identity.DetailIdentityOK, error) {
+			return detailIdentityResponseNoEnrollments(), nil
+		},
+	}
+	fakeEnrollment := &fakeEnrollmentService{
+		deleteEnrollmentFunc: func(params *enrollment.DeleteEnrollmentParams) (*enrollment.DeleteEnrollmentOK, error) {
+			t.Fatalf("delete enrollment should not be called without existing enrollments")
+			return nil, nil
+		},
+		createEnrollmentFunc: func(params *enrollment.CreateEnrollmentParams) (*enrollment.CreateEnrollmentCreated, error) {
+			return createEnrollmentResponse("enrollment-id"), nil
+		},
+		detailEnrollmentFunc: func(params *enrollment.DetailEnrollmentParams) (*enrollment.DetailEnrollmentOK, error) {
+			return detailEnrollmentResponse("jwt-token"), nil
+		},
+	}
+
+	client := &Client{identity: fakeIdentity, enrollment: fakeEnrollment}
+	_, _, err := client.CreateAgentIdentity(ctx, uuid.New(), uuid.New())
+	if err == nil || !strings.Contains(err.Error(), "missing token id") {
+		t.Fatalf("expected missing token id error, got %v", err)
 	}
 }
 
@@ -325,12 +397,12 @@ func TestCreateTunnelIdentityCreatesTunnelRolesAndTags(t *testing.T) {
 func TestCreateTunnelIdentityUsesJWTExpirationWhenControllerExpiryMissing(t *testing.T) {
 	ctx := context.Background()
 	expiresAt := time.Now().Add(2 * time.Hour).UTC().Truncate(time.Second)
-	stubEnrollmentFuncs(t, func(token string) (*sdkziti.EnrollmentClaims, *jwt.Token, error) {
+	stubEnrollmentParser(t, func(token string) (*sdkziti.EnrollmentClaims, *jwt.Token, error) {
 		if token != "tunnel-jwt" {
 			t.Fatalf("unexpected token: %s", token)
 		}
 		return &sdkziti.EnrollmentClaims{RegisteredClaims: jwt.RegisteredClaims{ExpiresAt: jwt.NewNumericDate(expiresAt)}}, nil, nil
-	}, nil)
+	})
 	fake := &fakeIdentityService{
 		createIdentityFunc: func(params *identity.CreateIdentityParams) (*identity.CreateIdentityCreated, error) {
 			return createIdentityResponse("tunnel-id"), nil
@@ -1104,6 +1176,15 @@ func assertSameStrings(t *testing.T, actual, expected []string) {
 	}
 }
 
+func stubEnrollmentParser(t *testing.T, parse func(string) (*sdkziti.EnrollmentClaims, *jwt.Token, error)) {
+	t.Helper()
+	originalParse := parseEnrollmentToken
+	parseEnrollmentToken = parse
+	t.Cleanup(func() {
+		parseEnrollmentToken = originalParse
+	})
+}
+
 func createIdentityResponse(identityID string) *identity.CreateIdentityCreated {
 	return &identity.CreateIdentityCreated{Payload: &rest_model.CreateEnvelope{Data: &rest_model.CreateLocation{ID: identityID}}}
 }
@@ -1117,6 +1198,10 @@ func detailEnrollmentResponse(jwt string) *enrollment.DetailEnrollmentOK {
 	return &enrollment.DetailEnrollmentOK{Payload: &rest_model.DetailEnrollmentEnvelope{Data: &rest_model.EnrollmentDetail{JWT: jwt, ExpiresAt: &expiresAt}}}
 }
 
+func jwtlibClaims(id string) jwt.RegisteredClaims {
+	return jwt.RegisteredClaims{ID: id}
+}
+
 func detailIdentityResponse(jwt string) *identity.DetailIdentityOK {
 	expiresAt := time.Now().Add(time.Hour).UTC()
 	return detailIdentityResponseWithExpiry(jwt, expiresAt)
@@ -1126,6 +1211,16 @@ func detailIdentityResponseWithExpiry(jwt string, expiresAt time.Time) *identity
 	expires := strfmt.DateTime(expiresAt)
 	return &identity.DetailIdentityOK{Payload: &rest_model.DetailIdentityEnvelope{Data: &rest_model.IdentityDetail{Enrollment: &rest_model.IdentityEnrollments{
 		Ott: &rest_model.IdentityEnrollmentsOtt{JWT: jwt, ExpiresAt: expires},
+	}}}}
+}
+
+func detailIdentityResponseNoEnrollments() *identity.DetailIdentityOK {
+	return &identity.DetailIdentityOK{Payload: &rest_model.DetailIdentityEnvelope{Data: &rest_model.IdentityDetail{Enrollment: &rest_model.IdentityEnrollments{}}}}
+}
+
+func detailIdentityResponseWithEnrollmentIDs(ottID string) *identity.DetailIdentityOK {
+	return &identity.DetailIdentityOK{Payload: &rest_model.DetailIdentityEnvelope{Data: &rest_model.IdentityDetail{Enrollment: &rest_model.IdentityEnrollments{
+		Ott: &rest_model.IdentityEnrollmentsOtt{ID: ottID},
 	}}}}
 }
 

--- a/internal/ziti/client_test.go
+++ b/internal/ziti/client_test.go
@@ -125,6 +125,7 @@ func (f *fakeServiceService) PatchService(params *service.PatchServiceParams, _ 
 
 type fakeConfigService struct {
 	createConfigFunc func(params *config.CreateConfigParams) (*config.CreateConfigCreated, error)
+	listConfigsFunc  func(params *config.ListConfigsParams) (*config.ListConfigsOK, error)
 	deleteConfigFunc func(params *config.DeleteConfigParams) (*config.DeleteConfigOK, error)
 	patchConfigFunc  func(params *config.PatchConfigParams) (*config.PatchConfigOK, error)
 }
@@ -134,6 +135,13 @@ func (f *fakeConfigService) CreateConfig(params *config.CreateConfigParams, _ ru
 		return nil, errors.New("create config not stubbed")
 	}
 	return f.createConfigFunc(params)
+}
+
+func (f *fakeConfigService) ListConfigs(params *config.ListConfigsParams, _ runtime.ClientAuthInfoWriter, _ ...config.ClientOption) (*config.ListConfigsOK, error) {
+	if f.listConfigsFunc == nil {
+		return nil, errors.New("list configs not stubbed")
+	}
+	return f.listConfigsFunc(params)
 }
 
 func (f *fakeConfigService) DeleteConfig(params *config.DeleteConfigParams, _ runtime.ClientAuthInfoWriter, _ ...config.ClientOption) (*config.DeleteConfigOK, error) {
@@ -597,6 +605,12 @@ func TestUpdateServiceConfigsAndTagsPatchesConfigsAndTags(t *testing.T) {
 		},
 	}
 	fakeConfig := &fakeConfigService{
+		listConfigsFunc: func(params *config.ListConfigsParams) (*config.ListConfigsOK, error) {
+			if params == nil || params.Filter == nil || *params.Filter != `name = "service-name-host-v1"` {
+				t.Fatalf("unexpected config lookup: %#v", params)
+			}
+			return listConfigsByNameResponse(nil, 2, 0, 0), nil
+		},
 		createConfigFunc: func(params *config.CreateConfigParams) (*config.CreateConfigCreated, error) {
 			if params == nil || params.Config == nil {
 				t.Fatalf("expected config create")
@@ -1268,6 +1282,93 @@ func listConfigsResponse(details []*rest_model.ConfigDetail, limit, offset, tota
 	}
 }
 
+func listConfigsByNameResponse(details []*rest_model.ConfigDetail, limit, offset, total int64) *config.ListConfigsOK {
+	return &config.ListConfigsOK{
+		Payload: &rest_model.ListConfigsEnvelope{
+			Data: details,
+			Meta: paginationMeta(limit, offset, total),
+		},
+	}
+}
+
 func paginationMeta(limit, offset, total int64) *rest_model.Meta {
 	return &rest_model.Meta{Pagination: &rest_model.Pagination{Limit: &limit, Offset: &offset, TotalCount: &total}}
+}
+
+func TestUpdateServiceReusesConfigByName(t *testing.T) {
+	ctx := context.Background()
+	serviceID := "service-id"
+	serviceName := "service-name"
+	hostConfigID := "host-config"
+	interceptConfigID := "intercept-config"
+	roles := rest_model.Attributes{"role-one"}
+	listConfigCalls := 0
+	patchConfigIDs := make([]string, 0, 2)
+
+	fakeConfig := &fakeConfigService{
+		listConfigsFunc: func(params *config.ListConfigsParams) (*config.ListConfigsOK, error) {
+			if params == nil || params.Filter == nil {
+				t.Fatalf("expected config name filter")
+			}
+			listConfigCalls++
+			switch *params.Filter {
+			case `name = "service-name-host-v1"`:
+				name := "service-name-host-v1"
+				configTypeID := hostV1ConfigTypeID
+				return listConfigsByNameResponse([]*rest_model.ConfigDetail{{BaseEntity: rest_model.BaseEntity{ID: &hostConfigID}, Name: &name, ConfigTypeID: &configTypeID}}, 2, 0, 1), nil
+			case `name = "service-name-intercept-v1"`:
+				name := "service-name-intercept-v1"
+				configTypeID := interceptV1ConfigTypeID
+				return listConfigsByNameResponse([]*rest_model.ConfigDetail{{BaseEntity: rest_model.BaseEntity{ID: &interceptConfigID}, Name: &name, ConfigTypeID: &configTypeID}}, 2, 0, 1), nil
+			default:
+				t.Fatalf("unexpected filter: %s", *params.Filter)
+			}
+			return nil, nil
+		},
+		createConfigFunc: func(params *config.CreateConfigParams) (*config.CreateConfigCreated, error) {
+			t.Fatalf("update must reuse existing configs, create called with %#v", params)
+			return nil, nil
+		},
+		patchConfigFunc: func(params *config.PatchConfigParams) (*config.PatchConfigOK, error) {
+			if params == nil || params.Config == nil {
+				t.Fatalf("expected config patch")
+			}
+			patchConfigIDs = append(patchConfigIDs, params.ID)
+			return &config.PatchConfigOK{}, nil
+		},
+	}
+	fakeService := &fakeServiceService{
+		updateServiceFunc: func(params *service.UpdateServiceParams) (*service.UpdateServiceOK, error) {
+			if params == nil || params.Service == nil {
+				t.Fatalf("expected service update")
+			}
+			expectedConfigs := []string{hostConfigID, interceptConfigID}
+			if !reflect.DeepEqual(params.Service.Configs, expectedConfigs) {
+				t.Fatalf("unexpected configs: %#v", params.Service.Configs)
+			}
+			return &service.UpdateServiceOK{}, nil
+		},
+		detailServiceFunc: func(params *service.DetailServiceParams) (*service.DetailServiceOK, error) {
+			return &service.DetailServiceOK{Payload: &rest_model.DetailServiceEnvelope{Data: &rest_model.ServiceDetail{
+				BaseEntity:     rest_model.BaseEntity{ID: &serviceID},
+				Name:           &serviceName,
+				RoleAttributes: &roles,
+			}}}, nil
+		},
+	}
+
+	client := &Client{service: fakeService, config: fakeConfig}
+	updated, err := client.UpdateService(ctx, serviceID, serviceName, []string{"role-one"}, &HostV1ConfigData{Protocol: "tcp", Address: "127.0.0.1", Port: 443}, &InterceptV1ConfigData{Protocols: []string{"tcp"}, Addresses: []string{"example.com"}, PortRanges: []PortRangeData{{Low: 443, High: 443}}})
+	if err != nil {
+		t.Fatalf("update service: %v", err)
+	}
+	if updated.ID != serviceID {
+		t.Fatalf("unexpected updated service: %#v", updated)
+	}
+	if listConfigCalls != 2 {
+		t.Fatalf("expected 2 config list calls, got %d", listConfigCalls)
+	}
+	if !reflect.DeepEqual(patchConfigIDs, []string{hostConfigID, interceptConfigID}) {
+		t.Fatalf("unexpected patched configs: %#v", patchConfigIDs)
+	}
 }

--- a/internal/ziti/client_test.go
+++ b/internal/ziti/client_test.go
@@ -27,6 +27,7 @@ type fakeIdentityService struct {
 	deleteIdentityFunc func(params *identity.DeleteIdentityParams) (*identity.DeleteIdentityOK, error)
 	detailIdentityFunc func(params *identity.DetailIdentityParams) (*identity.DetailIdentityOK, error)
 	listIdentitiesFunc func(params *identity.ListIdentitiesParams) (*identity.ListIdentitiesOK, error)
+	patchIdentityFunc  func(params *identity.PatchIdentityParams) (*identity.PatchIdentityOK, error)
 }
 
 type fakeEnrollmentService struct {
@@ -61,6 +62,13 @@ func (f *fakeIdentityService) ListIdentities(params *identity.ListIdentitiesPara
 		return nil, errors.New("list identities not stubbed")
 	}
 	return f.listIdentitiesFunc(params)
+}
+
+func (f *fakeIdentityService) PatchIdentity(params *identity.PatchIdentityParams, _ runtime.ClientAuthInfoWriter, _ ...identity.ClientOption) (*identity.PatchIdentityOK, error) {
+	if f.patchIdentityFunc == nil {
+		return nil, errors.New("patch identity not stubbed")
+	}
+	return f.patchIdentityFunc(params)
 }
 
 func (f *fakeEnrollmentService) CreateEnrollment(params *enrollment.CreateEnrollmentParams, _ runtime.ClientAuthInfoWriter, _ ...enrollment.ClientOption) (*enrollment.CreateEnrollmentCreated, error) {
@@ -424,19 +432,153 @@ func TestCreateTunnelIdentityUsesJWTExpirationWhenControllerExpiryMissing(t *tes
 	}
 }
 
-func TestPatchIdentityRoleAttributesUnsupported(t *testing.T) {
+func TestPatchIdentityRoleAttributesAddsAttrs(t *testing.T) {
 	ctx := context.Background()
 	fake := &fakeIdentityService{
-		detailIdentityFunc: func(params *identity.DetailIdentityParams) (*identity.DetailIdentityOK, error) {
-			t.Fatalf("detail identity should not be called for unsupported delta patch")
-			return nil, nil
+		detailIdentityFunc: detailIdentityWithRoleAttributes(rest_model.Attributes{"agents", "agent-one"}),
+		patchIdentityFunc: func(params *identity.PatchIdentityParams) (*identity.PatchIdentityOK, error) {
+			assertPatchIdentityRoleAttributes(t, params, "identity-id", []string{"agents", "agent-one", "group-one", "group-two"})
+			return &identity.PatchIdentityOK{}, nil
 		},
 	}
 
 	client := &Client{identity: fake}
-	err := client.PatchIdentityRoleAttributes(ctx, "identity-id", []string{"group-new"}, []string{"group-old"})
-	if !errors.Is(err, ErrRoleAttributePatchUnsupported) {
-		t.Fatalf("expected unsupported error, got %v", err)
+	if err := client.PatchIdentityRoleAttributes(ctx, "identity-id", []string{"group-one", "group-two"}, nil); err != nil {
+		t.Fatalf("patch identity role attributes: %v", err)
+	}
+}
+
+func TestPatchIdentityRoleAttributesRemovesAttrs(t *testing.T) {
+	ctx := context.Background()
+	fake := &fakeIdentityService{
+		detailIdentityFunc: detailIdentityWithRoleAttributes(rest_model.Attributes{"agents", "group-one", "agent-one", "group-two"}),
+		patchIdentityFunc: func(params *identity.PatchIdentityParams) (*identity.PatchIdentityOK, error) {
+			assertPatchIdentityRoleAttributes(t, params, "identity-id", []string{"agents", "agent-one"})
+			return &identity.PatchIdentityOK{}, nil
+		},
+	}
+
+	client := &Client{identity: fake}
+	if err := client.PatchIdentityRoleAttributes(ctx, "identity-id", nil, []string{"group-one", "group-two"}); err != nil {
+		t.Fatalf("patch identity role attributes: %v", err)
+	}
+}
+
+func TestPatchIdentityRoleAttributesAddsAndRemovesDeterministically(t *testing.T) {
+	ctx := context.Background()
+	fake := &fakeIdentityService{
+		detailIdentityFunc: detailIdentityWithRoleAttributes(rest_model.Attributes{"agents", "group-old", "agent-one", "group-same"}),
+		patchIdentityFunc: func(params *identity.PatchIdentityParams) (*identity.PatchIdentityOK, error) {
+			assertPatchIdentityRoleAttributes(t, params, "identity-id", []string{"agents", "agent-one", "group-new"})
+			return &identity.PatchIdentityOK{}, nil
+		},
+	}
+
+	client := &Client{identity: fake}
+	err := client.PatchIdentityRoleAttributes(ctx, "identity-id", []string{"group-new", "group-same"}, []string{"group-old", "group-same"})
+	if err != nil {
+		t.Fatalf("patch identity role attributes: %v", err)
+	}
+}
+
+func TestPatchIdentityRoleAttributesIsIdempotent(t *testing.T) {
+	ctx := context.Background()
+	currentAttrs := rest_model.Attributes{"agents", "group-one", "agent-one"}
+	fake := &fakeIdentityService{
+		detailIdentityFunc: detailIdentityWithRoleAttributes(currentAttrs),
+		patchIdentityFunc: func(params *identity.PatchIdentityParams) (*identity.PatchIdentityOK, error) {
+			assertPatchIdentityRoleAttributes(t, params, "identity-id", []string{"agents", "group-one", "agent-one"})
+			return &identity.PatchIdentityOK{}, nil
+		},
+	}
+
+	client := &Client{identity: fake}
+	err := client.PatchIdentityRoleAttributes(ctx, "identity-id", []string{"group-one", "group-one"}, []string{"missing", "missing"})
+	if err != nil {
+		t.Fatalf("patch identity role attributes: %v", err)
+	}
+}
+
+func TestPatchIdentityRoleAttributesPreservesUnrelatedAttrs(t *testing.T) {
+	ctx := context.Background()
+	currentAttrs := rest_model.Attributes{"agents", "agent-one", "workload-one", "devices", "user-one", "apps", "app-one", "custom"}
+	fake := &fakeIdentityService{
+		detailIdentityFunc: detailIdentityWithRoleAttributes(currentAttrs),
+		patchIdentityFunc: func(params *identity.PatchIdentityParams) (*identity.PatchIdentityOK, error) {
+			assertPatchIdentityRoleAttributes(t, params, "identity-id", []string{"agents", "agent-one", "workload-one", "devices", "user-one", "apps", "app-one", "custom", "group-one"})
+			return &identity.PatchIdentityOK{}, nil
+		},
+	}
+
+	client := &Client{identity: fake}
+	if err := client.PatchIdentityRoleAttributes(ctx, "identity-id", []string{"group-one"}, []string{"missing"}); err != nil {
+		t.Fatalf("patch identity role attributes: %v", err)
+	}
+}
+
+func TestPatchIdentityRoleAttributesMapsDetailNotFound(t *testing.T) {
+	ctx := context.Background()
+	fake := &fakeIdentityService{
+		detailIdentityFunc: func(params *identity.DetailIdentityParams) (*identity.DetailIdentityOK, error) {
+			return nil, &identity.DetailIdentityNotFound{}
+		},
+	}
+
+	client := &Client{identity: fake}
+	err := client.PatchIdentityRoleAttributes(ctx, "identity-id", []string{"group-one"}, nil)
+	if !errors.Is(err, ErrIdentityNotFound) {
+		t.Fatalf("expected identity not found, got %v", err)
+	}
+}
+
+func TestPatchIdentityRoleAttributesMapsPatchNotFound(t *testing.T) {
+	ctx := context.Background()
+	fake := &fakeIdentityService{
+		detailIdentityFunc: detailIdentityWithRoleAttributes(rest_model.Attributes{"agents"}),
+		patchIdentityFunc: func(params *identity.PatchIdentityParams) (*identity.PatchIdentityOK, error) {
+			return nil, &identity.PatchIdentityNotFound{}
+		},
+	}
+
+	client := &Client{identity: fake}
+	err := client.PatchIdentityRoleAttributes(ctx, "identity-id", []string{"group-one"}, nil)
+	if !errors.Is(err, ErrIdentityNotFound) {
+		t.Fatalf("expected identity not found, got %v", err)
+	}
+}
+
+func TestPatchIdentityRoleAttributesWrapsControllerError(t *testing.T) {
+	ctx := context.Background()
+	controllerErr := errors.New("controller unavailable")
+	fake := &fakeIdentityService{
+		detailIdentityFunc: detailIdentityWithRoleAttributes(rest_model.Attributes{"agents"}),
+		patchIdentityFunc: func(params *identity.PatchIdentityParams) (*identity.PatchIdentityOK, error) {
+			return nil, controllerErr
+		},
+	}
+
+	client := &Client{identity: fake}
+	err := client.PatchIdentityRoleAttributes(ctx, "identity-id", []string{"group-one"}, nil)
+	if !errors.Is(err, controllerErr) {
+		t.Fatalf("expected controller error, got %v", err)
+	}
+}
+
+func detailIdentityWithRoleAttributes(roleAttributes rest_model.Attributes) func(*identity.DetailIdentityParams) (*identity.DetailIdentityOK, error) {
+	return func(params *identity.DetailIdentityParams) (*identity.DetailIdentityOK, error) {
+		return &identity.DetailIdentityOK{Payload: &rest_model.DetailIdentityEnvelope{Data: &rest_model.IdentityDetail{
+			RoleAttributes: &roleAttributes,
+		}}}, nil
+	}
+}
+
+func assertPatchIdentityRoleAttributes(t *testing.T, params *identity.PatchIdentityParams, identityID string, expected []string) {
+	t.Helper()
+	if params == nil || params.ID != identityID || params.Identity == nil || params.Identity.RoleAttributes == nil {
+		t.Fatalf("unexpected patch params: %#v", params)
+	}
+	if !reflect.DeepEqual([]string(*params.Identity.RoleAttributes), expected) {
+		t.Fatalf("unexpected role attributes: %#v", *params.Identity.RoleAttributes)
 	}
 }
 

--- a/internal/ziti/client_test.go
+++ b/internal/ziti/client_test.go
@@ -201,9 +201,9 @@ func TestCreateAgentIdentityCreatesIdentity(t *testing.T) {
 	jwt := "jwt-token"
 
 	fake := &fakeIdentityService{
-		deleteIdentityFunc: func(params *identity.DeleteIdentityParams) (*identity.DeleteIdentityOK, error) {
-			t.Fatalf("delete identity should not be called: %#v", params)
-			return nil, nil
+		listIdentitiesFunc: func(params *identity.ListIdentitiesParams) (*identity.ListIdentitiesOK, error) {
+			assertListExternalID(t, params, workloadID)
+			return listIdentitiesResponse(nil, 100, 0, 0), nil
 		},
 		createIdentityFunc: func(params *identity.CreateIdentityParams) (*identity.CreateIdentityCreated, error) {
 			assertCreateExternalID(t, params, workloadID)
@@ -236,6 +236,10 @@ func TestCreateAgentIdentityWithOptionsAddsRolesAndTags(t *testing.T) {
 	agentID := uuid.New()
 	workloadID := uuid.New()
 	fake := &fakeIdentityService{
+		listIdentitiesFunc: func(params *identity.ListIdentitiesParams) (*identity.ListIdentitiesOK, error) {
+			assertListExternalID(t, params, workloadID)
+			return listIdentitiesResponse(nil, 100, 0, 0), nil
+		},
 		createIdentityFunc: func(params *identity.CreateIdentityParams) (*identity.CreateIdentityCreated, error) {
 			assertCreateAgentRoleAttributes(t, params, agentID, workloadID, "group-one")
 			assertTags(t, params.Identity.Tags, map[string]string{"network": "net-1"})
@@ -679,6 +683,10 @@ func TestCreateAgentIdentityCreateFailure(t *testing.T) {
 	var detailCalled bool
 
 	fake := &fakeIdentityService{
+		listIdentitiesFunc: func(params *identity.ListIdentitiesParams) (*identity.ListIdentitiesOK, error) {
+			assertListExternalID(t, params, workloadID)
+			return listIdentitiesResponse(nil, 100, 0, 0), nil
+		},
 		createIdentityFunc: func(params *identity.CreateIdentityParams) (*identity.CreateIdentityCreated, error) {
 			assertCreateExternalID(t, params, workloadID)
 			assertCreateAgentRoleAttributes(t, params, agentID, workloadID)
@@ -1085,6 +1093,14 @@ func TestCreateDeviceIdentityCreateFailure(t *testing.T) {
 	}
 	if detailCalled {
 		t.Fatalf("expected detail not called")
+	}
+}
+
+func assertListExternalID(t *testing.T, params *identity.ListIdentitiesParams, expectedID uuid.UUID) {
+	t.Helper()
+	expectedFilter := "externalId=" + strconv.Quote(expectedID.String())
+	if params == nil || params.Filter == nil || *params.Filter != expectedFilter {
+		t.Fatalf("expected filter %q, got %#v", expectedFilter, params)
 	}
 }
 

--- a/internal/ziti/client_test.go
+++ b/internal/ziti/client_test.go
@@ -210,6 +210,7 @@ func TestCreateAgentIdentityCreatesIdentity(t *testing.T) {
 	agentID := uuid.New()
 	workloadID := uuid.New()
 	createdID := "created-id"
+	enrollmentID := "enrollment-id"
 	jwt := "jwt-token"
 
 	fake := &fakeIdentityService{
@@ -220,20 +221,28 @@ func TestCreateAgentIdentityCreatesIdentity(t *testing.T) {
 		createIdentityFunc: func(params *identity.CreateIdentityParams) (*identity.CreateIdentityCreated, error) {
 			assertCreateExternalID(t, params, workloadID)
 			assertCreateAgentRoleAttributes(t, params, agentID, workloadID)
-			if params.Identity.Enrollment == nil || !params.Identity.Enrollment.Ott {
-				t.Fatalf("expected ott enrollment on agent identity")
+			if params.Identity.Enrollment != nil {
+				t.Fatalf("agent identity create must not request identity detail enrollment: %#v", params.Identity.Enrollment)
 			}
 			return createIdentityResponse(createdID), nil
 		},
-		detailIdentityFunc: func(params *identity.DetailIdentityParams) (*identity.DetailIdentityOK, error) {
-			if params == nil || params.ID != createdID {
-				t.Fatalf("expected detail identity id %q, got %#v", createdID, params)
+	}
+	fakeEnrollment := &fakeEnrollmentService{
+		createEnrollmentFunc: func(params *enrollment.CreateEnrollmentParams) (*enrollment.CreateEnrollmentCreated, error) {
+			if params == nil || params.Enrollment == nil || params.Enrollment.IdentityID == nil || *params.Enrollment.IdentityID != createdID {
+				t.Fatalf("expected create enrollment identity id %q, got %#v", createdID, params)
 			}
-			return detailIdentityResponse(jwt), nil
+			return createEnrollmentResponse(enrollmentID), nil
+		},
+		detailEnrollmentFunc: func(params *enrollment.DetailEnrollmentParams) (*enrollment.DetailEnrollmentOK, error) {
+			if params == nil || params.ID != enrollmentID {
+				t.Fatalf("expected detail enrollment id %q, got %#v", enrollmentID, params)
+			}
+			return detailEnrollmentResponse(jwt), nil
 		},
 	}
 
-	client := &Client{identity: fake}
+	client := &Client{identity: fake, enrollment: fakeEnrollment}
 	zitiID, token, err := client.CreateAgentIdentity(ctx, agentID, workloadID)
 	if err != nil {
 		t.Fatalf("create agent identity: %v", err)
@@ -257,21 +266,26 @@ func TestCreateAgentIdentityWithOptionsAddsRolesAndTags(t *testing.T) {
 		},
 		createIdentityFunc: func(params *identity.CreateIdentityParams) (*identity.CreateIdentityCreated, error) {
 			assertCreateAgentRoleAttributes(t, params, agentID, workloadID, "group-one")
-			if params.Identity.Enrollment == nil || !params.Identity.Enrollment.Ott {
-				t.Fatalf("expected ott enrollment on agent identity")
+			if params.Identity.Enrollment != nil {
+				t.Fatalf("agent identity create must not request identity detail enrollment: %#v", params.Identity.Enrollment)
 			}
 			assertTags(t, params.Identity.Tags, map[string]string{"network": "net-1"})
 			return createIdentityResponse("identity-id"), nil
 		},
-		detailIdentityFunc: func(params *identity.DetailIdentityParams) (*identity.DetailIdentityOK, error) {
-			if params == nil || params.ID != "identity-id" {
-				t.Fatalf("expected detail identity-id, got %#v", params)
+	}
+	fakeEnrollment := &fakeEnrollmentService{
+		createEnrollmentFunc: func(params *enrollment.CreateEnrollmentParams) (*enrollment.CreateEnrollmentCreated, error) {
+			if params == nil || params.Enrollment == nil || params.Enrollment.IdentityID == nil || *params.Enrollment.IdentityID != "identity-id" {
+				t.Fatalf("expected enrollment for identity-id, got %#v", params)
 			}
-			return detailIdentityResponse("jwt-token"), nil
+			return createEnrollmentResponse("enrollment-id"), nil
+		},
+		detailEnrollmentFunc: func(params *enrollment.DetailEnrollmentParams) (*enrollment.DetailEnrollmentOK, error) {
+			return detailEnrollmentResponse("jwt-token"), nil
 		},
 	}
 
-	client := &Client{identity: fake}
+	client := &Client{identity: fake, enrollment: fakeEnrollment}
 	_, _, err := client.CreateAgentIdentityWithOptions(ctx, agentID, workloadID, []string{"group-one"}, map[string]string{"network": "net-1"})
 	if err != nil {
 		t.Fatalf("create agent identity: %v", err)
@@ -417,7 +431,7 @@ func TestListServicesUsesRoleFilterParameter(t *testing.T) {
 			if params.Filter != nil && strings.Contains(*params.Filter, "roleAttributes") {
 				t.Fatalf("role attributes must use roleFilter, got filter %q", *params.Filter)
 			}
-			if !reflect.DeepEqual(params.RoleFilter, []string{"role-one", "role-two"}) {
+			if !reflect.DeepEqual(params.RoleFilter, []string{"#role-one", "#role-two"}) {
 				t.Fatalf("unexpected role filter: %#v", params.RoleFilter)
 			}
 			return listServicesResponse(nil, 100, 0, 0), nil
@@ -426,6 +440,27 @@ func TestListServicesUsesRoleFilterParameter(t *testing.T) {
 
 	client := &Client{service: fake}
 	_, err := client.ListServices(ctx, ServiceListFilter{RoleAttributes: []string{"role-one", "role-two"}})
+	if err != nil {
+		t.Fatalf("list services: %v", err)
+	}
+}
+
+func TestListServicesPreservesExplicitRoleFilterPrefixes(t *testing.T) {
+	ctx := context.Background()
+	fake := &fakeServiceService{
+		listServicesFunc: func(params *service.ListServicesParams) (*service.ListServicesOK, error) {
+			if params == nil {
+				t.Fatal("expected list services params")
+			}
+			if !reflect.DeepEqual(params.RoleFilter, []string{"#role-one", "@service-one"}) {
+				t.Fatalf("unexpected role filter: %#v", params.RoleFilter)
+			}
+			return listServicesResponse(nil, 100, 0, 0), nil
+		},
+	}
+
+	client := &Client{service: fake}
+	_, err := client.ListServices(ctx, ServiceListFilter{RoleAttributes: []string{"#role-one", "@service-one"}})
 	if err != nil {
 		t.Fatalf("list services: %v", err)
 	}

--- a/internal/ziti/client_test.go
+++ b/internal/ziti/client_test.go
@@ -415,6 +415,30 @@ func TestListServicesByTagConvertsRequestAndResponse(t *testing.T) {
 	}
 }
 
+func TestListServicesUsesRoleFilterParameter(t *testing.T) {
+	ctx := context.Background()
+	fake := &fakeServiceService{
+		listServicesFunc: func(params *service.ListServicesParams) (*service.ListServicesOK, error) {
+			if params == nil {
+				t.Fatal("expected list services params")
+			}
+			if params.Filter != nil && strings.Contains(*params.Filter, "roleAttributes") {
+				t.Fatalf("role attributes must use roleFilter, got filter %q", *params.Filter)
+			}
+			if !reflect.DeepEqual(params.RoleFilter, []string{"role-one", "role-two"}) {
+				t.Fatalf("unexpected role filter: %#v", params.RoleFilter)
+			}
+			return listServicesResponse(nil, 100, 0, 0), nil
+		},
+	}
+
+	client := &Client{service: fake}
+	_, err := client.ListServices(ctx, ServiceListFilter{RoleAttributes: []string{"role-one", "role-two"}})
+	if err != nil {
+		t.Fatalf("list services: %v", err)
+	}
+}
+
 func TestListIdentitiesByTagConvertsRequestAndResponse(t *testing.T) {
 	ctx := context.Background()
 	identityID := "identity-id"

--- a/internal/ziti/client_test.go
+++ b/internal/ziti/client_test.go
@@ -14,7 +14,6 @@ import (
 	"github.com/golang-jwt/jwt/v5"
 	"github.com/google/uuid"
 	"github.com/openziti/edge-api/rest_management_api_client/config"
-	"github.com/openziti/edge-api/rest_management_api_client/enrollment"
 	"github.com/openziti/edge-api/rest_management_api_client/identity"
 	"github.com/openziti/edge-api/rest_management_api_client/service"
 	"github.com/openziti/edge-api/rest_management_api_client/service_policy"
@@ -27,11 +26,6 @@ type fakeIdentityService struct {
 	deleteIdentityFunc func(params *identity.DeleteIdentityParams) (*identity.DeleteIdentityOK, error)
 	detailIdentityFunc func(params *identity.DetailIdentityParams) (*identity.DetailIdentityOK, error)
 	listIdentitiesFunc func(params *identity.ListIdentitiesParams) (*identity.ListIdentitiesOK, error)
-}
-
-type fakeEnrollmentService struct {
-	createEnrollmentFunc func(params *enrollment.CreateEnrollmentParams) (*enrollment.CreateEnrollmentCreated, error)
-	detailEnrollmentFunc func(params *enrollment.DetailEnrollmentParams) (*enrollment.DetailEnrollmentOK, error)
 }
 
 func (f *fakeIdentityService) CreateIdentity(params *identity.CreateIdentityParams, _ runtime.ClientAuthInfoWriter, _ ...identity.ClientOption) (*identity.CreateIdentityCreated, error) {
@@ -60,20 +54,6 @@ func (f *fakeIdentityService) ListIdentities(params *identity.ListIdentitiesPara
 		return nil, errors.New("list identities not stubbed")
 	}
 	return f.listIdentitiesFunc(params)
-}
-
-func (f *fakeEnrollmentService) CreateEnrollment(params *enrollment.CreateEnrollmentParams, _ runtime.ClientAuthInfoWriter, _ ...enrollment.ClientOption) (*enrollment.CreateEnrollmentCreated, error) {
-	if f.createEnrollmentFunc == nil {
-		return nil, errors.New("create enrollment not stubbed")
-	}
-	return f.createEnrollmentFunc(params)
-}
-
-func (f *fakeEnrollmentService) DetailEnrollment(params *enrollment.DetailEnrollmentParams, _ runtime.ClientAuthInfoWriter, _ ...enrollment.ClientOption) (*enrollment.DetailEnrollmentOK, error) {
-	if f.detailEnrollmentFunc == nil {
-		return nil, errors.New("detail enrollment not stubbed")
-	}
-	return f.detailEnrollmentFunc(params)
 }
 
 type fakeServiceService struct {
@@ -210,7 +190,6 @@ func TestCreateAgentIdentityCreatesIdentity(t *testing.T) {
 	agentID := uuid.New()
 	workloadID := uuid.New()
 	createdID := "created-id"
-	enrollmentID := "enrollment-id"
 	jwt := "jwt-token"
 
 	fake := &fakeIdentityService{
@@ -223,23 +202,15 @@ func TestCreateAgentIdentityCreatesIdentity(t *testing.T) {
 			assertCreateAgentRoleAttributes(t, params, agentID, workloadID)
 			return createIdentityResponse(createdID), nil
 		},
-	}
-	fakeEnrollment := &fakeEnrollmentService{
-		createEnrollmentFunc: func(params *enrollment.CreateEnrollmentParams) (*enrollment.CreateEnrollmentCreated, error) {
-			if params == nil || params.Enrollment == nil || params.Enrollment.IdentityID == nil || *params.Enrollment.IdentityID != createdID {
-				t.Fatalf("expected create enrollment identity id %q, got %#v", createdID, params)
+		detailIdentityFunc: func(params *identity.DetailIdentityParams) (*identity.DetailIdentityOK, error) {
+			if params == nil || params.ID != createdID {
+				t.Fatalf("expected detail identity id %q, got %#v", createdID, params)
 			}
-			return createEnrollmentResponse(enrollmentID), nil
-		},
-		detailEnrollmentFunc: func(params *enrollment.DetailEnrollmentParams) (*enrollment.DetailEnrollmentOK, error) {
-			if params == nil || params.ID != enrollmentID {
-				t.Fatalf("expected detail enrollment id %q, got %#v", enrollmentID, params)
-			}
-			return detailEnrollmentResponse(jwt), nil
+			return detailIdentityResponse(jwt), nil
 		},
 	}
 
-	client := &Client{identity: fake, enrollment: fakeEnrollment}
+	client := &Client{identity: fake}
 	zitiID, token, err := client.CreateAgentIdentity(ctx, agentID, workloadID)
 	if err != nil {
 		t.Fatalf("create agent identity: %v", err)
@@ -266,20 +237,12 @@ func TestCreateAgentIdentityWithOptionsAddsRolesAndTags(t *testing.T) {
 			assertTags(t, params.Identity.Tags, map[string]string{"network": "net-1"})
 			return createIdentityResponse("identity-id"), nil
 		},
-	}
-	fakeEnrollment := &fakeEnrollmentService{
-		createEnrollmentFunc: func(params *enrollment.CreateEnrollmentParams) (*enrollment.CreateEnrollmentCreated, error) {
-			if params == nil || params.Enrollment == nil || params.Enrollment.IdentityID == nil || *params.Enrollment.IdentityID != "identity-id" {
-				t.Fatalf("expected enrollment for identity-id, got %#v", params)
-			}
-			return createEnrollmentResponse("enrollment-id"), nil
-		},
-		detailEnrollmentFunc: func(params *enrollment.DetailEnrollmentParams) (*enrollment.DetailEnrollmentOK, error) {
-			return detailEnrollmentResponse("jwt-token"), nil
+		detailIdentityFunc: func(params *identity.DetailIdentityParams) (*identity.DetailIdentityOK, error) {
+			return detailIdentityResponse("jwt-token"), nil
 		},
 	}
 
-	client := &Client{identity: fake, enrollment: fakeEnrollment}
+	client := &Client{identity: fake}
 	_, _, err := client.CreateAgentIdentityWithOptions(ctx, agentID, workloadID, []string{"group-one"}, map[string]string{"network": "net-1"})
 	if err != nil {
 		t.Fatalf("create agent identity: %v", err)
@@ -575,7 +538,7 @@ func TestCreateAgentIdentityCreateFailure(t *testing.T) {
 	agentID := uuid.New()
 	workloadID := uuid.New()
 	createErr := errors.New("create failed")
-	var enrollmentCalled bool
+	var detailCalled bool
 
 	fake := &fakeIdentityService{
 		listIdentitiesFunc: func(params *identity.ListIdentitiesParams) (*identity.ListIdentitiesOK, error) {
@@ -587,15 +550,13 @@ func TestCreateAgentIdentityCreateFailure(t *testing.T) {
 			assertCreateAgentRoleAttributes(t, params, agentID, workloadID)
 			return nil, createErr
 		},
-	}
-	fakeEnrollment := &fakeEnrollmentService{
-		createEnrollmentFunc: func(params *enrollment.CreateEnrollmentParams) (*enrollment.CreateEnrollmentCreated, error) {
-			enrollmentCalled = true
-			return nil, errors.New("create enrollment should not be called")
+		detailIdentityFunc: func(params *identity.DetailIdentityParams) (*identity.DetailIdentityOK, error) {
+			detailCalled = true
+			return nil, errors.New("detail identity should not be called")
 		},
 	}
 
-	client := &Client{identity: fake, enrollment: fakeEnrollment}
+	client := &Client{identity: fake}
 	_, _, err := client.CreateAgentIdentity(ctx, agentID, workloadID)
 	if err == nil {
 		t.Fatalf("expected create error")
@@ -603,8 +564,8 @@ func TestCreateAgentIdentityCreateFailure(t *testing.T) {
 	if !errors.Is(err, createErr) {
 		t.Fatalf("expected error %q, got %v", createErr, err)
 	}
-	if enrollmentCalled {
-		t.Fatalf("expected enrollment not called")
+	if detailCalled {
+		t.Fatalf("expected detail not called")
 	}
 }
 
@@ -1055,15 +1016,6 @@ func assertSameStrings(t *testing.T, actual, expected []string) {
 
 func createIdentityResponse(identityID string) *identity.CreateIdentityCreated {
 	return &identity.CreateIdentityCreated{Payload: &rest_model.CreateEnvelope{Data: &rest_model.CreateLocation{ID: identityID}}}
-}
-
-func createEnrollmentResponse(enrollmentID string) *enrollment.CreateEnrollmentCreated {
-	return &enrollment.CreateEnrollmentCreated{Payload: &rest_model.CreateEnvelope{Data: &rest_model.CreateLocation{ID: enrollmentID}}}
-}
-
-func detailEnrollmentResponse(jwt string) *enrollment.DetailEnrollmentOK {
-	expiresAt := strfmt.DateTime(time.Now().Add(time.Hour).UTC())
-	return &enrollment.DetailEnrollmentOK{Payload: &rest_model.DetailEnrollmentEnvelope{Data: &rest_model.EnrollmentDetail{JWT: jwt, ExpiresAt: &expiresAt}}}
 }
 
 func detailIdentityResponse(jwt string) *identity.DetailIdentityOK {

--- a/internal/ziti/client_test.go
+++ b/internal/ziti/client_test.go
@@ -66,8 +66,6 @@ func (f *fakeIdentityService) PatchIdentity(params *identity.PatchIdentityParams
 
 type fakeServiceService struct {
 	createServiceFunc func(params *service.CreateServiceParams) (*service.CreateServiceCreated, error)
-	detailServiceFunc func(params *service.DetailServiceParams) (*service.DetailServiceOK, error)
-	listServicesFunc  func(params *service.ListServicesParams) (*service.ListServicesOK, error)
 	updateServiceFunc func(params *service.UpdateServiceParams) (*service.UpdateServiceOK, error)
 	deleteServiceFunc func(params *service.DeleteServiceParams) (*service.DeleteServiceOK, error)
 	detailServiceFunc func(params *service.DetailServiceParams) (*service.DetailServiceOK, error)
@@ -81,20 +79,6 @@ func (f *fakeServiceService) CreateService(params *service.CreateServiceParams, 
 		return nil, errors.New("create service not stubbed")
 	}
 	return f.createServiceFunc(params)
-}
-
-func (f *fakeServiceService) DetailService(params *service.DetailServiceParams, _ runtime.ClientAuthInfoWriter, _ ...service.ClientOption) (*service.DetailServiceOK, error) {
-	if f.detailServiceFunc == nil {
-		return nil, errors.New("detail service not stubbed")
-	}
-	return f.detailServiceFunc(params)
-}
-
-func (f *fakeServiceService) ListServices(params *service.ListServicesParams, _ runtime.ClientAuthInfoWriter, _ ...service.ClientOption) (*service.ListServicesOK, error) {
-	if f.listServicesFunc == nil {
-		return nil, errors.New("list services not stubbed")
-	}
-	return f.listServicesFunc(params)
 }
 
 func (f *fakeServiceService) UpdateService(params *service.UpdateServiceParams, _ runtime.ClientAuthInfoWriter, _ ...service.ClientOption) (*service.UpdateServiceOK, error) {
@@ -171,7 +155,6 @@ type fakeServicePolicyService struct {
 	detailServicePolicyFunc func(params *service_policy.DetailServicePolicyParams) (*service_policy.DetailServicePolicyOK, error)
 	listServicePoliciesFunc func(params *service_policy.ListServicePoliciesParams) (*service_policy.ListServicePoliciesOK, error)
 	deleteServicePolicyFunc func(params *service_policy.DeleteServicePolicyParams) (*service_policy.DeleteServicePolicyOK, error)
-	listServicePoliciesFunc func(params *service_policy.ListServicePoliciesParams) (*service_policy.ListServicePoliciesOK, error)
 }
 
 func (f *fakeServicePolicyService) CreateServicePolicy(params *service_policy.CreateServicePolicyParams, _ runtime.ClientAuthInfoWriter, _ ...service_policy.ClientOption) (*service_policy.CreateServicePolicyCreated, error) {
@@ -200,13 +183,6 @@ func (f *fakeServicePolicyService) DeleteServicePolicy(params *service_policy.De
 		return nil, errors.New("delete service policy not stubbed")
 	}
 	return f.deleteServicePolicyFunc(params)
-}
-
-func (f *fakeServicePolicyService) ListServicePolicies(params *service_policy.ListServicePoliciesParams, _ runtime.ClientAuthInfoWriter, _ ...service_policy.ClientOption) (*service_policy.ListServicePoliciesOK, error) {
-	if f.listServicePoliciesFunc == nil {
-		return nil, errors.New("list service policies not stubbed")
-	}
-	return f.listServicePoliciesFunc(params)
 }
 
 func TestCreateAgentIdentityCreatesIdentity(t *testing.T) {
@@ -590,7 +566,7 @@ func TestListServicePoliciesByTagConvertsRequestAndResponse(t *testing.T) {
 	}
 }
 
-func TestUpdateServicePatchesConfigsAndTags(t *testing.T) {
+func TestUpdateServiceConfigsAndTagsPatchesConfigsAndTags(t *testing.T) {
 	ctx := context.Background()
 	serviceID := "service-id"
 	serviceName := "service-name"
@@ -631,7 +607,7 @@ func TestUpdateServicePatchesConfigsAndTags(t *testing.T) {
 	}
 
 	client := &Client{service: fakeService, config: fakeConfig}
-	updated, err := client.UpdateService(ctx, serviceID, &HostV1ConfigData{Protocol: "tcp", Address: "127.0.0.1", Port: 8080}, nil, map[string]string{"owner": "networks"}, true)
+	updated, err := client.updateServiceConfigsAndTags(ctx, serviceID, &HostV1ConfigData{Protocol: "tcp", Address: "127.0.0.1", Port: 8080}, nil, map[string]string{"owner": "networks"}, true)
 	if err != nil {
 		t.Fatalf("update service: %v", err)
 	}
@@ -640,7 +616,7 @@ func TestUpdateServicePatchesConfigsAndTags(t *testing.T) {
 	}
 }
 
-func TestUpdateServiceTagOnlyDoesNotPatchConfigs(t *testing.T) {
+func TestUpdateServiceConfigsAndTagsTagOnlyDoesNotPatchConfigs(t *testing.T) {
 	ctx := context.Background()
 	serviceID := "service-id"
 	serviceName := "service-name"
@@ -676,7 +652,7 @@ func TestUpdateServiceTagOnlyDoesNotPatchConfigs(t *testing.T) {
 	}
 
 	client := &Client{service: fakeService, config: fakeConfig}
-	if _, err := client.UpdateService(ctx, serviceID, nil, nil, map[string]string{"owner": "networks"}, true); err != nil {
+	if _, err := client.updateServiceConfigsAndTags(ctx, serviceID, nil, nil, map[string]string{"owner": "networks"}, true); err != nil {
 		t.Fatalf("update service: %v", err)
 	}
 }

--- a/internal/ziti/client_test.go
+++ b/internal/ziti/client_test.go
@@ -66,6 +66,9 @@ func (f *fakeIdentityService) PatchIdentity(params *identity.PatchIdentityParams
 
 type fakeServiceService struct {
 	createServiceFunc func(params *service.CreateServiceParams) (*service.CreateServiceCreated, error)
+	detailServiceFunc func(params *service.DetailServiceParams) (*service.DetailServiceOK, error)
+	listServicesFunc  func(params *service.ListServicesParams) (*service.ListServicesOK, error)
+	updateServiceFunc func(params *service.UpdateServiceParams) (*service.UpdateServiceOK, error)
 	deleteServiceFunc func(params *service.DeleteServiceParams) (*service.DeleteServiceOK, error)
 	detailServiceFunc func(params *service.DetailServiceParams) (*service.DetailServiceOK, error)
 	listConfigFunc    func(params *service.ListServiceConfigParams) (*service.ListServiceConfigOK, error)
@@ -78,6 +81,27 @@ func (f *fakeServiceService) CreateService(params *service.CreateServiceParams, 
 		return nil, errors.New("create service not stubbed")
 	}
 	return f.createServiceFunc(params)
+}
+
+func (f *fakeServiceService) DetailService(params *service.DetailServiceParams, _ runtime.ClientAuthInfoWriter, _ ...service.ClientOption) (*service.DetailServiceOK, error) {
+	if f.detailServiceFunc == nil {
+		return nil, errors.New("detail service not stubbed")
+	}
+	return f.detailServiceFunc(params)
+}
+
+func (f *fakeServiceService) ListServices(params *service.ListServicesParams, _ runtime.ClientAuthInfoWriter, _ ...service.ClientOption) (*service.ListServicesOK, error) {
+	if f.listServicesFunc == nil {
+		return nil, errors.New("list services not stubbed")
+	}
+	return f.listServicesFunc(params)
+}
+
+func (f *fakeServiceService) UpdateService(params *service.UpdateServiceParams, _ runtime.ClientAuthInfoWriter, _ ...service.ClientOption) (*service.UpdateServiceOK, error) {
+	if f.updateServiceFunc == nil {
+		return nil, errors.New("update service not stubbed")
+	}
+	return f.updateServiceFunc(params)
 }
 
 func (f *fakeServiceService) DeleteService(params *service.DeleteServiceParams, _ runtime.ClientAuthInfoWriter, _ ...service.ClientOption) (*service.DeleteServiceOK, error) {
@@ -144,6 +168,8 @@ func (f *fakeConfigService) PatchConfig(params *config.PatchConfigParams, _ runt
 
 type fakeServicePolicyService struct {
 	createServicePolicyFunc func(params *service_policy.CreateServicePolicyParams) (*service_policy.CreateServicePolicyCreated, error)
+	detailServicePolicyFunc func(params *service_policy.DetailServicePolicyParams) (*service_policy.DetailServicePolicyOK, error)
+	listServicePoliciesFunc func(params *service_policy.ListServicePoliciesParams) (*service_policy.ListServicePoliciesOK, error)
 	deleteServicePolicyFunc func(params *service_policy.DeleteServicePolicyParams) (*service_policy.DeleteServicePolicyOK, error)
 	listServicePoliciesFunc func(params *service_policy.ListServicePoliciesParams) (*service_policy.ListServicePoliciesOK, error)
 }
@@ -153,6 +179,20 @@ func (f *fakeServicePolicyService) CreateServicePolicy(params *service_policy.Cr
 		return nil, errors.New("create service policy not stubbed")
 	}
 	return f.createServicePolicyFunc(params)
+}
+
+func (f *fakeServicePolicyService) DetailServicePolicy(params *service_policy.DetailServicePolicyParams, _ runtime.ClientAuthInfoWriter, _ ...service_policy.ClientOption) (*service_policy.DetailServicePolicyOK, error) {
+	if f.detailServicePolicyFunc == nil {
+		return nil, errors.New("detail service policy not stubbed")
+	}
+	return f.detailServicePolicyFunc(params)
+}
+
+func (f *fakeServicePolicyService) ListServicePolicies(params *service_policy.ListServicePoliciesParams, _ runtime.ClientAuthInfoWriter, _ ...service_policy.ClientOption) (*service_policy.ListServicePoliciesOK, error) {
+	if f.listServicePoliciesFunc == nil {
+		return nil, errors.New("list service policies not stubbed")
+	}
+	return f.listServicePoliciesFunc(params)
 }
 
 func (f *fakeServicePolicyService) DeleteServicePolicy(params *service_policy.DeleteServicePolicyParams, _ runtime.ClientAuthInfoWriter, _ ...service_policy.ClientOption) (*service_policy.DeleteServicePolicyOK, error) {

--- a/internal/ziti/client_test.go
+++ b/internal/ziti/client_test.go
@@ -210,7 +210,6 @@ func TestCreateAgentIdentityCreatesIdentity(t *testing.T) {
 	agentID := uuid.New()
 	workloadID := uuid.New()
 	createdID := "created-id"
-	enrollmentID := "enrollment-id"
 	jwt := "jwt-token"
 
 	fake := &fakeIdentityService{
@@ -221,25 +220,20 @@ func TestCreateAgentIdentityCreatesIdentity(t *testing.T) {
 		createIdentityFunc: func(params *identity.CreateIdentityParams) (*identity.CreateIdentityCreated, error) {
 			assertCreateExternalID(t, params, workloadID)
 			assertCreateAgentRoleAttributes(t, params, agentID, workloadID)
+			if params.Identity.Enrollment == nil || !params.Identity.Enrollment.Ott {
+				t.Fatalf("expected ott enrollment on agent identity")
+			}
 			return createIdentityResponse(createdID), nil
 		},
-	}
-	fakeEnrollment := &fakeEnrollmentService{
-		createEnrollmentFunc: func(params *enrollment.CreateEnrollmentParams) (*enrollment.CreateEnrollmentCreated, error) {
-			if params == nil || params.Enrollment == nil || params.Enrollment.IdentityID == nil || *params.Enrollment.IdentityID != createdID {
-				t.Fatalf("expected create enrollment identity id %q, got %#v", createdID, params)
+		detailIdentityFunc: func(params *identity.DetailIdentityParams) (*identity.DetailIdentityOK, error) {
+			if params == nil || params.ID != createdID {
+				t.Fatalf("expected detail identity id %q, got %#v", createdID, params)
 			}
-			return createEnrollmentResponse(enrollmentID), nil
-		},
-		detailEnrollmentFunc: func(params *enrollment.DetailEnrollmentParams) (*enrollment.DetailEnrollmentOK, error) {
-			if params == nil || params.ID != enrollmentID {
-				t.Fatalf("expected detail enrollment id %q, got %#v", enrollmentID, params)
-			}
-			return detailEnrollmentResponse(jwt), nil
+			return detailIdentityResponse(jwt), nil
 		},
 	}
 
-	client := &Client{identity: fake, enrollment: fakeEnrollment}
+	client := &Client{identity: fake}
 	zitiID, token, err := client.CreateAgentIdentity(ctx, agentID, workloadID)
 	if err != nil {
 		t.Fatalf("create agent identity: %v", err)
@@ -263,23 +257,21 @@ func TestCreateAgentIdentityWithOptionsAddsRolesAndTags(t *testing.T) {
 		},
 		createIdentityFunc: func(params *identity.CreateIdentityParams) (*identity.CreateIdentityCreated, error) {
 			assertCreateAgentRoleAttributes(t, params, agentID, workloadID, "group-one")
+			if params.Identity.Enrollment == nil || !params.Identity.Enrollment.Ott {
+				t.Fatalf("expected ott enrollment on agent identity")
+			}
 			assertTags(t, params.Identity.Tags, map[string]string{"network": "net-1"})
 			return createIdentityResponse("identity-id"), nil
 		},
-	}
-	fakeEnrollment := &fakeEnrollmentService{
-		createEnrollmentFunc: func(params *enrollment.CreateEnrollmentParams) (*enrollment.CreateEnrollmentCreated, error) {
-			if params == nil || params.Enrollment == nil || params.Enrollment.IdentityID == nil || *params.Enrollment.IdentityID != "identity-id" {
-				t.Fatalf("expected enrollment for identity-id, got %#v", params)
+		detailIdentityFunc: func(params *identity.DetailIdentityParams) (*identity.DetailIdentityOK, error) {
+			if params == nil || params.ID != "identity-id" {
+				t.Fatalf("expected detail identity-id, got %#v", params)
 			}
-			return createEnrollmentResponse("enrollment-id"), nil
-		},
-		detailEnrollmentFunc: func(params *enrollment.DetailEnrollmentParams) (*enrollment.DetailEnrollmentOK, error) {
-			return detailEnrollmentResponse("jwt-token"), nil
+			return detailIdentityResponse("jwt-token"), nil
 		},
 	}
 
-	client := &Client{identity: fake, enrollment: fakeEnrollment}
+	client := &Client{identity: fake}
 	_, _, err := client.CreateAgentIdentityWithOptions(ctx, agentID, workloadID, []string{"group-one"}, map[string]string{"network": "net-1"})
 	if err != nil {
 		t.Fatalf("create agent identity: %v", err)

--- a/internal/ziti/config.go
+++ b/internal/ziti/config.go
@@ -54,6 +54,27 @@ type OpenZitiService struct {
 	Tags           map[string]string
 }
 
+type Service struct {
+	ID                string
+	Name              string
+	RoleAttributes    []string
+	HostV1Config      *HostV1ConfigData
+	InterceptV1Config *InterceptV1ConfigData
+}
+
+type ServiceListFilter struct {
+	Name           string
+	NamePrefix     string
+	RoleAttributes []string
+	PageSize       int32
+	PageToken      string
+}
+
+type ServiceListResult struct {
+	Services      []Service
+	NextPageToken string
+}
+
 type OpenZitiServicePolicy struct {
 	ID            string
 	Name          string
@@ -61,6 +82,29 @@ type OpenZitiServicePolicy struct {
 	IdentityRoles []string
 	ServiceRoles  []string
 	Tags          map[string]string
+}
+
+type ServicePolicy struct {
+	ID            string
+	Name          string
+	Type          string
+	IdentityRoles []string
+	ServiceRoles  []string
+}
+
+type ServicePolicyListFilter struct {
+	Name          string
+	NamePrefix    string
+	Type          string
+	IdentityRoles []string
+	ServiceRoles  []string
+	PageSize      int32
+	PageToken     string
+}
+
+type ServicePolicyListResult struct {
+	ServicePolicies []ServicePolicy
+	NextPageToken   string
 }
 
 type ListResult[T any] struct {

--- a/internal/ziti/config.go
+++ b/internal/ziti/config.go
@@ -37,6 +37,7 @@ type IdentityLiveness struct {
 
 type EnrollmentJWT struct {
 	Token     string
+	TokenID   string
 	ExpiresAt time.Time
 }
 


### PR DESCRIPTION
## Summary
- Implement service get/list/update APIs for structured reconciliation access.
- Implement service policy get/list APIs for structured reconciliation access.
- Add idempotent `return_existing` create support via existing-name lookup.
- Link to API contract PR: agynio/api#146.

Tracking issue: #60

## Test & Lint Summary
- `go test ./...`: 2 packages passed, 0 failed, 0 skipped.
- `go vet ./...`: passed with no errors.
- `go build ./...`: passed.