### PR TITLE
Fix identity role attribute patching

### DIFF
--- a/internal/server/identity_reenroll_test.go
+++ b/internal/server/identity_reenroll_test.go
@@ -4,6 +4,7 @@ import (
 	"context"
 	"errors"
 	"fmt"
+	"reflect"
 	"strings"
 	"testing"
 	"time"
@@ -74,7 +75,15 @@ type fakeZitiClient struct {
 	deleteServiceIDs  []string
 	agentCalls        []agentCall
 	createAgentErr    error
+	patchIdentityErr  error
+	patchIdentityCall *patchIdentityCall
 	tunnelExpiresAt   time.Time
+}
+
+type patchIdentityCall struct {
+	zitiID string
+	add    []string
+	remove []string
 }
 
 type agentCall struct {
@@ -168,8 +177,13 @@ func (f *fakeZitiClient) DeleteServicePolicy(_ context.Context, _ string) error 
 	return nil
 }
 
-func (f *fakeZitiClient) PatchIdentityRoleAttributes(_ context.Context, _ string, _, _ []string) error {
-	return ziti.ErrRoleAttributePatchUnsupported
+func (f *fakeZitiClient) PatchIdentityRoleAttributes(_ context.Context, zitiID string, add, remove []string) error {
+	f.patchIdentityCall = &patchIdentityCall{
+		zitiID: zitiID,
+		add:    append([]string(nil), add...),
+		remove: append([]string(nil), remove...),
+	}
+	return f.patchIdentityErr
 }
 
 func (f *fakeZitiClient) GetIdentityLiveness(_ context.Context, _ string) (ziti.IdentityLiveness, error) {
@@ -401,7 +415,7 @@ func TestCreateTunnelIdentityReturnsJWTExpiry(t *testing.T) {
 	}
 }
 
-func TestPatchIdentityRoleAttributesReportsUnsupported(t *testing.T) {
+func TestPatchIdentityRoleAttributesDelegatesToZiti(t *testing.T) {
 	ctx := context.Background()
 	storeClient := newFakeManagedIdentityStore()
 	zitiClient := &fakeZitiClient{}
@@ -410,8 +424,27 @@ func TestPatchIdentityRoleAttributesReportsUnsupported(t *testing.T) {
 	_, err := server.PatchIdentityRoleAttributes(ctx, &zitimanagementv1.PatchIdentityRoleAttributesRequest{
 		ZitiIdentityId: "identity-id",
 		Add:            []string{"group-one"},
+		Remove:         []string{"group-two"},
 	})
-	if status.Code(err) != codes.FailedPrecondition {
-		t.Fatalf("expected failed precondition, got %v", err)
+	if err != nil {
+		t.Fatalf("patch identity role attributes: %v", err)
+	}
+	if zitiClient.patchIdentityCall == nil || zitiClient.patchIdentityCall.zitiID != "identity-id" || !reflect.DeepEqual(zitiClient.patchIdentityCall.add, []string{"group-one"}) || !reflect.DeepEqual(zitiClient.patchIdentityCall.remove, []string{"group-two"}) {
+		t.Fatalf("unexpected patch call: %#v", zitiClient.patchIdentityCall)
+	}
+}
+
+func TestPatchIdentityRoleAttributesMapsNotFound(t *testing.T) {
+	ctx := context.Background()
+	storeClient := newFakeManagedIdentityStore()
+	zitiClient := &fakeZitiClient{patchIdentityErr: ziti.ErrIdentityNotFound}
+	server := New(storeClient, zitiClient, time.Minute, false)
+
+	_, err := server.PatchIdentityRoleAttributes(ctx, &zitimanagementv1.PatchIdentityRoleAttributesRequest{
+		ZitiIdentityId: "identity-id",
+		Add:            []string{"group-one"},
+	})
+	if status.Code(err) != codes.NotFound {
+		t.Fatalf("expected not found, got %v", err)
 	}
 }

--- a/internal/server/server.go
+++ b/internal/server/server.go
@@ -507,8 +507,8 @@ func (s *Server) PatchIdentityRoleAttributes(ctx context.Context, req *zitimanag
 		return nil, status.Error(codes.InvalidArgument, "ziti_identity_id is required")
 	}
 	if err := s.ziti.PatchIdentityRoleAttributes(ctx, zitiID, req.GetAdd(), req.GetRemove()); err != nil {
-		if errors.Is(err, ziti.ErrRoleAttributePatchUnsupported) {
-			return nil, status.Error(codes.FailedPrecondition, err.Error())
+		if errors.Is(err, ziti.ErrIdentityNotFound) {
+			return nil, status.Error(codes.NotFound, "ziti identity not found")
 		}
 		return nil, status.Errorf(codes.Internal, "patch ziti identity role attributes: %v", err)
 	}

--- a/internal/ziti/client.go
+++ b/internal/ziti/client.go
@@ -30,7 +30,6 @@ import (
 var ErrIdentityNotFound = errors.New("identity not found")
 var ErrServiceNotFound = errors.New("service not found")
 var ErrServicePolicyNotFound = errors.New("service policy not found")
-var ErrRoleAttributePatchUnsupported = errors.New("identity role-attribute delta patch unsupported by OpenZiti management API")
 
 const (
 	roleAttributeAgents  = "agents"
@@ -44,6 +43,7 @@ type identityService interface {
 	DeleteIdentity(params *identity.DeleteIdentityParams, authInfo runtime.ClientAuthInfoWriter, opts ...identity.ClientOption) (*identity.DeleteIdentityOK, error)
 	DetailIdentity(params *identity.DetailIdentityParams, authInfo runtime.ClientAuthInfoWriter, opts ...identity.ClientOption) (*identity.DetailIdentityOK, error)
 	ListIdentities(params *identity.ListIdentitiesParams, authInfo runtime.ClientAuthInfoWriter, opts ...identity.ClientOption) (*identity.ListIdentitiesOK, error)
+	PatchIdentity(params *identity.PatchIdentityParams, authInfo runtime.ClientAuthInfoWriter, opts ...identity.ClientOption) (*identity.PatchIdentityOK, error)
 }
 
 type serviceService interface {
@@ -726,7 +726,60 @@ func (c *Client) CreateTunnelIdentity(ctx context.Context, networkID, tunnelCred
 }
 
 func (c *Client) PatchIdentityRoleAttributes(ctx context.Context, zitiIdentityID string, add, remove []string) error {
-	return ErrRoleAttributePatchUnsupported
+	detail, err := c.detailIdentity(ctx, zitiIdentityID)
+	if err != nil {
+		return err
+	}
+
+	roleAttributes := patchRoleAttributes(detail.RoleAttributes, add, remove)
+	params := identity.NewPatchIdentityParamsWithContext(ctx)
+	params.ID = zitiIdentityID
+	params.Identity = &rest_model.IdentityPatch{RoleAttributes: &roleAttributes}
+	err = c.withReauth(func() error {
+		identityClient := c.identityClient()
+		_, callErr := identityClient.PatchIdentity(params, nil)
+		return callErr
+	})
+	if err != nil {
+		var notFound *identity.PatchIdentityNotFound
+		if errors.As(err, &notFound) {
+			return ErrIdentityNotFound
+		}
+		return fmt.Errorf("patch ziti identity role attributes: %w", err)
+	}
+	return nil
+}
+
+func patchRoleAttributes(current *rest_model.Attributes, add, remove []string) rest_model.Attributes {
+	roleAttributeSet := make(map[string]struct{}, len(add))
+	if current != nil {
+		for _, roleAttribute := range *current {
+			roleAttributeSet[roleAttribute] = struct{}{}
+		}
+	}
+	for _, roleAttribute := range add {
+		roleAttributeSet[roleAttribute] = struct{}{}
+	}
+	for _, roleAttribute := range remove {
+		delete(roleAttributeSet, roleAttribute)
+	}
+
+	roleAttributes := make(rest_model.Attributes, 0, len(roleAttributeSet))
+	if current != nil {
+		for _, roleAttribute := range *current {
+			if _, ok := roleAttributeSet[roleAttribute]; ok {
+				roleAttributes = append(roleAttributes, roleAttribute)
+				delete(roleAttributeSet, roleAttribute)
+			}
+		}
+	}
+	for _, roleAttribute := range add {
+		if _, ok := roleAttributeSet[roleAttribute]; ok {
+			roleAttributes = append(roleAttributes, roleAttribute)
+			delete(roleAttributeSet, roleAttribute)
+		}
+	}
+	return roleAttributes
 }
 
 func (c *Client) GetIdentityLiveness(ctx context.Context, zitiIdentityID string) (IdentityLiveness, error) {
@@ -751,6 +804,10 @@ func (c *Client) detailIdentity(ctx context.Context, zitiIdentityID string) (*re
 		return callErr
 	})
 	if err != nil {
+		var notFound *identity.DetailIdentityNotFound
+		if errors.As(err, &notFound) {
+			return nil, ErrIdentityNotFound
+		}
 		return nil, fmt.Errorf("detail ziti identity: %w", err)
 	}
 	if detail.Payload == nil || detail.Payload.Data == nil {

--- a/internal/ziti/client_test.go
+++ b/internal/ziti/client_test.go
@@ -26,6 +26,7 @@ type fakeIdentityService struct {
 	deleteIdentityFunc func(params *identity.DeleteIdentityParams) (*identity.DeleteIdentityOK, error)
 	detailIdentityFunc func(params *identity.DetailIdentityParams) (*identity.DetailIdentityOK, error)
 	listIdentitiesFunc func(params *identity.ListIdentitiesParams) (*identity.ListIdentitiesOK, error)
+	patchIdentityFunc  func(params *identity.PatchIdentityParams) (*identity.PatchIdentityOK, error)
 }
 
 func (f *fakeIdentityService) CreateIdentity(params *identity.CreateIdentityParams, _ runtime.ClientAuthInfoWriter, _ ...identity.ClientOption) (*identity.CreateIdentityCreated, error) {
@@ -54,6 +55,13 @@ func (f *fakeIdentityService) ListIdentities(params *identity.ListIdentitiesPara
 		return nil, errors.New("list identities not stubbed")
 	}
 	return f.listIdentitiesFunc(params)
+}
+
+func (f *fakeIdentityService) PatchIdentity(params *identity.PatchIdentityParams, _ runtime.ClientAuthInfoWriter, _ ...identity.ClientOption) (*identity.PatchIdentityOK, error) {
+	if f.patchIdentityFunc == nil {
+		return nil, errors.New("patch identity not stubbed")
+	}
+	return f.patchIdentityFunc(params)
 }
 
 type fakeServiceService struct {
@@ -281,19 +289,153 @@ func TestCreateTunnelIdentityUsesJWTExpirationWhenControllerExpiryMissing(t *tes
 	}
 }
 
-func TestPatchIdentityRoleAttributesUnsupported(t *testing.T) {
+func TestPatchIdentityRoleAttributesAddsAttrs(t *testing.T) {
 	ctx := context.Background()
 	fake := &fakeIdentityService{
-		detailIdentityFunc: func(params *identity.DetailIdentityParams) (*identity.DetailIdentityOK, error) {
-			t.Fatalf("detail identity should not be called for unsupported delta patch")
-			return nil, nil
+		detailIdentityFunc: detailIdentityWithRoleAttributes(rest_model.Attributes{"agents", "agent-one"}),
+		patchIdentityFunc: func(params *identity.PatchIdentityParams) (*identity.PatchIdentityOK, error) {
+			assertPatchIdentityRoleAttributes(t, params, "identity-id", []string{"agents", "agent-one", "group-one", "group-two"})
+			return &identity.PatchIdentityOK{}, nil
 		},
 	}
 
 	client := &Client{identity: fake}
-	err := client.PatchIdentityRoleAttributes(ctx, "identity-id", []string{"group-new"}, []string{"group-old"})
-	if !errors.Is(err, ErrRoleAttributePatchUnsupported) {
-		t.Fatalf("expected unsupported error, got %v", err)
+	if err := client.PatchIdentityRoleAttributes(ctx, "identity-id", []string{"group-one", "group-two"}, nil); err != nil {
+		t.Fatalf("patch identity role attributes: %v", err)
+	}
+}
+
+func TestPatchIdentityRoleAttributesRemovesAttrs(t *testing.T) {
+	ctx := context.Background()
+	fake := &fakeIdentityService{
+		detailIdentityFunc: detailIdentityWithRoleAttributes(rest_model.Attributes{"agents", "group-one", "agent-one", "group-two"}),
+		patchIdentityFunc: func(params *identity.PatchIdentityParams) (*identity.PatchIdentityOK, error) {
+			assertPatchIdentityRoleAttributes(t, params, "identity-id", []string{"agents", "agent-one"})
+			return &identity.PatchIdentityOK{}, nil
+		},
+	}
+
+	client := &Client{identity: fake}
+	if err := client.PatchIdentityRoleAttributes(ctx, "identity-id", nil, []string{"group-one", "group-two"}); err != nil {
+		t.Fatalf("patch identity role attributes: %v", err)
+	}
+}
+
+func TestPatchIdentityRoleAttributesAddsAndRemovesDeterministically(t *testing.T) {
+	ctx := context.Background()
+	fake := &fakeIdentityService{
+		detailIdentityFunc: detailIdentityWithRoleAttributes(rest_model.Attributes{"agents", "group-old", "agent-one", "group-same"}),
+		patchIdentityFunc: func(params *identity.PatchIdentityParams) (*identity.PatchIdentityOK, error) {
+			assertPatchIdentityRoleAttributes(t, params, "identity-id", []string{"agents", "agent-one", "group-new"})
+			return &identity.PatchIdentityOK{}, nil
+		},
+	}
+
+	client := &Client{identity: fake}
+	err := client.PatchIdentityRoleAttributes(ctx, "identity-id", []string{"group-new", "group-same"}, []string{"group-old", "group-same"})
+	if err != nil {
+		t.Fatalf("patch identity role attributes: %v", err)
+	}
+}
+
+func TestPatchIdentityRoleAttributesIsIdempotent(t *testing.T) {
+	ctx := context.Background()
+	currentAttrs := rest_model.Attributes{"agents", "group-one", "agent-one"}
+	fake := &fakeIdentityService{
+		detailIdentityFunc: detailIdentityWithRoleAttributes(currentAttrs),
+		patchIdentityFunc: func(params *identity.PatchIdentityParams) (*identity.PatchIdentityOK, error) {
+			assertPatchIdentityRoleAttributes(t, params, "identity-id", []string{"agents", "group-one", "agent-one"})
+			return &identity.PatchIdentityOK{}, nil
+		},
+	}
+
+	client := &Client{identity: fake}
+	err := client.PatchIdentityRoleAttributes(ctx, "identity-id", []string{"group-one", "group-one"}, []string{"missing", "missing"})
+	if err != nil {
+		t.Fatalf("patch identity role attributes: %v", err)
+	}
+}
+
+func TestPatchIdentityRoleAttributesPreservesUnrelatedAttrs(t *testing.T) {
+	ctx := context.Background()
+	currentAttrs := rest_model.Attributes{"agents", "agent-one", "workload-one", "devices", "user-one", "apps", "app-one", "custom"}
+	fake := &fakeIdentityService{
+		detailIdentityFunc: detailIdentityWithRoleAttributes(currentAttrs),
+		patchIdentityFunc: func(params *identity.PatchIdentityParams) (*identity.PatchIdentityOK, error) {
+			assertPatchIdentityRoleAttributes(t, params, "identity-id", []string{"agents", "agent-one", "workload-one", "devices", "user-one", "apps", "app-one", "custom", "group-one"})
+			return &identity.PatchIdentityOK{}, nil
+		},
+	}
+
+	client := &Client{identity: fake}
+	if err := client.PatchIdentityRoleAttributes(ctx, "identity-id", []string{"group-one"}, []string{"missing"}); err != nil {
+		t.Fatalf("patch identity role attributes: %v", err)
+	}
+}
+
+func TestPatchIdentityRoleAttributesMapsDetailNotFound(t *testing.T) {
+	ctx := context.Background()
+	fake := &fakeIdentityService{
+		detailIdentityFunc: func(params *identity.DetailIdentityParams) (*identity.DetailIdentityOK, error) {
+			return nil, &identity.DetailIdentityNotFound{}
+		},
+	}
+
+	client := &Client{identity: fake}
+	err := client.PatchIdentityRoleAttributes(ctx, "identity-id", []string{"group-one"}, nil)
+	if !errors.Is(err, ErrIdentityNotFound) {
+		t.Fatalf("expected identity not found, got %v", err)
+	}
+}
+
+func TestPatchIdentityRoleAttributesMapsPatchNotFound(t *testing.T) {
+	ctx := context.Background()
+	fake := &fakeIdentityService{
+		detailIdentityFunc: detailIdentityWithRoleAttributes(rest_model.Attributes{"agents"}),
+		patchIdentityFunc: func(params *identity.PatchIdentityParams) (*identity.PatchIdentityOK, error) {
+			return nil, &identity.PatchIdentityNotFound{}
+		},
+	}
+
+	client := &Client{identity: fake}
+	err := client.PatchIdentityRoleAttributes(ctx, "identity-id", []string{"group-one"}, nil)
+	if !errors.Is(err, ErrIdentityNotFound) {
+		t.Fatalf("expected identity not found, got %v", err)
+	}
+}
+
+func TestPatchIdentityRoleAttributesWrapsControllerError(t *testing.T) {
+	ctx := context.Background()
+	controllerErr := errors.New("controller unavailable")
+	fake := &fakeIdentityService{
+		detailIdentityFunc: detailIdentityWithRoleAttributes(rest_model.Attributes{"agents"}),
+		patchIdentityFunc: func(params *identity.PatchIdentityParams) (*identity.PatchIdentityOK, error) {
+			return nil, controllerErr
+		},
+	}
+
+	client := &Client{identity: fake}
+	err := client.PatchIdentityRoleAttributes(ctx, "identity-id", []string{"group-one"}, nil)
+	if !errors.Is(err, controllerErr) {
+		t.Fatalf("expected controller error, got %v", err)
+	}
+}
+
+func detailIdentityWithRoleAttributes(roleAttributes rest_model.Attributes) func(*identity.DetailIdentityParams) (*identity.DetailIdentityOK, error) {
+	return func(params *identity.DetailIdentityParams) (*identity.DetailIdentityOK, error) {
+		return &identity.DetailIdentityOK{Payload: &rest_model.DetailIdentityEnvelope{Data: &rest_model.IdentityDetail{
+			RoleAttributes: &roleAttributes,
+		}}}, nil
+	}
+}
+
+func assertPatchIdentityRoleAttributes(t *testing.T, params *identity.PatchIdentityParams, identityID string, expected []string) {
+	t.Helper()
+	if params == nil || params.ID != identityID || params.Identity == nil || params.Identity.RoleAttributes == nil {
+		t.Fatalf("unexpected patch params: %#v", params)
+	}
+	if !reflect.DeepEqual([]string(*params.Identity.RoleAttributes), expected) {
+		t.Fatalf("unexpected role attributes: %#v", *params.Identity.RoleAttributes)
 	}
 }
 


### PR DESCRIPTION
## Summary
- Implements safe delta patching for identity role attributes via current attrs + add - remove.
- Preserves unrelated/base attrs while making duplicate add/remove calls idempotent.
- Maps controller not-found errors to `ErrIdentityNotFound` / gRPC `NotFound` and wraps other controller errors.
- Replaces unsupported-behavior tests with add/remove/idempotency/preservation/error-mapping coverage.

Closes #68

## Test & Lint Summary
- `buf generate buf.build/agynio/api --path agynio/api/ziti_management/v1`
- `go test ./...` — 98 passed, 0 failed, 0 skipped.
- `go vet ./...` — passed with no errors.