### PR TITLE
feat(ziti): complete private network primitives

### DIFF
--- a/internal/server/converter.go
+++ b/internal/server/converter.go
@@ -88,7 +88,7 @@ func fromProtoHostV1Config(value *zitimanagementv1.HostV1Config) (*ziti.HostV1Co
 		return nil, fmt.Errorf("address is required")
 	}
 	port := value.GetPort()
-	if !value.GetForwardPort() && (port <= 0 || port > maxPort) {
+	if !value.GetForwardPort() && len(value.GetAllowedPortRanges()) == 0 && (port <= 0 || port > maxPort) {
 		return nil, fmt.Errorf("port must be between 1 and %d", maxPort)
 	}
 	if value.GetForwardPort() && port > maxPort {

--- a/internal/server/converter_test.go
+++ b/internal/server/converter_test.go
@@ -192,6 +192,21 @@ func TestFromProtoHostV1Config(t *testing.T) {
 			},
 		},
 		{
+			name: "valid multi-port target mapping",
+			input: &zitimanagementv1.HostV1Config{
+				Protocol:          "tcp",
+				Address:           "10.0.0.1",
+				ForwardPort:       true,
+				AllowedPortRanges: []*zitimanagementv1.PortRange{{Low: 5432, High: 5432}, {Low: 6379, High: 6379}},
+			},
+			want: &ziti.HostV1ConfigData{
+				Protocol:          "tcp",
+				Address:           "10.0.0.1",
+				ForwardPort:       true,
+				AllowedPortRanges: []ziti.PortRangeData{{Low: 5432, High: 5432}, {Low: 6379, High: 6379}},
+			},
+		},
+		{
 			name: "empty allowed address",
 			input: &zitimanagementv1.HostV1Config{
 				Protocol:         "tcp",

--- a/internal/server/identity_reenroll_test.go
+++ b/internal/server/identity_reenroll_test.go
@@ -4,6 +4,7 @@ import (
 	"context"
 	"errors"
 	"fmt"
+	"reflect"
 	"strings"
 	"testing"
 	"time"
@@ -12,8 +13,6 @@ import (
 	"github.com/agynio/ziti-management/internal/store"
 	"github.com/agynio/ziti-management/internal/ziti"
 	"github.com/google/uuid"
-	"google.golang.org/grpc/codes"
-	"google.golang.org/grpc/status"
 )
 
 type fakeManagedIdentityStore struct {
@@ -75,6 +74,13 @@ type fakeZitiClient struct {
 	agentCalls        []agentCall
 	createAgentErr    error
 	tunnelExpiresAt   time.Time
+	patchedRoles      rolePatch
+}
+
+type rolePatch struct {
+	zitiID string
+	add    []string
+	remove []string
 }
 
 type agentCall struct {
@@ -168,8 +174,9 @@ func (f *fakeZitiClient) DeleteServicePolicy(_ context.Context, _ string) error 
 	return nil
 }
 
-func (f *fakeZitiClient) PatchIdentityRoleAttributes(_ context.Context, _ string, _, _ []string) error {
-	return ziti.ErrRoleAttributePatchUnsupported
+func (f *fakeZitiClient) PatchIdentityRoleAttributes(_ context.Context, zitiID string, add, remove []string) error {
+	f.patchedRoles = rolePatch{zitiID: zitiID, add: add, remove: remove}
+	return nil
 }
 
 func (f *fakeZitiClient) GetIdentityLiveness(_ context.Context, _ string) (ziti.IdentityLiveness, error) {
@@ -401,7 +408,7 @@ func TestCreateTunnelIdentityReturnsJWTExpiry(t *testing.T) {
 	}
 }
 
-func TestPatchIdentityRoleAttributesReportsUnsupported(t *testing.T) {
+func TestPatchIdentityRoleAttributesDelegatesPatch(t *testing.T) {
 	ctx := context.Background()
 	storeClient := newFakeManagedIdentityStore()
 	zitiClient := &fakeZitiClient{}
@@ -410,8 +417,12 @@ func TestPatchIdentityRoleAttributesReportsUnsupported(t *testing.T) {
 	_, err := server.PatchIdentityRoleAttributes(ctx, &zitimanagementv1.PatchIdentityRoleAttributesRequest{
 		ZitiIdentityId: "identity-id",
 		Add:            []string{"group-one"},
+		Remove:         []string{"group-two"},
 	})
-	if status.Code(err) != codes.FailedPrecondition {
-		t.Fatalf("expected failed precondition, got %v", err)
+	if err != nil {
+		t.Fatalf("patch role attributes: %v", err)
+	}
+	if zitiClient.patchedRoles.zitiID != "identity-id" || !reflect.DeepEqual(zitiClient.patchedRoles.add, []string{"group-one"}) || !reflect.DeepEqual(zitiClient.patchedRoles.remove, []string{"group-two"}) {
+		t.Fatalf("unexpected patch: %#v", zitiClient.patchedRoles)
 	}
 }

--- a/internal/server/server.go
+++ b/internal/server/server.go
@@ -507,9 +507,6 @@ func (s *Server) PatchIdentityRoleAttributes(ctx context.Context, req *zitimanag
 		return nil, status.Error(codes.InvalidArgument, "ziti_identity_id is required")
 	}
 	if err := s.ziti.PatchIdentityRoleAttributes(ctx, zitiID, req.GetAdd(), req.GetRemove()); err != nil {
-		if errors.Is(err, ziti.ErrRoleAttributePatchUnsupported) {
-			return nil, status.Error(codes.FailedPrecondition, err.Error())
-		}
 		return nil, status.Errorf(codes.Internal, "patch ziti identity role attributes: %v", err)
 	}
 	return &zitimanagementv1.PatchIdentityRoleAttributesResponse{}, nil

--- a/internal/ziti/client.go
+++ b/internal/ziti/client.go
@@ -9,6 +9,7 @@ import (
 	"errors"
 	"fmt"
 	"os"
+	"sort"
 	"strconv"
 	"strings"
 	"sync"
@@ -30,7 +31,6 @@ import (
 var ErrIdentityNotFound = errors.New("identity not found")
 var ErrServiceNotFound = errors.New("service not found")
 var ErrServicePolicyNotFound = errors.New("service policy not found")
-var ErrRoleAttributePatchUnsupported = errors.New("identity role-attribute delta patch unsupported by OpenZiti management API")
 
 const (
 	roleAttributeAgents  = "agents"
@@ -44,6 +44,7 @@ type identityService interface {
 	DeleteIdentity(params *identity.DeleteIdentityParams, authInfo runtime.ClientAuthInfoWriter, opts ...identity.ClientOption) (*identity.DeleteIdentityOK, error)
 	DetailIdentity(params *identity.DetailIdentityParams, authInfo runtime.ClientAuthInfoWriter, opts ...identity.ClientOption) (*identity.DetailIdentityOK, error)
 	ListIdentities(params *identity.ListIdentitiesParams, authInfo runtime.ClientAuthInfoWriter, opts ...identity.ClientOption) (*identity.ListIdentitiesOK, error)
+	PatchIdentity(params *identity.PatchIdentityParams, authInfo runtime.ClientAuthInfoWriter, opts ...identity.ClientOption) (*identity.PatchIdentityOK, error)
 }
 
 type serviceService interface {
@@ -458,7 +459,7 @@ func (c *Client) CreateDeviceIdentity(ctx context.Context, userIdentityID uuid.U
 func (c *Client) CreateDeviceIdentityWithOptions(ctx context.Context, userIdentityID uuid.UUID, name string, additionalRoleAttributes []string, tags map[string]string) (string, string, error) {
 	identityType := rest_model.IdentityTypeDevice
 	isAdmin := false
-	roleAttrs := mergeRoleAttributes([]string{roleAttributeDevices}, additionalRoleAttributes)
+	roleAttrs := mergeRoleAttributes([]string{roleAttributeDevices, fmt.Sprintf("user-%s", userIdentityID.String())}, additionalRoleAttributes)
 	externalID := userIdentityID.String()
 	identityCreate := &rest_model.IdentityCreate{
 		Name:           &name,
@@ -726,7 +727,48 @@ func (c *Client) CreateTunnelIdentity(ctx context.Context, networkID, tunnelCred
 }
 
 func (c *Client) PatchIdentityRoleAttributes(ctx context.Context, zitiIdentityID string, add, remove []string) error {
-	return ErrRoleAttributePatchUnsupported
+	detail, err := c.detailIdentity(ctx, zitiIdentityID)
+	if err != nil {
+		return err
+	}
+	roleAttrs := patchRoleAttributes(detail.RoleAttributes, add, remove)
+	params := identity.NewPatchIdentityParamsWithContext(ctx)
+	params.ID = zitiIdentityID
+	params.Identity = &rest_model.IdentityPatch{RoleAttributes: &roleAttrs}
+	err = c.withReauth(func() error {
+		identityClient := c.identityClient()
+		_, callErr := identityClient.PatchIdentity(params, nil)
+		return callErr
+	})
+	if err != nil {
+		return fmt.Errorf("patch ziti identity: %w", err)
+	}
+	return nil
+}
+
+func patchRoleAttributes(current *rest_model.Attributes, add, remove []string) rest_model.Attributes {
+	roleSet := map[string]bool{}
+	if current != nil {
+		for _, attr := range *current {
+			if attr != "" {
+				roleSet[attr] = true
+			}
+		}
+	}
+	for _, attr := range remove {
+		delete(roleSet, attr)
+	}
+	for _, attr := range add {
+		if attr != "" {
+			roleSet[attr] = true
+		}
+	}
+	roleAttrs := make(rest_model.Attributes, 0, len(roleSet))
+	for attr := range roleSet {
+		roleAttrs = append(roleAttrs, attr)
+	}
+	sort.Strings(roleAttrs)
+	return roleAttrs
 }
 
 func (c *Client) GetIdentityLiveness(ctx context.Context, zitiIdentityID string) (IdentityLiveness, error) {
@@ -1061,7 +1103,7 @@ func (c *Client) CreateAndEnrollAppIdentityWithOptions(ctx context.Context, appI
 	name := fmt.Sprintf("app-%s-%s", slug, id.ShortUUID())
 	identityType := rest_model.IdentityTypeDevice
 	isAdmin := false
-	roleAttrs := mergeRoleAttributes([]string{roleAttributeApps}, additionalRoleAttributes)
+	roleAttrs := mergeRoleAttributes([]string{roleAttributeApps, fmt.Sprintf("app-%s", appID.String())}, additionalRoleAttributes)
 	externalID := appID.String()
 	if err := c.deleteIdentityByExternalID(ctx, externalID); err != nil {
 		return "", nil, fmt.Errorf("delete existing ziti identity: %w", err)

--- a/internal/ziti/client.go
+++ b/internal/ziti/client.go
@@ -36,6 +36,7 @@ const (
 	roleAttributeAgents  = "agents"
 	roleAttributeApps    = "apps"
 	roleAttributeDevices = "devices"
+	roleAttributeRunners = "runners"
 	roleAttributeTunnels = "tunnels"
 )
 
@@ -1129,7 +1130,7 @@ func (c *Client) CreateAndEnrollRunnerIdentityWithTags(ctx context.Context, runn
 	name := fmt.Sprintf("runner-%s-%s", runnerID.String(), id.ShortUUID())
 	identityType := rest_model.IdentityTypeDevice
 	isAdmin := false
-	roleAttrs := rest_model.Attributes(roleAttributes)
+	roleAttrs := mergeRoleAttributes([]string{roleAttributeRunners}, roleAttributes)
 	externalID := runnerID.String()
 	if err := c.deleteIdentityByExternalID(ctx, externalID); err != nil {
 		return "", nil, fmt.Errorf("delete existing ziti identity: %w", err)

--- a/internal/ziti/client_test.go
+++ b/internal/ziti/client_test.go
@@ -411,6 +411,38 @@ func TestCreateAndEnrollAppIdentityAddsAppRoleAndTags(t *testing.T) {
 	}
 }
 
+func TestCreateAndEnrollRunnerIdentityAddsRunnerRoleAndTags(t *testing.T) {
+	ctx := context.Background()
+	runnerID := uuid.New()
+	fake := &fakeIdentityService{
+		listIdentitiesFunc: func(params *identity.ListIdentitiesParams) (*identity.ListIdentitiesOK, error) {
+			return listIdentitiesResponse(nil, 100, 0, 0), nil
+		},
+		createIdentityFunc: func(params *identity.CreateIdentityParams) (*identity.CreateIdentityCreated, error) {
+			assertCreateExternalID(t, params, runnerID)
+			expectedRoles := rest_model.Attributes{"runners", "group-one"}
+			if params.Identity.RoleAttributes == nil || !reflect.DeepEqual(*params.Identity.RoleAttributes, expectedRoles) {
+				t.Fatalf("unexpected role attributes: %#v", params.Identity.RoleAttributes)
+			}
+			assertTags(t, params.Identity.Tags, map[string]string{"owner": "runners"})
+			return createIdentityResponse("runner-identity-id"), nil
+		},
+		detailIdentityFunc: func(params *identity.DetailIdentityParams) (*identity.DetailIdentityOK, error) {
+			return detailIdentityResponse("jwt-token"), nil
+		},
+	}
+	stubEnrollmentFuncs(t, func(token string) (*sdkziti.EnrollmentClaims, *jwt.Token, error) {
+		return &sdkziti.EnrollmentClaims{}, nil, nil
+	}, func(flags enroll.EnrollmentFlags) (*sdkziti.Config, error) {
+		return &sdkziti.Config{}, nil
+	})
+
+	client := &Client{identity: fake}
+	if _, _, err := client.CreateAndEnrollRunnerIdentityWithTags(ctx, runnerID, []string{"group-one", "runners"}, map[string]string{"owner": "runners"}); err != nil {
+		t.Fatalf("create runner identity: %v", err)
+	}
+}
+
 func TestListIdentitiesByTagConvertsRequestAndResponse(t *testing.T) {
 	ctx := context.Background()
 	identityID := "identity-id"

--- a/internal/ziti/client_test.go
+++ b/internal/ziti/client_test.go
@@ -19,6 +19,7 @@ import (
 	"github.com/openziti/edge-api/rest_management_api_client/service_policy"
 	"github.com/openziti/edge-api/rest_model"
 	sdkziti "github.com/openziti/sdk-golang/ziti"
+	"github.com/openziti/sdk-golang/ziti/enroll"
 )
 
 type fakeIdentityService struct {
@@ -26,6 +27,7 @@ type fakeIdentityService struct {
 	deleteIdentityFunc func(params *identity.DeleteIdentityParams) (*identity.DeleteIdentityOK, error)
 	detailIdentityFunc func(params *identity.DetailIdentityParams) (*identity.DetailIdentityOK, error)
 	listIdentitiesFunc func(params *identity.ListIdentitiesParams) (*identity.ListIdentitiesOK, error)
+	patchIdentityFunc  func(params *identity.PatchIdentityParams) (*identity.PatchIdentityOK, error)
 }
 
 func (f *fakeIdentityService) CreateIdentity(params *identity.CreateIdentityParams, _ runtime.ClientAuthInfoWriter, _ ...identity.ClientOption) (*identity.CreateIdentityCreated, error) {
@@ -54,6 +56,13 @@ func (f *fakeIdentityService) ListIdentities(params *identity.ListIdentitiesPara
 		return nil, errors.New("list identities not stubbed")
 	}
 	return f.listIdentitiesFunc(params)
+}
+
+func (f *fakeIdentityService) PatchIdentity(params *identity.PatchIdentityParams, _ runtime.ClientAuthInfoWriter, _ ...identity.ClientOption) (*identity.PatchIdentityOK, error) {
+	if f.patchIdentityFunc == nil {
+		return nil, errors.New("patch identity not stubbed")
+	}
+	return f.patchIdentityFunc(params)
 }
 
 type fakeServiceService struct {
@@ -281,19 +290,38 @@ func TestCreateTunnelIdentityUsesJWTExpirationWhenControllerExpiryMissing(t *tes
 	}
 }
 
-func TestPatchIdentityRoleAttributesUnsupported(t *testing.T) {
+func TestPatchIdentityRoleAttributesIsIdempotent(t *testing.T) {
 	ctx := context.Background()
+	current := rest_model.Attributes{"devices", "group-old", "user-1"}
 	fake := &fakeIdentityService{
 		detailIdentityFunc: func(params *identity.DetailIdentityParams) (*identity.DetailIdentityOK, error) {
-			t.Fatalf("detail identity should not be called for unsupported delta patch")
-			return nil, nil
+			if params == nil || params.ID != "identity-id" {
+				t.Fatalf("unexpected detail params: %#v", params)
+			}
+			identityID := "identity-id"
+			name := "device"
+			return &identity.DetailIdentityOK{Payload: &rest_model.DetailIdentityEnvelope{Data: &rest_model.IdentityDetail{
+				BaseEntity:     rest_model.BaseEntity{ID: &identityID},
+				Name:           &name,
+				RoleAttributes: &current,
+			}}}, nil
+		},
+		patchIdentityFunc: func(params *identity.PatchIdentityParams) (*identity.PatchIdentityOK, error) {
+			if params == nil || params.ID != "identity-id" || params.Identity == nil || params.Identity.RoleAttributes == nil {
+				t.Fatalf("unexpected patch params: %#v", params)
+			}
+			expected := rest_model.Attributes{"devices", "group-new", "user-1"}
+			if !reflect.DeepEqual(*params.Identity.RoleAttributes, expected) {
+				t.Fatalf("unexpected role attributes: %#v", *params.Identity.RoleAttributes)
+			}
+			return &identity.PatchIdentityOK{}, nil
 		},
 	}
 
 	client := &Client{identity: fake}
-	err := client.PatchIdentityRoleAttributes(ctx, "identity-id", []string{"group-new"}, []string{"group-old"})
-	if !errors.Is(err, ErrRoleAttributePatchUnsupported) {
-		t.Fatalf("expected unsupported error, got %v", err)
+	err := client.PatchIdentityRoleAttributes(ctx, "identity-id", []string{"group-new", "devices", "group-new"}, []string{"group-old", "missing"})
+	if err != nil {
+		t.Fatalf("patch role attributes: %v", err)
 	}
 }
 
@@ -347,6 +375,39 @@ func TestListServicesByTagConvertsRequestAndResponse(t *testing.T) {
 	}
 	if result.NextPageToken != "30" || len(result.Items) != 1 || result.Items[0].ID != serviceID {
 		t.Fatalf("unexpected result: %#v", result)
+	}
+}
+
+func TestCreateAndEnrollAppIdentityAddsAppRoleAndTags(t *testing.T) {
+	ctx := context.Background()
+	appID := uuid.New()
+	createdID := "app-identity-id"
+	fake := &fakeIdentityService{
+		listIdentitiesFunc: func(params *identity.ListIdentitiesParams) (*identity.ListIdentitiesOK, error) {
+			return listIdentitiesResponse(nil, 100, 0, 0), nil
+		},
+		createIdentityFunc: func(params *identity.CreateIdentityParams) (*identity.CreateIdentityCreated, error) {
+			assertCreateExternalID(t, params, appID)
+			expectedRoles := rest_model.Attributes{"apps", "app-" + appID.String(), "group-one"}
+			if params.Identity.RoleAttributes == nil || !reflect.DeepEqual(*params.Identity.RoleAttributes, expectedRoles) {
+				t.Fatalf("unexpected role attributes: %#v", params.Identity.RoleAttributes)
+			}
+			assertTags(t, params.Identity.Tags, map[string]string{"owner": "apps"})
+			return createIdentityResponse(createdID), nil
+		},
+		detailIdentityFunc: func(params *identity.DetailIdentityParams) (*identity.DetailIdentityOK, error) {
+			return detailIdentityResponse("jwt-token"), nil
+		},
+	}
+	stubEnrollmentFuncs(t, func(token string) (*sdkziti.EnrollmentClaims, *jwt.Token, error) {
+		return &sdkziti.EnrollmentClaims{}, nil, nil
+	}, func(flags enroll.EnrollmentFlags) (*sdkziti.Config, error) {
+		return &sdkziti.Config{}, nil
+	})
+
+	client := &Client{identity: fake}
+	if _, _, err := client.CreateAndEnrollAppIdentityWithOptions(ctx, appID, "slug", []string{"group-one", "apps"}, map[string]string{"owner": "apps"}); err != nil {
+		t.Fatalf("create app identity: %v", err)
 	}
 }
 
@@ -857,7 +918,8 @@ func TestCreateDeviceIdentity(t *testing.T) {
 			if *params.Identity.Name != "laptop" {
 				t.Fatalf("unexpected identity name: %s", *params.Identity.Name)
 			}
-			if params.Identity.RoleAttributes == nil || !reflect.DeepEqual(*params.Identity.RoleAttributes, rest_model.Attributes{"devices"}) {
+			expectedRoles := rest_model.Attributes{"devices", "user-" + userID.String()}
+			if params.Identity.RoleAttributes == nil || !reflect.DeepEqual(*params.Identity.RoleAttributes, expectedRoles) {
 				t.Fatalf("unexpected role attributes: %#v", params.Identity.RoleAttributes)
 			}
 			if params.Identity.Enrollment == nil || !params.Identity.Enrollment.Ott {


### PR DESCRIPTION
## Summary
- Implements idempotent `PatchIdentityRoleAttributes` by reading existing role attrs, applying add/remove deltas, and patching the OpenZiti identity while preserving unrelated attrs.
- Adds Private Networks base role attrs on identity creation: user devices get `user-<id>` and apps get `app-<id>`; tunnel identities already retain `tunnels` and `network-<network_id>`.
- Allows host.v1 multi-port target mapping through `allowed_port_ranges` without requiring a single static `port`, and keeps service/config tag support and list-by-tag paths covered.
- Adds tests for role attr patching, user/app/tunnel base attrs and JWT behavior, multi-port host config conversion, service config construction, and tags.

Related to #154.

## Tests / lint
- `go test ./...` — 92 passed, 0 failed, 0 skipped.
- `go vet ./...` — passed with no errors.
- `buf generate buf.build/agynio/api --path agynio/api/ziti_management/v1` — passed.
- `go vet ./...` after generated stubs — passed with no errors.