### PR TITLE
fix(chart): wire ziti controller url

### DIFF
--- a/charts/ziti-management/templates/deployment.yaml
+++ b/charts/ziti-management/templates/deployment.yaml
@@ -1,1 +1,11 @@
-{{- include "service-base.deployment" . -}}
+{{- $values := deepCopy .Values -}}
+{{- $env := list -}}
+{{- range $entry := $values.env -}}
+{{- if eq $entry.name "ZITI_CONTROLLER_URL" -}}
+{{- $env = append $env (mergeOverwrite (deepCopy $entry) (dict "value" $.Values.zitiControllerUrl)) -}}
+{{- else -}}
+{{- $env = append $env $entry -}}
+{{- end -}}
+{{- end -}}
+{{- $values = mergeOverwrite $values (dict "env" $env) -}}
+{{- include "service-base.deployment" (mergeOverwrite (deepCopy .) (dict "Values" $values)) -}}


### PR DESCRIPTION
## Summary
- Wires the chart-owned `zitiControllerUrl` value into the rendered `ZITI_CONTROLLER_URL` container env.
- Keeps the existing `service-base` deployment include and adapts values at render time without provisioning changes.

Fixes #63

## Validation
- `buf generate buf.build/agynio/api --path agynio/api/ziti_management/v1 --path agynio/api/identity/v1`
- `go test ./...` — 2 passed, 0 failed, 0 skipped
- `helm dependency build charts/ziti-management`
- `helm lint charts/ziti-management` — 1 chart linted, 0 failed
- `helm template ziti charts/ziti-management --set zitiControllerUrl=https://ziti-mgmt.agyn.cloud:443/edge/management/v1` — rendered `ZITI_CONTROLLER_URL` with the supplied value
- `gofmt -w $(git ls-files '*.go')`
- `git diff --check`

## Release note
Chart release/version bump should happen after merge only.
