### PR TITLE
fix: filter ziti service policy fields locally

### DIFF
--- a/internal/ziti/client.go
+++ b/internal/ziti/client.go
@@ -326,18 +326,9 @@ func serviceFilter(filter ServiceListFilter) string {
 }
 
 func servicePolicyFilter(filter ServicePolicyListFilter) string {
-	filters := make([]string, 0, 2+len(filter.IdentityRoles)+len(filter.ServiceRoles))
+	filters := make([]string, 0, 1)
 	if filter.Name != "" {
 		filters = append(filters, fmt.Sprintf("name = %s", strconv.Quote(filter.Name)))
-	}
-	if filter.Type != "" {
-		filters = append(filters, fmt.Sprintf("type = %s", strconv.Quote(filter.Type)))
-	}
-	for _, identityRole := range filter.IdentityRoles {
-		filters = append(filters, fmt.Sprintf("identityRoles contains %s", strconv.Quote(identityRole)))
-	}
-	for _, serviceRole := range filter.ServiceRoles {
-		filters = append(filters, fmt.Sprintf("serviceRoles contains %s", strconv.Quote(serviceRole)))
 	}
 	return strings.Join(filters, " and ")
 }
@@ -892,6 +883,19 @@ func (c *Client) ListServicePolicies(ctx context.Context, filter ServicePolicyLi
 func servicePolicyMatchesFilter(policy OpenZitiServicePolicy, filter ServicePolicyListFilter) bool {
 	if filter.NamePrefix != "" && !strings.HasPrefix(policy.Name, filter.NamePrefix) {
 		return false
+	}
+	if filter.Type != "" && policy.Type != filter.Type {
+		return false
+	}
+	for _, identityRole := range filter.IdentityRoles {
+		if !containsString(policy.IdentityRoles, identityRole) {
+			return false
+		}
+	}
+	for _, serviceRole := range filter.ServiceRoles {
+		if !containsString(policy.ServiceRoles, serviceRole) {
+			return false
+		}
 	}
 	return true
 }

--- a/internal/ziti/client_test.go
+++ b/internal/ziti/client_test.go
@@ -838,7 +838,7 @@ func TestListServicePoliciesConvertsFilterPaginationAndResponse(t *testing.T) {
 	policyType := rest_model.DialBindDial
 	fake := &fakeServicePolicyService{
 		listServicePoliciesFunc: func(params *service_policy.ListServicePoliciesParams) (*service_policy.ListServicePoliciesOK, error) {
-			expected := `name = "egress-rule-agent" and type = "Dial" and identityRoles contains "#agent-1" and serviceRoles contains "-rule-1"`
+			expected := `name = "egress-rule-agent"`
 			if params == nil || params.Filter == nil || *params.Filter != expected {
 				t.Fatalf("unexpected filter: %#v", params)
 			}
@@ -879,6 +879,52 @@ func TestListServicePoliciesConvertsFilterPaginationAndResponse(t *testing.T) {
 	}
 }
 
+func TestListServicePoliciesFiltersSetFieldsLocally(t *testing.T) {
+	ctx := context.Background()
+	policyID := "policy-id"
+	policyName := "policy-name"
+	otherPolicyID := "other-policy-id"
+	otherPolicyName := "other-policy"
+	bindType := rest_model.DialBindBind
+	dialType := rest_model.DialBindDial
+	fake := &fakeServicePolicyService{
+		listServicePoliciesFunc: func(params *service_policy.ListServicePoliciesParams) (*service_policy.ListServicePoliciesOK, error) {
+			if params == nil || params.Limit == nil || *params.Limit != 10 || params.Offset == nil || *params.Offset != 0 {
+				t.Fatalf("unexpected pagination: %#v", params)
+			}
+			if params.Filter != nil {
+				t.Fatalf("unexpected filter: %#v", params)
+			}
+			return listServicePoliciesResponse([]*rest_model.ServicePolicyDetail{{
+				BaseEntity:    rest_model.BaseEntity{ID: &policyID},
+				Name:          &policyName,
+				Type:          &dialType,
+				IdentityRoles: rest_model.Roles{"#agent-1"},
+				ServiceRoles:  rest_model.Roles{"-rule-1"},
+			}, {
+				BaseEntity:    rest_model.BaseEntity{ID: &otherPolicyID},
+				Name:          &otherPolicyName,
+				Type:          &bindType,
+				IdentityRoles: rest_model.Roles{"#agent-2"},
+				ServiceRoles:  rest_model.Roles{"-rule-2"},
+			}}, 10, 0, 2), nil
+		},
+	}
+
+	client := &Client{servicePolicy: fake}
+	result, err := client.ListServicePolicies(ctx, ServicePolicyListFilter{
+		Type:          "Dial",
+		IdentityRoles: []string{"#agent-1"},
+		ServiceRoles:  []string{"-rule-1"},
+	}, 10, "")
+	if err != nil {
+		t.Fatalf("list service policies: %v", err)
+	}
+	if result.NextPageToken != "" || len(result.Items) != 1 || result.Items[0].ID != policyID {
+		t.Fatalf("unexpected result: %#v", result)
+	}
+}
+
 func TestListServicePoliciesPagesUntilEnoughPrefixMatches(t *testing.T) {
 	ctx := context.Background()
 	firstID := "policy-id-1"
@@ -894,7 +940,7 @@ func TestListServicePoliciesPagesUntilEnoughPrefixMatches(t *testing.T) {
 			if params == nil || params.Limit == nil || *params.Limit != 2 || params.Offset == nil {
 				t.Fatalf("unexpected pagination: %#v", params)
 			}
-			if params.Filter == nil || *params.Filter != `type = "Dial" and identityRoles contains "#agent-1"` {
+			if params.Filter != nil {
 				t.Fatalf("unexpected filter: %#v", params)
 			}
 			calls++
@@ -966,7 +1012,7 @@ func TestListServicePoliciesKeepsControllerLimitWhileScanningPrefixMatches(t *te
 			if params == nil || params.Limit == nil || *params.Limit != 3 || params.Offset == nil {
 				t.Fatalf("unexpected pagination: %#v", params)
 			}
-			if params.Filter == nil || *params.Filter != `type = "Dial" and identityRoles contains "#agent-1"` {
+			if params.Filter != nil {
 				t.Fatalf("unexpected filter: %#v", params)
 			}
 			calls++
@@ -1045,7 +1091,7 @@ func TestListServicePoliciesTokenResumesInsideFetchedPage(t *testing.T) {
 			if params == nil || params.Limit == nil || *params.Limit != 2 || params.Offset == nil || *params.Offset != 0 {
 				t.Fatalf("unexpected pagination: %#v", params)
 			}
-			if params.Filter == nil || *params.Filter != `type = "Dial" and identityRoles contains "#agent-1"` {
+			if params.Filter != nil {
 				t.Fatalf("unexpected filter: %#v", params)
 			}
 			return listServicePoliciesResponse([]*rest_model.ServicePolicyDetail{{


### PR DESCRIPTION
## Summary
- Stop sending unsupported OpenZiti service-policy filters for fields that the controller rejects (`type`, `identityRoles`, `serviceRoles`).
- Preserve `ServicePolicyListFilter` semantics by applying type, identity-role, and service-role filtering client-side with the existing prefix pagination scan.
- Add regression coverage for the Bootstrap failure path where role/type service-policy filters would otherwise produce OpenZiti `INVALID_FILTER` errors.

Unblocks agynio/architecture#155 and Bootstrap agynio/bootstrap#570 after release.

## Validation
- `CGO_ENABLED=0 go test ./internal/ziti/...` - pass: 1 package, 0 failed.
- `CGO_ENABLED=0 go vet ./internal/ziti/...` - pass: no issues.
- `git diff --check` - pass: no whitespace errors.