### PR TITLE
fix: avoid unsupported startsWith filters

### DIFF
--- a/internal/ziti/client.go
+++ b/internal/ziti/client.go
@@ -322,9 +322,6 @@ func serviceFilter(filter ServiceListFilter) string {
 	if filter.Name != "" {
 		filters = append(filters, fmt.Sprintf("name = %s", strconv.Quote(filter.Name)))
 	}
-	if filter.NamePrefix != "" {
-		filters = append(filters, fmt.Sprintf("name startsWith %s", strconv.Quote(filter.NamePrefix)))
-	}
 	for _, roleAttribute := range filter.RoleAttributes {
 		filters = append(filters, fmt.Sprintf("roleAttributes contains %s", strconv.Quote(roleAttribute)))
 	}
@@ -332,12 +329,9 @@ func serviceFilter(filter ServiceListFilter) string {
 }
 
 func servicePolicyFilter(filter ServicePolicyListFilter) string {
-	filters := make([]string, 0, 3+len(filter.IdentityRoles)+len(filter.ServiceRoles))
+	filters := make([]string, 0, 2+len(filter.IdentityRoles)+len(filter.ServiceRoles))
 	if filter.Name != "" {
 		filters = append(filters, fmt.Sprintf("name = %s", strconv.Quote(filter.Name)))
-	}
-	if filter.NamePrefix != "" {
-		filters = append(filters, fmt.Sprintf("name startsWith %s", strconv.Quote(filter.NamePrefix)))
 	}
 	if filter.Type != "" {
 		filters = append(filters, fmt.Sprintf("type = %s", strconv.Quote(filter.Type)))
@@ -735,9 +729,20 @@ func (c *Client) ListServices(ctx context.Context, filter ServiceListFilter, pag
 	}
 	items := make([]OpenZitiService, 0, len(listed.Payload.Data))
 	for _, serviceDetail := range listed.Payload.Data {
-		items = append(items, toOpenZitiService(serviceDetail))
+		item := toOpenZitiService(serviceDetail)
+		if !serviceMatchesFilter(item, filter) {
+			continue
+		}
+		items = append(items, item)
 	}
 	return ListResult[OpenZitiService]{Items: items, NextPageToken: nextPageToken(listed.Payload.Meta)}, nil
+}
+
+func serviceMatchesFilter(service OpenZitiService, filter ServiceListFilter) bool {
+	if filter.NamePrefix != "" && !strings.HasPrefix(service.Name, filter.NamePrefix) {
+		return false
+	}
+	return true
 }
 
 func (c *Client) CreateServicePolicy(ctx context.Context, name, policyType string, identityRoles, serviceRoles []string) (string, error) {
@@ -820,9 +825,20 @@ func (c *Client) ListServicePolicies(ctx context.Context, filter ServicePolicyLi
 	}
 	items := make([]OpenZitiServicePolicy, 0, len(listed.Payload.Data))
 	for _, policyDetail := range listed.Payload.Data {
-		items = append(items, toOpenZitiServicePolicy(policyDetail))
+		item := toOpenZitiServicePolicy(policyDetail)
+		if !servicePolicyMatchesFilter(item, filter) {
+			continue
+		}
+		items = append(items, item)
 	}
 	return ListResult[OpenZitiServicePolicy]{Items: items, NextPageToken: nextPageToken(listed.Payload.Meta)}, nil
+}
+
+func servicePolicyMatchesFilter(policy OpenZitiServicePolicy, filter ServicePolicyListFilter) bool {
+	if filter.NamePrefix != "" && !strings.HasPrefix(policy.Name, filter.NamePrefix) {
+		return false
+	}
+	return true
 }
 
 func (c *Client) DeleteServicePolicy(ctx context.Context, policyID string) error {

--- a/internal/ziti/client.go
+++ b/internal/ziti/client.go
@@ -369,6 +369,13 @@ func nextPageToken(meta *rest_model.Meta) string {
 	return strconv.FormatInt(nextOffset, 10)
 }
 
+func pageTokenFromOffset(offset, total int64) string {
+	if offset >= total {
+		return ""
+	}
+	return strconv.FormatInt(offset, 10)
+}
+
 func nextPageOffset(meta *rest_model.Meta) (int64, bool) {
 	if meta == nil || meta.Pagination == nil || meta.Pagination.Offset == nil || meta.Pagination.Limit == nil || meta.Pagination.TotalCount == nil {
 		return 0, false
@@ -378,6 +385,13 @@ func nextPageOffset(meta *rest_model.Meta) (int64, bool) {
 		return 0, false
 	}
 	return nextOffset, true
+}
+
+func totalCount(meta *rest_model.Meta) int64 {
+	if meta == nil || meta.Pagination == nil || meta.Pagination.TotalCount == nil {
+		return 0
+	}
+	return *meta.Pagination.TotalCount
 }
 
 func (c *Client) deleteIdentityByExternalID(ctx context.Context, externalID string) error {
@@ -738,14 +752,15 @@ func (c *Client) ListServices(ctx context.Context, filter ServiceListFilter, pag
 		if listed.Payload == nil {
 			return ListResult[OpenZitiService]{}, errors.New("list ziti services response missing payload")
 		}
-		for _, serviceDetail := range listed.Payload.Data {
+		for index, serviceDetail := range listed.Payload.Data {
 			item := toOpenZitiService(serviceDetail)
 			if !serviceMatchesFilter(item, filter) {
 				continue
 			}
 			items = append(items, item)
 			if int64(len(items)) == limit {
-				return ListResult[OpenZitiService]{Items: items, NextPageToken: nextPageToken(listed.Payload.Meta)}, nil
+				nextOffset := currentOffset + int64(index) + 1
+				return ListResult[OpenZitiService]{Items: items, NextPageToken: pageTokenFromOffset(nextOffset, totalCount(listed.Payload.Meta))}, nil
 			}
 		}
 		nextOffset, ok := nextPageOffset(listed.Payload.Meta)
@@ -844,14 +859,15 @@ func (c *Client) ListServicePolicies(ctx context.Context, filter ServicePolicyLi
 		if listed.Payload == nil {
 			return ListResult[OpenZitiServicePolicy]{}, errors.New("list ziti service policies response missing payload")
 		}
-		for _, policyDetail := range listed.Payload.Data {
+		for index, policyDetail := range listed.Payload.Data {
 			item := toOpenZitiServicePolicy(policyDetail)
 			if !servicePolicyMatchesFilter(item, filter) {
 				continue
 			}
 			items = append(items, item)
 			if int64(len(items)) == limit {
-				return ListResult[OpenZitiServicePolicy]{Items: items, NextPageToken: nextPageToken(listed.Payload.Meta)}, nil
+				nextOffset := currentOffset + int64(index) + 1
+				return ListResult[OpenZitiServicePolicy]{Items: items, NextPageToken: pageTokenFromOffset(nextOffset, totalCount(listed.Payload.Meta))}, nil
 			}
 		}
 		nextOffset, ok := nextPageOffset(listed.Payload.Meta)

--- a/internal/ziti/client.go
+++ b/internal/ziti/client.go
@@ -362,14 +362,22 @@ func listPagination(pageSize int32, pageToken string) (int64, int64, error) {
 }
 
 func nextPageToken(meta *rest_model.Meta) string {
-	if meta == nil || meta.Pagination == nil || meta.Pagination.Offset == nil || meta.Pagination.Limit == nil || meta.Pagination.TotalCount == nil {
-		return ""
-	}
-	nextOffset := *meta.Pagination.Offset + *meta.Pagination.Limit
-	if nextOffset >= *meta.Pagination.TotalCount {
+	nextOffset, ok := nextPageOffset(meta)
+	if !ok {
 		return ""
 	}
 	return strconv.FormatInt(nextOffset, 10)
+}
+
+func nextPageOffset(meta *rest_model.Meta) (int64, bool) {
+	if meta == nil || meta.Pagination == nil || meta.Pagination.Offset == nil || meta.Pagination.Limit == nil || meta.Pagination.TotalCount == nil {
+		return 0, false
+	}
+	nextOffset := *meta.Pagination.Offset + *meta.Pagination.Limit
+	if nextOffset >= *meta.Pagination.TotalCount {
+		return 0, false
+	}
+	return nextOffset, true
 }
 
 func (c *Client) deleteIdentityByExternalID(ctx context.Context, externalID string) error {
@@ -708,34 +716,45 @@ func (c *Client) ListServices(ctx context.Context, filter ServiceListFilter, pag
 		return ListResult[OpenZitiService]{}, err
 	}
 	compiledFilter := serviceFilter(filter)
-	params := service.NewListServicesParamsWithContext(ctx)
-	params.Limit = &limit
-	params.Offset = &offset
-	if compiledFilter != "" {
-		params.Filter = &compiledFilter
-	}
-	var listed *service.ListServicesOK
-	err = c.withReauth(func() error {
-		var callErr error
-		serviceClient := c.serviceClient()
-		listed, callErr = serviceClient.ListServices(params, nil)
-		return callErr
-	})
-	if err != nil {
-		return ListResult[OpenZitiService]{}, fmt.Errorf("list ziti services: %w", err)
-	}
-	if listed.Payload == nil {
-		return ListResult[OpenZitiService]{}, errors.New("list ziti services response missing payload")
-	}
-	items := make([]OpenZitiService, 0, len(listed.Payload.Data))
-	for _, serviceDetail := range listed.Payload.Data {
-		item := toOpenZitiService(serviceDetail)
-		if !serviceMatchesFilter(item, filter) {
-			continue
+	items := make([]OpenZitiService, 0, limit)
+	currentOffset := offset
+	for {
+		remaining := limit - int64(len(items))
+		params := service.NewListServicesParamsWithContext(ctx)
+		params.Limit = &remaining
+		params.Offset = &currentOffset
+		if compiledFilter != "" {
+			params.Filter = &compiledFilter
 		}
-		items = append(items, item)
+		var listed *service.ListServicesOK
+		err = c.withReauth(func() error {
+			var callErr error
+			serviceClient := c.serviceClient()
+			listed, callErr = serviceClient.ListServices(params, nil)
+			return callErr
+		})
+		if err != nil {
+			return ListResult[OpenZitiService]{}, fmt.Errorf("list ziti services: %w", err)
+		}
+		if listed.Payload == nil {
+			return ListResult[OpenZitiService]{}, errors.New("list ziti services response missing payload")
+		}
+		for _, serviceDetail := range listed.Payload.Data {
+			item := toOpenZitiService(serviceDetail)
+			if !serviceMatchesFilter(item, filter) {
+				continue
+			}
+			items = append(items, item)
+			if int64(len(items)) == limit {
+				return ListResult[OpenZitiService]{Items: items, NextPageToken: nextPageToken(listed.Payload.Meta)}, nil
+			}
+		}
+		nextOffset, ok := nextPageOffset(listed.Payload.Meta)
+		if !ok {
+			return ListResult[OpenZitiService]{Items: items}, nil
+		}
+		currentOffset = nextOffset
 	}
-	return ListResult[OpenZitiService]{Items: items, NextPageToken: nextPageToken(listed.Payload.Meta)}, nil
 }
 
 func serviceMatchesFilter(service OpenZitiService, filter ServiceListFilter) bool {
@@ -804,34 +823,45 @@ func (c *Client) ListServicePolicies(ctx context.Context, filter ServicePolicyLi
 		return ListResult[OpenZitiServicePolicy]{}, err
 	}
 	compiledFilter := servicePolicyFilter(filter)
-	params := service_policy.NewListServicePoliciesParamsWithContext(ctx)
-	params.Limit = &limit
-	params.Offset = &offset
-	if compiledFilter != "" {
-		params.Filter = &compiledFilter
-	}
-	var listed *service_policy.ListServicePoliciesOK
-	err = c.withReauth(func() error {
-		var callErr error
-		servicePolicyClient := c.servicePolicyClient()
-		listed, callErr = servicePolicyClient.ListServicePolicies(params, nil)
-		return callErr
-	})
-	if err != nil {
-		return ListResult[OpenZitiServicePolicy]{}, fmt.Errorf("list ziti service policies: %w", err)
-	}
-	if listed.Payload == nil {
-		return ListResult[OpenZitiServicePolicy]{}, errors.New("list ziti service policies response missing payload")
-	}
-	items := make([]OpenZitiServicePolicy, 0, len(listed.Payload.Data))
-	for _, policyDetail := range listed.Payload.Data {
-		item := toOpenZitiServicePolicy(policyDetail)
-		if !servicePolicyMatchesFilter(item, filter) {
-			continue
+	items := make([]OpenZitiServicePolicy, 0, limit)
+	currentOffset := offset
+	for {
+		remaining := limit - int64(len(items))
+		params := service_policy.NewListServicePoliciesParamsWithContext(ctx)
+		params.Limit = &remaining
+		params.Offset = &currentOffset
+		if compiledFilter != "" {
+			params.Filter = &compiledFilter
 		}
-		items = append(items, item)
+		var listed *service_policy.ListServicePoliciesOK
+		err = c.withReauth(func() error {
+			var callErr error
+			servicePolicyClient := c.servicePolicyClient()
+			listed, callErr = servicePolicyClient.ListServicePolicies(params, nil)
+			return callErr
+		})
+		if err != nil {
+			return ListResult[OpenZitiServicePolicy]{}, fmt.Errorf("list ziti service policies: %w", err)
+		}
+		if listed.Payload == nil {
+			return ListResult[OpenZitiServicePolicy]{}, errors.New("list ziti service policies response missing payload")
+		}
+		for _, policyDetail := range listed.Payload.Data {
+			item := toOpenZitiServicePolicy(policyDetail)
+			if !servicePolicyMatchesFilter(item, filter) {
+				continue
+			}
+			items = append(items, item)
+			if int64(len(items)) == limit {
+				return ListResult[OpenZitiServicePolicy]{Items: items, NextPageToken: nextPageToken(listed.Payload.Meta)}, nil
+			}
+		}
+		nextOffset, ok := nextPageOffset(listed.Payload.Meta)
+		if !ok {
+			return ListResult[OpenZitiServicePolicy]{Items: items}, nil
+		}
+		currentOffset = nextOffset
 	}
-	return ListResult[OpenZitiServicePolicy]{Items: items, NextPageToken: nextPageToken(listed.Payload.Meta)}, nil
 }
 
 func servicePolicyMatchesFilter(policy OpenZitiServicePolicy, filter ServicePolicyListFilter) bool {

--- a/internal/ziti/client.go
+++ b/internal/ziti/client.go
@@ -719,9 +719,8 @@ func (c *Client) ListServices(ctx context.Context, filter ServiceListFilter, pag
 	items := make([]OpenZitiService, 0, limit)
 	currentOffset := offset
 	for {
-		remaining := limit - int64(len(items))
 		params := service.NewListServicesParamsWithContext(ctx)
-		params.Limit = &remaining
+		params.Limit = &limit
 		params.Offset = &currentOffset
 		if compiledFilter != "" {
 			params.Filter = &compiledFilter
@@ -826,9 +825,8 @@ func (c *Client) ListServicePolicies(ctx context.Context, filter ServicePolicyLi
 	items := make([]OpenZitiServicePolicy, 0, limit)
 	currentOffset := offset
 	for {
-		remaining := limit - int64(len(items))
 		params := service_policy.NewListServicePoliciesParamsWithContext(ctx)
-		params.Limit = &remaining
+		params.Limit = &limit
 		params.Offset = &currentOffset
 		if compiledFilter != "" {
 			params.Filter = &compiledFilter

--- a/internal/ziti/client_test.go
+++ b/internal/ziti/client_test.go
@@ -575,6 +575,75 @@ func TestListServicesPagesUntilEnoughPrefixMatches(t *testing.T) {
 	}
 }
 
+func TestListServicesKeepsControllerLimitWhileScanningPrefixMatches(t *testing.T) {
+	ctx := context.Background()
+	firstID := "service-id-1"
+	firstName := "egress-rule-one"
+	secondID := "service-id-2"
+	secondName := "egress-rule-two"
+	thirdID := "service-id-3"
+	thirdName := "egress-rule-three"
+	otherID := "other-id"
+	otherName := "other-service"
+	roles := rest_model.Attributes{"egress-services"}
+	calls := 0
+	fake := &fakeServiceService{
+		listServicesFunc: func(params *service.ListServicesParams) (*service.ListServicesOK, error) {
+			if params == nil || params.Limit == nil || *params.Limit != 3 || params.Offset == nil {
+				t.Fatalf("unexpected pagination: %#v", params)
+			}
+			if params.Filter == nil || *params.Filter != `roleAttributes contains "egress-services"` {
+				t.Fatalf("unexpected filter: %#v", params)
+			}
+			calls++
+			switch *params.Offset {
+			case 0:
+				return listServicesResponse([]*rest_model.ServiceDetail{{
+					BaseEntity:     rest_model.BaseEntity{ID: &firstID},
+					Name:           &firstName,
+					RoleAttributes: &roles,
+				}, {
+					BaseEntity:     rest_model.BaseEntity{ID: &otherID},
+					Name:           &otherName,
+					RoleAttributes: &roles,
+				}, {
+					BaseEntity:     rest_model.BaseEntity{ID: &secondID},
+					Name:           &secondName,
+					RoleAttributes: &roles,
+				}}, 3, 0, 6), nil
+			case 3:
+				return listServicesResponse([]*rest_model.ServiceDetail{{
+					BaseEntity:     rest_model.BaseEntity{ID: &otherID},
+					Name:           &otherName,
+					RoleAttributes: &roles,
+				}, {
+					BaseEntity:     rest_model.BaseEntity{ID: &thirdID},
+					Name:           &thirdName,
+					RoleAttributes: &roles,
+				}}, 3, 3, 6), nil
+			default:
+				t.Fatalf("unexpected offset: %d", *params.Offset)
+				return nil, nil
+			}
+		},
+	}
+
+	client := &Client{service: fake}
+	result, err := client.ListServices(ctx, ServiceListFilter{
+		NamePrefix:     "egress-rule-",
+		RoleAttributes: []string{"egress-services"},
+	}, 3, "")
+	if err != nil {
+		t.Fatalf("list services: %v", err)
+	}
+	if calls != 2 {
+		t.Fatalf("expected 2 calls, got %d", calls)
+	}
+	if result.NextPageToken != "" || len(result.Items) != 3 || result.Items[0].ID != firstID || result.Items[1].ID != secondID || result.Items[2].ID != thirdID {
+		t.Fatalf("unexpected result: %#v", result)
+	}
+}
+
 func TestListServicesByTagConvertsRequestAndResponse(t *testing.T) {
 	ctx := context.Background()
 	serviceID := "service-id"
@@ -776,6 +845,81 @@ func TestListServicePoliciesPagesUntilEnoughPrefixMatches(t *testing.T) {
 		t.Fatalf("expected 2 calls, got %d", calls)
 	}
 	if result.NextPageToken != "4" || len(result.Items) != 2 || result.Items[0].ID != firstID || result.Items[1].ID != secondID {
+		t.Fatalf("unexpected result: %#v", result)
+	}
+}
+
+func TestListServicePoliciesKeepsControllerLimitWhileScanningPrefixMatches(t *testing.T) {
+	ctx := context.Background()
+	firstID := "policy-id-1"
+	firstName := "egress-rule-one"
+	secondID := "policy-id-2"
+	secondName := "egress-rule-two"
+	thirdID := "policy-id-3"
+	thirdName := "egress-rule-three"
+	otherID := "other-policy-id"
+	otherName := "other-policy"
+	policyType := rest_model.DialBindDial
+	calls := 0
+	fake := &fakeServicePolicyService{
+		listServicePoliciesFunc: func(params *service_policy.ListServicePoliciesParams) (*service_policy.ListServicePoliciesOK, error) {
+			if params == nil || params.Limit == nil || *params.Limit != 3 || params.Offset == nil {
+				t.Fatalf("unexpected pagination: %#v", params)
+			}
+			if params.Filter == nil || *params.Filter != `type = "Dial" and identityRoles contains "#agent-1"` {
+				t.Fatalf("unexpected filter: %#v", params)
+			}
+			calls++
+			switch *params.Offset {
+			case 0:
+				return listServicePoliciesResponse([]*rest_model.ServicePolicyDetail{{
+					BaseEntity:    rest_model.BaseEntity{ID: &firstID},
+					Name:          &firstName,
+					Type:          &policyType,
+					IdentityRoles: rest_model.Roles{"#agent-1"},
+				}, {
+					BaseEntity:    rest_model.BaseEntity{ID: &otherID},
+					Name:          &otherName,
+					Type:          &policyType,
+					IdentityRoles: rest_model.Roles{"#agent-1"},
+				}, {
+					BaseEntity:    rest_model.BaseEntity{ID: &secondID},
+					Name:          &secondName,
+					Type:          &policyType,
+					IdentityRoles: rest_model.Roles{"#agent-1"},
+				}}, 3, 0, 6), nil
+			case 3:
+				return listServicePoliciesResponse([]*rest_model.ServicePolicyDetail{{
+					BaseEntity:    rest_model.BaseEntity{ID: &otherID},
+					Name:          &otherName,
+					Type:          &policyType,
+					IdentityRoles: rest_model.Roles{"#agent-1"},
+				}, {
+					BaseEntity:    rest_model.BaseEntity{ID: &thirdID},
+					Name:          &thirdName,
+					Type:          &policyType,
+					IdentityRoles: rest_model.Roles{"#agent-1"},
+				}}, 3, 3, 6), nil
+			default:
+				t.Fatalf("unexpected offset: %d", *params.Offset)
+				return nil, nil
+			}
+		},
+	}
+
+	client := &Client{servicePolicy: fake}
+	result, err := client.ListServicePolicies(ctx, ServicePolicyListFilter{
+		NamePrefix:    "egress-rule-",
+		Type:          "Dial",
+		IdentityRoles: []string{"#agent-1"},
+	}, 3, "")
+	if err != nil {
+		t.Fatalf("list service policies: %v", err)
+	}
+	if calls != 2 {
+		t.Fatalf("expected 2 calls, got %d", calls)
+	}
+	if result.NextPageToken != "" || len(result.Items) != 3 || result.Items[0].ID != firstID || result.Items[1].ID != secondID || result.Items[2].ID != thirdID {
 		t.Fatalf("unexpected result: %#v", result)
 	}
 }

--- a/internal/ziti/client_test.go
+++ b/internal/ziti/client_test.go
@@ -494,7 +494,7 @@ func TestListServicesConvertsFilterPaginationAndResponse(t *testing.T) {
 				BaseEntity:     rest_model.BaseEntity{ID: &otherServiceID},
 				Name:           &otherServiceName,
 				RoleAttributes: &roles,
-			}}, 10, 20, 31), nil
+			}}, 10, 20, 30), nil
 		},
 	}
 
@@ -507,7 +507,70 @@ func TestListServicesConvertsFilterPaginationAndResponse(t *testing.T) {
 	if err != nil {
 		t.Fatalf("list services: %v", err)
 	}
-	if result.NextPageToken != "30" || len(result.Items) != 1 || result.Items[0].ID != serviceID || result.Items[0].Name != serviceName {
+	if result.NextPageToken != "" || len(result.Items) != 1 || result.Items[0].ID != serviceID || result.Items[0].Name != serviceName {
+		t.Fatalf("unexpected result: %#v", result)
+	}
+}
+
+func TestListServicesPagesUntilEnoughPrefixMatches(t *testing.T) {
+	ctx := context.Background()
+	firstID := "service-id-1"
+	firstName := "egress-rule-one"
+	secondID := "service-id-2"
+	secondName := "egress-rule-two"
+	otherID := "other-id"
+	otherName := "other-service"
+	roles := rest_model.Attributes{"egress-services"}
+	calls := 0
+	fake := &fakeServiceService{
+		listServicesFunc: func(params *service.ListServicesParams) (*service.ListServicesOK, error) {
+			if params == nil || params.Limit == nil || *params.Limit != 2 || params.Offset == nil {
+				t.Fatalf("unexpected pagination: %#v", params)
+			}
+			if params.Filter == nil || *params.Filter != `roleAttributes contains "egress-services"` {
+				t.Fatalf("unexpected filter: %#v", params)
+			}
+			calls++
+			switch *params.Offset {
+			case 0:
+				return listServicesResponse([]*rest_model.ServiceDetail{{
+					BaseEntity:     rest_model.BaseEntity{ID: &otherID},
+					Name:           &otherName,
+					RoleAttributes: &roles,
+				}, {
+					BaseEntity:     rest_model.BaseEntity{ID: &otherID},
+					Name:           &otherName,
+					RoleAttributes: &roles,
+				}}, 2, 0, 5), nil
+			case 2:
+				return listServicesResponse([]*rest_model.ServiceDetail{{
+					BaseEntity:     rest_model.BaseEntity{ID: &firstID},
+					Name:           &firstName,
+					RoleAttributes: &roles,
+				}, {
+					BaseEntity:     rest_model.BaseEntity{ID: &secondID},
+					Name:           &secondName,
+					RoleAttributes: &roles,
+				}}, 2, 2, 5), nil
+			default:
+				t.Fatalf("unexpected offset: %d", *params.Offset)
+				return nil, nil
+			}
+		},
+	}
+
+	client := &Client{service: fake}
+	result, err := client.ListServices(ctx, ServiceListFilter{
+		NamePrefix:     "egress-rule-",
+		RoleAttributes: []string{"egress-services"},
+	}, 2, "")
+	if err != nil {
+		t.Fatalf("list services: %v", err)
+	}
+	if calls != 2 {
+		t.Fatalf("expected 2 calls, got %d", calls)
+	}
+	if result.NextPageToken != "4" || len(result.Items) != 2 || result.Items[0].ID != firstID || result.Items[1].ID != secondID {
 		t.Fatalf("unexpected result: %#v", result)
 	}
 }
@@ -629,7 +692,7 @@ func TestListServicePoliciesConvertsFilterPaginationAndResponse(t *testing.T) {
 				Type:          &policyType,
 				IdentityRoles: rest_model.Roles{"#agent-1"},
 				ServiceRoles:  rest_model.Roles{"-rule-1"},
-			}}, 5, 10, 20), nil
+			}}, 5, 10, 15), nil
 		},
 	}
 
@@ -644,7 +707,75 @@ func TestListServicePoliciesConvertsFilterPaginationAndResponse(t *testing.T) {
 	if err != nil {
 		t.Fatalf("list service policies: %v", err)
 	}
-	if result.NextPageToken != "15" || len(result.Items) != 1 || result.Items[0].ID != policyID || result.Items[0].Type != "Dial" {
+	if result.NextPageToken != "" || len(result.Items) != 1 || result.Items[0].ID != policyID || result.Items[0].Type != "Dial" {
+		t.Fatalf("unexpected result: %#v", result)
+	}
+}
+
+func TestListServicePoliciesPagesUntilEnoughPrefixMatches(t *testing.T) {
+	ctx := context.Background()
+	firstID := "policy-id-1"
+	firstName := "egress-rule-one"
+	secondID := "policy-id-2"
+	secondName := "egress-rule-two"
+	otherID := "other-policy-id"
+	otherName := "other-policy"
+	policyType := rest_model.DialBindDial
+	calls := 0
+	fake := &fakeServicePolicyService{
+		listServicePoliciesFunc: func(params *service_policy.ListServicePoliciesParams) (*service_policy.ListServicePoliciesOK, error) {
+			if params == nil || params.Limit == nil || *params.Limit != 2 || params.Offset == nil {
+				t.Fatalf("unexpected pagination: %#v", params)
+			}
+			if params.Filter == nil || *params.Filter != `type = "Dial" and identityRoles contains "#agent-1"` {
+				t.Fatalf("unexpected filter: %#v", params)
+			}
+			calls++
+			switch *params.Offset {
+			case 0:
+				return listServicePoliciesResponse([]*rest_model.ServicePolicyDetail{{
+					BaseEntity:    rest_model.BaseEntity{ID: &otherID},
+					Name:          &otherName,
+					Type:          &policyType,
+					IdentityRoles: rest_model.Roles{"#agent-1"},
+				}, {
+					BaseEntity:    rest_model.BaseEntity{ID: &otherID},
+					Name:          &otherName,
+					Type:          &policyType,
+					IdentityRoles: rest_model.Roles{"#agent-1"},
+				}}, 2, 0, 5), nil
+			case 2:
+				return listServicePoliciesResponse([]*rest_model.ServicePolicyDetail{{
+					BaseEntity:    rest_model.BaseEntity{ID: &firstID},
+					Name:          &firstName,
+					Type:          &policyType,
+					IdentityRoles: rest_model.Roles{"#agent-1"},
+				}, {
+					BaseEntity:    rest_model.BaseEntity{ID: &secondID},
+					Name:          &secondName,
+					Type:          &policyType,
+					IdentityRoles: rest_model.Roles{"#agent-1"},
+				}}, 2, 2, 5), nil
+			default:
+				t.Fatalf("unexpected offset: %d", *params.Offset)
+				return nil, nil
+			}
+		},
+	}
+
+	client := &Client{servicePolicy: fake}
+	result, err := client.ListServicePolicies(ctx, ServicePolicyListFilter{
+		NamePrefix:    "egress-rule-",
+		Type:          "Dial",
+		IdentityRoles: []string{"#agent-1"},
+	}, 2, "")
+	if err != nil {
+		t.Fatalf("list service policies: %v", err)
+	}
+	if calls != 2 {
+		t.Fatalf("expected 2 calls, got %d", calls)
+	}
+	if result.NextPageToken != "4" || len(result.Items) != 2 || result.Items[0].ID != firstID || result.Items[1].ID != secondID {
 		t.Fatalf("unexpected result: %#v", result)
 	}
 }

--- a/internal/ziti/client_test.go
+++ b/internal/ziti/client_test.go
@@ -583,6 +583,8 @@ func TestListServicesKeepsControllerLimitWhileScanningPrefixMatches(t *testing.T
 	secondName := "egress-rule-two"
 	thirdID := "service-id-3"
 	thirdName := "egress-rule-three"
+	fourthID := "service-id-4"
+	fourthName := "egress-rule-four"
 	otherID := "other-id"
 	otherName := "other-service"
 	roles := rest_model.Attributes{"egress-services"}
@@ -620,6 +622,10 @@ func TestListServicesKeepsControllerLimitWhileScanningPrefixMatches(t *testing.T
 					BaseEntity:     rest_model.BaseEntity{ID: &thirdID},
 					Name:           &thirdName,
 					RoleAttributes: &roles,
+				}, {
+					BaseEntity:     rest_model.BaseEntity{ID: &fourthID},
+					Name:           &fourthName,
+					RoleAttributes: &roles,
 				}}, 3, 3, 6), nil
 			default:
 				t.Fatalf("unexpected offset: %d", *params.Offset)
@@ -639,7 +645,59 @@ func TestListServicesKeepsControllerLimitWhileScanningPrefixMatches(t *testing.T
 	if calls != 2 {
 		t.Fatalf("expected 2 calls, got %d", calls)
 	}
-	if result.NextPageToken != "" || len(result.Items) != 3 || result.Items[0].ID != firstID || result.Items[1].ID != secondID || result.Items[2].ID != thirdID {
+	if result.NextPageToken != "5" || len(result.Items) != 3 || result.Items[0].ID != firstID || result.Items[1].ID != secondID || result.Items[2].ID != thirdID {
+		t.Fatalf("unexpected result: %#v", result)
+	}
+}
+
+func TestListServicesTokenResumesInsideFetchedPage(t *testing.T) {
+	ctx := context.Background()
+	firstID := "service-id-1"
+	firstName := "egress-rule-one"
+	secondID := "service-id-2"
+	secondName := "egress-rule-two"
+	thirdID := "service-id-3"
+	thirdName := "egress-rule-three"
+	otherID := "other-id"
+	otherName := "other-service"
+	roles := rest_model.Attributes{"egress-services"}
+	fake := &fakeServiceService{
+		listServicesFunc: func(params *service.ListServicesParams) (*service.ListServicesOK, error) {
+			if params == nil || params.Limit == nil || *params.Limit != 2 || params.Offset == nil || *params.Offset != 0 {
+				t.Fatalf("unexpected pagination: %#v", params)
+			}
+			if params.Filter == nil || *params.Filter != `roleAttributes contains "egress-services"` {
+				t.Fatalf("unexpected filter: %#v", params)
+			}
+			return listServicesResponse([]*rest_model.ServiceDetail{{
+				BaseEntity:     rest_model.BaseEntity{ID: &firstID},
+				Name:           &firstName,
+				RoleAttributes: &roles,
+			}, {
+				BaseEntity:     rest_model.BaseEntity{ID: &secondID},
+				Name:           &secondName,
+				RoleAttributes: &roles,
+			}, {
+				BaseEntity:     rest_model.BaseEntity{ID: &otherID},
+				Name:           &otherName,
+				RoleAttributes: &roles,
+			}, {
+				BaseEntity:     rest_model.BaseEntity{ID: &thirdID},
+				Name:           &thirdName,
+				RoleAttributes: &roles,
+			}}, 4, 0, 4), nil
+		},
+	}
+
+	client := &Client{service: fake}
+	result, err := client.ListServices(ctx, ServiceListFilter{
+		NamePrefix:     "egress-rule-",
+		RoleAttributes: []string{"egress-services"},
+	}, 2, "")
+	if err != nil {
+		t.Fatalf("list services: %v", err)
+	}
+	if result.NextPageToken != "2" || len(result.Items) != 2 || result.Items[0].ID != firstID || result.Items[1].ID != secondID {
 		t.Fatalf("unexpected result: %#v", result)
 	}
 }
@@ -857,6 +915,8 @@ func TestListServicePoliciesKeepsControllerLimitWhileScanningPrefixMatches(t *te
 	secondName := "egress-rule-two"
 	thirdID := "policy-id-3"
 	thirdName := "egress-rule-three"
+	fourthID := "policy-id-4"
+	fourthName := "egress-rule-four"
 	otherID := "other-policy-id"
 	otherName := "other-policy"
 	policyType := rest_model.DialBindDial
@@ -899,6 +959,11 @@ func TestListServicePoliciesKeepsControllerLimitWhileScanningPrefixMatches(t *te
 					Name:          &thirdName,
 					Type:          &policyType,
 					IdentityRoles: rest_model.Roles{"#agent-1"},
+				}, {
+					BaseEntity:    rest_model.BaseEntity{ID: &fourthID},
+					Name:          &fourthName,
+					Type:          &policyType,
+					IdentityRoles: rest_model.Roles{"#agent-1"},
 				}}, 3, 3, 6), nil
 			default:
 				t.Fatalf("unexpected offset: %d", *params.Offset)
@@ -919,7 +984,64 @@ func TestListServicePoliciesKeepsControllerLimitWhileScanningPrefixMatches(t *te
 	if calls != 2 {
 		t.Fatalf("expected 2 calls, got %d", calls)
 	}
-	if result.NextPageToken != "" || len(result.Items) != 3 || result.Items[0].ID != firstID || result.Items[1].ID != secondID || result.Items[2].ID != thirdID {
+	if result.NextPageToken != "5" || len(result.Items) != 3 || result.Items[0].ID != firstID || result.Items[1].ID != secondID || result.Items[2].ID != thirdID {
+		t.Fatalf("unexpected result: %#v", result)
+	}
+}
+
+func TestListServicePoliciesTokenResumesInsideFetchedPage(t *testing.T) {
+	ctx := context.Background()
+	firstID := "policy-id-1"
+	firstName := "egress-rule-one"
+	secondID := "policy-id-2"
+	secondName := "egress-rule-two"
+	thirdID := "policy-id-3"
+	thirdName := "egress-rule-three"
+	otherID := "other-policy-id"
+	otherName := "other-policy"
+	policyType := rest_model.DialBindDial
+	fake := &fakeServicePolicyService{
+		listServicePoliciesFunc: func(params *service_policy.ListServicePoliciesParams) (*service_policy.ListServicePoliciesOK, error) {
+			if params == nil || params.Limit == nil || *params.Limit != 2 || params.Offset == nil || *params.Offset != 0 {
+				t.Fatalf("unexpected pagination: %#v", params)
+			}
+			if params.Filter == nil || *params.Filter != `type = "Dial" and identityRoles contains "#agent-1"` {
+				t.Fatalf("unexpected filter: %#v", params)
+			}
+			return listServicePoliciesResponse([]*rest_model.ServicePolicyDetail{{
+				BaseEntity:    rest_model.BaseEntity{ID: &firstID},
+				Name:          &firstName,
+				Type:          &policyType,
+				IdentityRoles: rest_model.Roles{"#agent-1"},
+			}, {
+				BaseEntity:    rest_model.BaseEntity{ID: &secondID},
+				Name:          &secondName,
+				Type:          &policyType,
+				IdentityRoles: rest_model.Roles{"#agent-1"},
+			}, {
+				BaseEntity:    rest_model.BaseEntity{ID: &otherID},
+				Name:          &otherName,
+				Type:          &policyType,
+				IdentityRoles: rest_model.Roles{"#agent-1"},
+			}, {
+				BaseEntity:    rest_model.BaseEntity{ID: &thirdID},
+				Name:          &thirdName,
+				Type:          &policyType,
+				IdentityRoles: rest_model.Roles{"#agent-1"},
+			}}, 4, 0, 4), nil
+		},
+	}
+
+	client := &Client{servicePolicy: fake}
+	result, err := client.ListServicePolicies(ctx, ServicePolicyListFilter{
+		NamePrefix:    "egress-rule-",
+		Type:          "Dial",
+		IdentityRoles: []string{"#agent-1"},
+	}, 2, "")
+	if err != nil {
+		t.Fatalf("list service policies: %v", err)
+	}
+	if result.NextPageToken != "2" || len(result.Items) != 2 || result.Items[0].ID != firstID || result.Items[1].ID != secondID {
 		t.Fatalf("unexpected result: %#v", result)
 	}
 }

--- a/internal/ziti/client_test.go
+++ b/internal/ziti/client_test.go
@@ -477,16 +477,22 @@ func TestListServicesConvertsFilterPaginationAndResponse(t *testing.T) {
 	roles := rest_model.Attributes{"egress-services"}
 	fake := &fakeServiceService{
 		listServicesFunc: func(params *service.ListServicesParams) (*service.ListServicesOK, error) {
-			expected := `name = "api.github.com" and name startsWith "egress-rule-" and roleAttributes contains "egress-services"`
+			expected := `name = "api.github.com" and roleAttributes contains "egress-services"`
 			if params == nil || params.Filter == nil || *params.Filter != expected {
 				t.Fatalf("unexpected filter: %#v", params)
 			}
 			if params.Limit == nil || *params.Limit != 10 || params.Offset == nil || *params.Offset != 20 {
 				t.Fatalf("unexpected pagination: %#v", params)
 			}
+			otherServiceID := "other-id"
+			otherServiceName := "other-service"
 			return listServicesResponse([]*rest_model.ServiceDetail{{
 				BaseEntity:     rest_model.BaseEntity{ID: &serviceID, Tags: tagsFromMap(map[string]string{"owner": "egress"})},
 				Name:           &serviceName,
+				RoleAttributes: &roles,
+			}, {
+				BaseEntity:     rest_model.BaseEntity{ID: &otherServiceID},
+				Name:           &otherServiceName,
 				RoleAttributes: &roles,
 			}}, 10, 20, 31), nil
 		},
@@ -602,16 +608,24 @@ func TestListServicePoliciesConvertsFilterPaginationAndResponse(t *testing.T) {
 	policyType := rest_model.DialBindDial
 	fake := &fakeServicePolicyService{
 		listServicePoliciesFunc: func(params *service_policy.ListServicePoliciesParams) (*service_policy.ListServicePoliciesOK, error) {
-			expected := `name = "egress-rule-agent" and name startsWith "egress-rule-" and type = "Dial" and identityRoles contains "#agent-1" and serviceRoles contains "-rule-1"`
+			expected := `name = "egress-rule-agent" and type = "Dial" and identityRoles contains "#agent-1" and serviceRoles contains "-rule-1"`
 			if params == nil || params.Filter == nil || *params.Filter != expected {
 				t.Fatalf("unexpected filter: %#v", params)
 			}
 			if params.Limit == nil || *params.Limit != 5 || params.Offset == nil || *params.Offset != 10 {
 				t.Fatalf("unexpected pagination: %#v", params)
 			}
+			otherPolicyID := "other-policy-id"
+			otherPolicyName := "other-policy"
 			return listServicePoliciesResponse([]*rest_model.ServicePolicyDetail{{
 				BaseEntity:    rest_model.BaseEntity{ID: &policyID, Tags: tagsFromMap(map[string]string{"owner": "egress"})},
 				Name:          &policyName,
+				Type:          &policyType,
+				IdentityRoles: rest_model.Roles{"#agent-1"},
+				ServiceRoles:  rest_model.Roles{"-rule-1"},
+			}, {
+				BaseEntity:    rest_model.BaseEntity{ID: &otherPolicyID},
+				Name:          &otherPolicyName,
 				Type:          &policyType,
 				IdentityRoles: rest_model.Roles{"#agent-1"},
 				ServiceRoles:  rest_model.Roles{"-rule-1"},


### PR DESCRIPTION
## Summary
- Stop emitting OpenZiti `startsWith` filters for services and service policies.
- Keep exact-name/type/role filters server-side and apply NamePrefix filtering locally after listing.
- Update tests to prove OpenZiti requests omit `startsWith` while client results still honor prefix filters.

Unblocks agynio/architecture#155 and Bootstrap agynio/bootstrap#570 after release.

## Validation
- `CGO_ENABLED=0 go test ./internal/ziti/...` - pass: 1 package, 0 failed.
- `CGO_ENABLED=0 go vet ./internal/ziti/...` - pass: no issues.

Note: `go test ./...` currently requires generated protobuf stubs from the CI generation step and cannot run from this checkout before `buf generate`; the focused changed package passes locally.