### PR TITLE
fix: filter ziti service roles locally

### DIFF
--- a/internal/ziti/client.go
+++ b/internal/ziti/client.go
@@ -318,12 +318,9 @@ func tagFilter(tags map[string]string) string {
 }
 
 func serviceFilter(filter ServiceListFilter) string {
-	filters := make([]string, 0, 2+len(filter.RoleAttributes))
+	filters := make([]string, 0, 1)
 	if filter.Name != "" {
 		filters = append(filters, fmt.Sprintf("name = %s", strconv.Quote(filter.Name)))
-	}
-	for _, roleAttribute := range filter.RoleAttributes {
-		filters = append(filters, fmt.Sprintf("roleAttributes contains %s", strconv.Quote(roleAttribute)))
 	}
 	return strings.Join(filters, " and ")
 }
@@ -775,7 +772,21 @@ func serviceMatchesFilter(service OpenZitiService, filter ServiceListFilter) boo
 	if filter.NamePrefix != "" && !strings.HasPrefix(service.Name, filter.NamePrefix) {
 		return false
 	}
+	for _, roleAttribute := range filter.RoleAttributes {
+		if !containsString(service.RoleAttributes, roleAttribute) {
+			return false
+		}
+	}
 	return true
+}
+
+func containsString(values []string, expected string) bool {
+	for _, value := range values {
+		if value == expected {
+			return true
+		}
+	}
+	return false
 }
 
 func (c *Client) CreateServicePolicy(ctx context.Context, name, policyType string, identityRoles, serviceRoles []string) (string, error) {

--- a/internal/ziti/client_test.go
+++ b/internal/ziti/client_test.go
@@ -512,6 +512,46 @@ func TestListServicesConvertsFilterPaginationAndResponse(t *testing.T) {
 	}
 }
 
+func TestListServicesFiltersRoleAttributesLocally(t *testing.T) {
+	ctx := context.Background()
+	serviceID := "service-id"
+	serviceName := "service-name"
+	otherServiceID := "other-service-id"
+	otherServiceName := "other-service"
+	roles := rest_model.Attributes{"egress-services"}
+	otherRoles := rest_model.Attributes{"other-services"}
+	fake := &fakeServiceService{
+		listServicesFunc: func(params *service.ListServicesParams) (*service.ListServicesOK, error) {
+			if params == nil || params.Limit == nil || *params.Limit != 10 || params.Offset == nil || *params.Offset != 0 {
+				t.Fatalf("unexpected pagination: %#v", params)
+			}
+			if params.Filter != nil {
+				t.Fatalf("unexpected filter: %#v", params)
+			}
+			return listServicesResponse([]*rest_model.ServiceDetail{{
+				BaseEntity:     rest_model.BaseEntity{ID: &serviceID},
+				Name:           &serviceName,
+				RoleAttributes: &roles,
+			}, {
+				BaseEntity:     rest_model.BaseEntity{ID: &otherServiceID},
+				Name:           &otherServiceName,
+				RoleAttributes: &otherRoles,
+			}}, 10, 0, 2), nil
+		},
+	}
+
+	client := &Client{service: fake}
+	result, err := client.ListServices(ctx, ServiceListFilter{
+		RoleAttributes: []string{"egress-services"},
+	}, 10, "")
+	if err != nil {
+		t.Fatalf("list services: %v", err)
+	}
+	if result.NextPageToken != "" || len(result.Items) != 1 || result.Items[0].ID != serviceID {
+		t.Fatalf("unexpected result: %#v", result)
+	}
+}
+
 func TestListServicesPagesUntilEnoughPrefixMatches(t *testing.T) {
 	ctx := context.Background()
 	firstID := "service-id-1"

--- a/internal/ziti/client_test.go
+++ b/internal/ziti/client_test.go
@@ -477,7 +477,7 @@ func TestListServicesConvertsFilterPaginationAndResponse(t *testing.T) {
 	roles := rest_model.Attributes{"egress-services"}
 	fake := &fakeServiceService{
 		listServicesFunc: func(params *service.ListServicesParams) (*service.ListServicesOK, error) {
-			expected := `name = "api.github.com" and roleAttributes contains "egress-services"`
+			expected := `name = "api.github.com"`
 			if params == nil || params.Filter == nil || *params.Filter != expected {
 				t.Fatalf("unexpected filter: %#v", params)
 			}
@@ -527,7 +527,7 @@ func TestListServicesPagesUntilEnoughPrefixMatches(t *testing.T) {
 			if params == nil || params.Limit == nil || *params.Limit != 2 || params.Offset == nil {
 				t.Fatalf("unexpected pagination: %#v", params)
 			}
-			if params.Filter == nil || *params.Filter != `roleAttributes contains "egress-services"` {
+			if params.Filter != nil {
 				t.Fatalf("unexpected filter: %#v", params)
 			}
 			calls++
@@ -594,7 +594,7 @@ func TestListServicesKeepsControllerLimitWhileScanningPrefixMatches(t *testing.T
 			if params == nil || params.Limit == nil || *params.Limit != 3 || params.Offset == nil {
 				t.Fatalf("unexpected pagination: %#v", params)
 			}
-			if params.Filter == nil || *params.Filter != `roleAttributes contains "egress-services"` {
+			if params.Filter != nil {
 				t.Fatalf("unexpected filter: %#v", params)
 			}
 			calls++
@@ -666,7 +666,7 @@ func TestListServicesTokenResumesInsideFetchedPage(t *testing.T) {
 			if params == nil || params.Limit == nil || *params.Limit != 2 || params.Offset == nil || *params.Offset != 0 {
 				t.Fatalf("unexpected pagination: %#v", params)
 			}
-			if params.Filter == nil || *params.Filter != `roleAttributes contains "egress-services"` {
+			if params.Filter != nil {
 				t.Fatalf("unexpected filter: %#v", params)
 			}
 			return listServicesResponse([]*rest_model.ServiceDetail{{


### PR DESCRIPTION
## Summary
- Stop sending `roleAttributes contains ...` in OpenZiti service list filters because the controller rejects that set-symbol expression.
- Preserve `ServiceListFilter.RoleAttributes` semantics by filtering returned services client-side alongside `NamePrefix`.
- Update service-list tests to assert role-attribute filters are no longer sent to OpenZiti.

Unblocks agynio/architecture#155 and Bootstrap agynio/bootstrap#570 after release.

## Validation
- `CGO_ENABLED=0 go test ./internal/ziti/...` - pass: 1 package, 0 failed.
- `CGO_ENABLED=0 go vet ./internal/ziti/...` - pass: no issues.
- `git diff --check` - pass: no whitespace errors.